### PR TITLE
add allowed action for adyen/process/json

### DIFF
--- a/etc/webrestrictions.xml
+++ b/etc/webrestrictions.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_WebsiteRestriction:etc/webrestrictions.xsd">
+    <action path="adyen_process_json" type="generic" />
+</config>


### PR DESCRIPTION
Adds webrestrictions.xml config. 

This allows the notification response to be processed successfully when Website Restrictions are enabled (aka Private Sales) in Enterprise Edition.

Without this config the response would be redirected to the customer/account/login controller.