### PR TITLE
Display a nicer label for for adyen_hpp payment info

### DIFF
--- a/view/frontend/templates/info/adyen_hpp.phtml
+++ b/view/frontend/templates/info/adyen_hpp.phtml
@@ -36,9 +36,11 @@ $_info = $this->getInfo();
         <dt class="title"><?php echo $block->escapeHtml($block->getMethod()->getTitle()) ?></dt>
     <?php else: ?>
 
-    <?php if ($_brandCode = $_info->getAdditionalInformation('brand_code')):?>
-        <dt class="title"><?php echo $_brandCode; ?></dt>
-    <?php endif;?>
+        <?php if ($_methodTitle = $_info->getAdditionalInformation('method_title')):?>
+            <dt class="title"><?php echo $_methodTitle; ?></dt>
+        <?php elseif ($_brandCode = $_info->getAdditionalInformation('brand_code')):?>
+            <dt class="title"><?php echo $_brandCode; ?></dt>
+        <?php endif;?>
 
 <?php endif; ?>
 


### PR DESCRIPTION
At this moment brand_code (e.g.: "paypal") is used, while method_title (e.g.: "PayPal") is nicer to show as payment method info