### PR TITLE
PW-243: Do not send CSE token for recurring cards if the updated expiry date is not changed,

### DIFF
--- a/Controller/Process/Json.php
+++ b/Controller/Process/Json.php
@@ -287,9 +287,12 @@ class Json extends \Magento\Framework\App\Action\Action
         $pspReference = trim($response['pspReference']);
         $eventCode = trim($response['eventCode']);
         $success = trim($response['success']);
-
+        $originalReference = null;
+        if(isset($response['originalReference'])) {
+            $originalReference = trim($response['originalReference']);
+        }
         $notification = $this->_objectManager->create('Adyen\Payment\Model\Notification');
-        return $notification->isDuplicate($pspReference, $eventCode, $success);
+        return $notification->isDuplicate($pspReference, $eventCode, $success, $originalReference);
     }
 
     /**

--- a/Model/Cron.php
+++ b/Model/Cron.php
@@ -784,133 +784,111 @@ class Cron
                     }
                 }
                 break;
-            case Notification::RECURRING_CONTRACT:
 
+            case Notification::RECURRING_CONTRACT:
                 // storedReferenceCode
                 $recurringDetailReference = $this->_pspReference;
 
-                // check if there is already a BillingAgreement
-                $billingAgreement = $this->_billingAgreementFactory->create();
-                $billingAgreement->load($recurringDetailReference, 'reference_id');
-
-
-                if ($billingAgreement && $billingAgreement->getAgreementId() > 0 && $billingAgreement->isValid()) {
-
-                    try {
-                        $billingAgreement->addOrderRelation($this->_order);
-                        $billingAgreement->setStatus($billingAgreement::STATUS_ACTIVE);
-                        $billingAgreement->setIsObjectChanged(true);
-                        $this->_order->addRelatedObject($billingAgreement);
-                        $message = __('Used existing billing agreement #%s.', $billingAgreement->getReferenceId());
-                    } catch (Exception $e) {
-                        // could be that it is already linked to this order
-                        $message = __('Used existing billing agreement #%s.', $billingAgreement->getReferenceId());
-                    }
-                } else {
-
-                    $this->_order->getPayment()->setBillingAgreementData(
-                        [
-                            'billing_agreement_id' => $recurringDetailReference,
-                            'method_code' => $this->_order->getPayment()->getMethodCode(),
-                        ]
+                $storeId = $this->_order->getStoreId();
+                $customerReference = $this->_order->getCustomerId();
+                $listRecurringContracts = null;
+                $this->_adyenLogger->addAdyenNotificationCronjob(
+                    __('CustomerReference is: %1 and storeId is %2 and RecurringDetailsReference is %3', $customerReference, $storeId, $recurringDetailReference)
+                );
+                try {
+                    $listRecurringContracts = $this->_adyenPaymentRequest->getRecurringContractsForShopper(
+                        $customerReference, $storeId
                     );
+                    $contractDetail = null;
+                    // get current Contract details and get list of all current ones
+                    $recurringReferencesList = [];
 
-                    // create new object
-                    $billingAgreement = $this->_billingAgreementFactory->create();
-                    $billingAgreement->setStoreId($this->_order->getStoreId());
-                    $billingAgreement->importOrderPayment($this->_order->getPayment());
-
-                    // get all data for this contract by doing a listRecurringCall
-                    $customerReference = $billingAgreement->getCustomerReference();
-                    $storeId = $billingAgreement->getStoreId();
-
-                    /*
-                     * for quest checkout users we can't save this in the billing agreement
-                     * because it is linked to customer
-                     */
-                    if ($customerReference && $storeId) {
-
-                        $listRecurringContracts = null;
-                        try {
-                            $listRecurringContracts = $this->_adyenPaymentRequest->getRecurringContractsForShopper(
-                                $customerReference, $storeId
-                            );
-                        } catch(\Exception $exception) {
-                            $this->_adyenLogger->addAdyenNotificationCronjob($exception->getMessage());
-                        }
-
-                        $contractDetail = null;
-                        // get current Contract details and get list of all current ones
-                        $recurringReferencesList = [];
-
-                        if ($listRecurringContracts) {
-                            foreach ($listRecurringContracts as $rc) {
-                                $recurringReferencesList[] = $rc['recurringDetailReference'];
-                                if (isset($rc['recurringDetailReference']) &&
-                                    $rc['recurringDetailReference'] == $recurringDetailReference) {
-                                    $contractDetail = $rc;
-                                }
-                            }
-                        }
-
-                        if ($contractDetail != null) {
-                            // update status of all the current saved agreements in magento
-                            $billingAgreements = $this->_billingAgreementCollectionFactory->create();
-                            $billingAgreements->addFieldToFilter('customer_id', $customerReference);
-
-                            // get collection
-
-                            foreach ($billingAgreements as $updateBillingAgreement) {
-                                if (!in_array($updateBillingAgreement->getReferenceId(), $recurringReferencesList)) {
-                                    $updateBillingAgreement->setStatus(
-                                        \Adyen\Payment\Model\Billing\Agreement::STATUS_CANCELED
-                                    );
-                                    $updateBillingAgreement->save();
-                                } else {
-                                    $updateBillingAgreement->setStatus(
-                                        \Adyen\Payment\Model\Billing\Agreement::STATUS_ACTIVE
-                                    );
-                                    $updateBillingAgreement->save();
-                                }
-                            }
-
-                            // add this billing agreement
-                            $billingAgreement->parseRecurringContractData($contractDetail);
-                            if ($billingAgreement->isValid()) {
-                                $message = __('Created billing agreement #%1.', $billingAgreement->getReferenceId());
-
-                                // save into sales_billing_agreement_order
-                                $billingAgreement->addOrderRelation($this->_order);
-
-                                // add to order to save agreement
-                                $this->_order->addRelatedObject($billingAgreement);
-                            } else {
-                                $message = __('Failed to create billing agreement for this order.');
-                            }
-
-
-                        } else {
-                            $this->_adyenLogger->addAdyenNotificationCronjob(
-                                'Failed to create billing agreement for this order ' .
-                                '(listRecurringCall did not contain contract)'
-                            );
-                            $this->_adyenLogger->addAdyenNotificationCronjob(
-                                __('recurringDetailReference in notification is %1', $recurringDetailReference)
-                            );
-                            $this->_adyenLogger->addAdyenNotificationCronjob(
-                                __('CustomerReference is: %1 and storeId is %2', $customerReference, $storeId)
-                            );
-                            $this->_adyenLogger->addAdyenNotificationCronjob(print_r($listRecurringContracts, 1));
-                            $message = __(
-                                'Failed to create billing agreement for this order ' .
-                                '(listRecurringCall did not contain contract)'
-                            );
-                        }
-
-                        $comment = $this->_order->addStatusHistoryComment($message);
-                        $this->_order->addRelatedObject($comment);
+                    if (!$listRecurringContracts) {
+                        throw new \Exception("Empty list recurring contracts");
                     }
+                    // Find the reference on the list
+                    foreach ($listRecurringContracts as $rc) {
+                        $recurringReferencesList[] = $rc['recurringDetailReference'];
+                        if (isset($rc['recurringDetailReference']) &&
+                            $rc['recurringDetailReference'] == $recurringDetailReference) {
+                            $contractDetail = $rc;
+                        }
+                    }
+
+                    if ($contractDetail == null) {
+                        $this->_adyenLogger->addAdyenNotificationCronjob(print_r($listRecurringContracts, 1));
+                        $message = __(
+                            'Failed to create billing agreement for this order ' .
+                            '(listRecurringCall did not contain contract)'
+                        );
+                        throw new \Exception($message);
+                    }
+
+                    $billingAgreements = $this->_billingAgreementCollectionFactory->create();
+                    $billingAgreements->addFieldToFilter('customer_id', $customerReference);
+
+                    // Get collection and update existing agreements
+
+                    foreach ($billingAgreements as $updateBillingAgreement) {
+                        if (!in_array($updateBillingAgreement->getReferenceId(), $recurringReferencesList)) {
+                            $updateBillingAgreement->setStatus(
+                                \Adyen\Payment\Model\Billing\Agreement::STATUS_CANCELED
+                            );
+                            $updateBillingAgreement->save();
+                        } else {
+                            $updateBillingAgreement->setStatus(
+                                \Adyen\Payment\Model\Billing\Agreement::STATUS_ACTIVE
+                            );
+                            $updateBillingAgreement->save();
+                        }
+                    }
+
+                    // Get or create billing agreement
+                    $billingAgreement = $this->_billingAgreementFactory->create();
+                    $billingAgreement->load($recurringDetailReference, 'reference_id');
+                    $message = __('Updated billing agreement #%1.', $recurringDetailReference);
+                    // check if BA exists
+                    if (!($billingAgreement && $billingAgreement->getAgreementId() > 0 && $billingAgreement->isValid())) {
+                        // create new
+                        $this->_adyenLogger->addAdyenNotificationCronjob("Creating new Billing Agreement");
+                        $this->_order->getPayment()->setBillingAgreementData(
+                            [
+                                'billing_agreement_id' => $recurringDetailReference,
+                                'method_code' => $this->_order->getPayment()->getMethodCode(),
+                            ]
+                        );
+
+                        $billingAgreement = $this->_billingAgreementFactory->create();
+                        $billingAgreement->setStoreId($this->_order->getStoreId());
+                        $billingAgreement->importOrderPayment($this->_order->getPayment());
+                        $message = __('Created billing agreement #%1.', $recurringDetailReference);
+                    }
+                    else {
+                        $this->_adyenLogger->addAdyenNotificationCronjob("Using existing Billing Agreement");
+                        $billingAgreement->setIsObjectChanged(true);
+                    }
+
+                    // Populate billing agreement data
+                    $billingAgreement->parseRecurringContractData($contractDetail);
+                    if ($billingAgreement->isValid()) {
+
+                        // save into sales_billing_agreement_order
+                        $billingAgreement->addOrderRelation($this->_order);
+
+                        // add to order to save agreement
+                        $this->_order->addRelatedObject($billingAgreement);
+                    } else {
+                        $message = __('Failed to create billing agreement for this order.');
+                        throw new \Exception($message);
+                    }
+
+                } catch(\Exception $exception) {
+                    $message = $exception->getMessage();
                 }
