### PR TITLE
sort order lowered in order to show the conf settings on magento version 2.1.3

### DIFF
--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -25,7 +25,7 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_file.xsd">
     <system>
         <section id="payment" translate="label" type="text" sortOrder="400" showInDefault="1" showInWebsite="1" showInStore="1">
-            <group id="adyen_group_all_in_one" translate="label" type="text" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="1">
+            <group id="adyen_group_all_in_one" translate="label" type="text" sortOrder="5" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Adyen All-in-One Payment Solutions</label>
                 <comment><![CDATA[Adyen All-in-One Payment Solutions]]></comment>
                 <attribute type="expanded">1</attribute>


### PR DESCRIPTION
Lowered the sort order for the adyen payment method configuration settings group, looks like from 2.1.3 sort order below 5 is not working.

Thanks
Sanu