### PR TITLE
Added PayPal requriement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
     "magento/module-backend": "100.0.*",
     "magento/module-directory": "100.0.*",
     "magento/module-theme": "100.0.*",
+    "magento/module-paypal": "100.0.*",
     "magento/framework": "100.0.*",
     "magento/magento-composer-installer": "*",
     "adyen/php-api-library": "*"

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -29,6 +29,7 @@
             <module name="Magento_Sales"/>
             <module name="Magento_Quote"/>
             <module name="Magento_Checkout"/>
+            <module name="Magento_Paypal"/>
         </sequence>
     </module>
 </config>


### PR DESCRIPTION
### Problem
During our deployment process, where the database is created, it crashes in https://github.com/Adyen/adyen-magento2/blob/1.1.1/Setup/UpgradeSchema.php#L90 due to:
```
Module 'Adyen_Payment':
Installing schema.. Upgrading schema.. 

  [Zend_Db_Statement_Exception]                                                                                                                                  
  SQLSTATE[42S02]: Base table or view not found: 1146 Table 'project_m2.paypal_billing_agreement' doesn't exist, query was: DESCRIBE `paypal_billing_agreement`  

  [PDOException]                                                                                                 
  SQLSTATE[42S02]: Base table or view not found: 1146 Table 'project_m2.paypal_billing_agreement' doesn't exist
```
### Expected Result
1. Adyen should depend on PayPal to be installed.
2. A new version in https://packagist.org/packages/adyen/module-payment