+
+                $this->_adyenLogger->addAdyenNotificationCronjob($message);
+                $comment = $this->_order->addStatusHistoryComment($message);
+                $this->_order->addRelatedObject($comment);
                 break;
             default:
                 $this->_adyenLogger->addAdyenNotificationCronjob(
@@ -976,7 +954,7 @@ class Cron
             }
         } else {
             $this->_adyenLogger->addAdyenNotificationCronjob(
-                'Did not create a credit memo for this order becasue refund is done through Magento'
+                'Did not create a credit memo for this order because refund is done through Magento'
             );
         }
     }

--- a/Model/Cron.php
+++ b/Model/Cron.php
@@ -834,19 +834,17 @@ class Cron
                             $updateBillingAgreement->setStatus(
                                 \Adyen\Payment\Model\Billing\Agreement::STATUS_CANCELED
                             );
-                            $updateBillingAgreement->save();
                         } else {
                             $updateBillingAgreement->setStatus(
                                 \Adyen\Payment\Model\Billing\Agreement::STATUS_ACTIVE
                             );
-                            $updateBillingAgreement->save();
                         }
+                        $updateBillingAgreement->save();
                     }
 
                     // Get or create billing agreement
                     $billingAgreement = $this->_billingAgreementFactory->create();
                     $billingAgreement->load($recurringDetailReference, 'reference_id');
