### PR TITLE
Fix for missing config id in Model/Cron.php

### DIFF
--- a/Model/Cron.php
+++ b/Model/Cron.php
@@ -1365,7 +1365,8 @@ class Cron
             'capture_on_shipment', 'adyen_abstract', $this->_order->getStoreId()
         );
 
-        if (!$captureOnShipment) {
+        $status = NULL;
+        if (!is_null($captureOnShipment) && !$captureOnShipment) {
             $status = $this->_getConfigData('payment_authorized', 'adyen_abstract', $this->_order->getStoreId());
         }
 


### PR DESCRIPTION
Hello @rikterbeek !
Working with one M2 project I faced with next bug: all Adyen based orders get status processing even if they were successfully paid and transaction approved by the Adyen service. This project has the latest version of the adyen-magento2 module and I think I found one bug for which this pull request created.
Please, check this method:
`Adyen\Payment\Model\Cron::_setPaymentAuthorized($manualReviewComment = true, $createInvoice = false)`
The 'capture_on_shipment' config id doesn't exist in the latest version of the adyen-magento2 module. And as a result this code will return NULL:
```
  //if you have capture on shipment enabled don't set update the status of the payment
  $captureOnShipment = $this->_getConfigData(
      'capture_on_shipment', 'adyen_abstract', $this->_order->getStoreId()
  );
```
and next condition will always be true:
```
if (!$captureOnShipment) {
    $status = $this->_getConfigData('payment_authorized', 'adyen_abstract', $this->_order->getStoreId());
        }
```
so the $status value will be 'processing' as the default config value. As a result, all orders will have status 'processing' even if they successfully paid and completed (the same method lines 1423-1427)
```     
 $status = (!empty($status)) ? $status : $this->_order->getStatus();
        $this->_order->addStatusHistoryComment(__($comment), $status);
        $this->_adyenLogger->addAdyenNotificationCronjob(
            'Order status is changed to authorised status, status is ' . $status
        );
```
because, as I can see, this method save not only history comment but also edit order status
`Magento\Sales\Model\Order::addStatusHistoryComment($comment, $status = false)`
P.S. I added $status = NULL for "adyen_boleto" payment. If it will be enabled we will not get "not existed variable" error. The main idea of my changes is to skip not existed config id to save real order status.

Thank you, Alexander