### PR TITLE
Fix: #154 HPP Icons not showing on checkout

### DIFF
--- a/Helper/PaymentMethods.php
+++ b/Helper/PaymentMethods.php
@@ -212,7 +212,7 @@ class PaymentMethods extends AbstractHelper
 
                     $params = [];
                     // use frontend area
-                    $params = array_merge(['area' => 'frontend', '_secure' => $this->_request->isSecure()], $params);
+                    $params = array_merge(['area' => 'frontend', 'theme' => 'Magento/blank', '_secure' => $this->_request->isSecure()], $params);
 
                     $asset = $this->_assetRepo->createAsset('Adyen_Payment::images/logos/' .
                         $paymentMethodCode . '.png', $params);


### PR DESCRIPTION
Add additional parameter for theme to generate correct url. 

Causes asset repo to use '<Vendor>/<theme>' instead of '_view' in the url.

See #154 for reference.