-                    $message = __('Updated billing agreement #%1.', $recurringDetailReference);
                     // check if BA exists
                     if (!($billingAgreement && $billingAgreement->getAgreementId() > 0 && $billingAgreement->isValid())) {
                         // create new
@@ -866,6 +864,7 @@ class Cron
                     else {
                         $this->_adyenLogger->addAdyenNotificationCronjob("Using existing Billing Agreement");
                         $billingAgreement->setIsObjectChanged(true);
+                        $message = __('Updated billing agreement #%1.', $recurringDetailReference);
                     }
 
                     // Populate billing agreement data

--- a/Model/Notification.php
+++ b/Model/Notification.php
@@ -84,11 +84,12 @@ class Notification extends \Magento\Framework\Model\AbstractModel
      * @param $pspReference
      * @param $eventCode
      * @param $success
+     * @param $originalReference
      * @return bool (true if the notification is a duplicate)
      */
-    public function isDuplicate($pspReference, $eventCode, $success)
+    public function isDuplicate($pspReference, $eventCode, $success, $originalReference)
     {
-        $result = $this->getResource()->getNotification($pspReference, $eventCode, $success);
+        $result = $this->getResource()->getNotification($pspReference, $eventCode, $success, $originalReference);
         return (empty($result)) ? false : true;
     }
     

--- a/Model/Resource/Notification.php
+++ b/Model/Resource/Notification.php
@@ -40,15 +40,17 @@ class Notification extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
      * @param $pspReference
      * @param $eventCode
      * @param $success
+     * @param $originalReference
      * @return array
      */
-    public function getNotification($pspReference, $eventCode, $success)
+    public function getNotification($pspReference, $eventCode, $success, $originalReference)
     {
         $select = $this->getConnection()->select()
             ->from(['notification' => $this->getTable('adyen_notification')])
             ->where('notification.pspreference=?', $pspReference)
             ->where('notification.event_code=?', $eventCode)
-            ->where('notification.success=?', $success);
+            ->where('notification.success=?', $success)
+            ->where('notification.original_reference=?', $originalReference);
         return $this->getConnection()->fetchAll($select);
     }
 }

--- a/view/frontend/web/js/view/payment/method-renderer/adyen-oneclick-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-oneclick-method.js
@@ -101,7 +101,7 @@ define(
                         generationtime : generationtime
                     };
 
-                    if(updatedExpiryDate || window.checkoutConfig.payment.adyenOneclick.hasCustomerInteraction){
+                    if(updatedExpiryDate || self.hasVerification()){
 
                         var options = { enableValidations: false};
                         var cse_key = this.getCSEKey();
@@ -185,6 +185,9 @@ define(
                         getGenerationTime: function() {
                             return window.checkoutConfig.payment.adyenCc.generationTime;
                         },
+                        hasVerification: function() {
+                            return window.checkoutConfig.payment.adyenOneclick.hasCustomerInteraction;
+                        },
                         validate: function () {
 
                             var code = self.item.method;
@@ -203,7 +206,7 @@ define(
 
                                 // only check if recurring type is set to oneclick
                                 var cid = true;
-                                if(self.hasVerification()) {
+                                if(this.hasVerification()) {
                                     var cid = Boolean($(form + ' #' + codeValue + '_cc_cid').valid());
                                 }
                             } else {
@@ -230,6 +233,8 @@ define(
             },
             selectBillingAgreement: function() {
                 var self = this;
+                self.expiry(false);
+                updatedExpiryDate = false;
 
                 // set payment method data
                 var  data = {
@@ -262,9 +267,6 @@ define(
                 }
                 return null;
             }),
-            hasVerification: function() {
-                return window.checkoutConfig.payment.adyenOneclick.hasCustomerInteraction;
-            },
             getPlaceOrderUrl: function() {
                 return window.checkoutConfig.payment.iframe.placeOrderUrl[this.getCode()];
             }

--- a/view/frontend/web/js/view/payment/method-renderer/adyen-oneclick-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-oneclick-method.js
@@ -85,7 +85,6 @@ define(
                     "method": self.method,
                     "additional_data": {
                         variant: self.agreement_data.variant,
-                        // recurring_detail_reference: "8315028947219783"
                         recurring_detail_reference: self.value
                     }
                 }

--- a/view/frontend/web/template/payment/oneclick-form.html
+++ b/view/frontend/web/template/payment/oneclick-form.html
@@ -131,7 +131,7 @@
                 </div>
 
 
-                <!-- ko if: ($parent.hasVerification())-->
+                <!-- ko if: hasVerification()-->
                 <div class="field cvv required" data-bind="attr: {id: getCode() + '_' + value + '_cc_type_cvv_div'}">
                     <label data-bind="attr: {for: getCode() + '_' + value + '_cc_cid'}" class="label">
                         <span><!-- ko text: $t('Card Verification Number')--><!-- /ko --></span>


### PR DESCRIPTION
- Do not send CSE token for recurring cards if the updated expiry date is not changed
- isDuplicate now checks for the 'original_reference' field, this allows now to process two notifications with the same billing agreement but different payment.
- Reworked Cron.php to update ExpiryDate on existing billing agreements.