### PR TITLE
Cleanup composer dependencies removed obvious modules that already co…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,19 +9,6 @@
   ],
   "require": {
     "php": "~5.5.0|~5.6.0|~7.0.0",
-    "magento/module-config": "100.1.*",
-    "magento/module-store": "100.1.*",
-    "magento/module-checkout": "100.1.*",
-    "magento/module-catalog": "101.0.*",
-    "magento/module-sales": "100.1.*",
-    "magento/module-customer": "100.1.*",
-    "magento/module-payment": "100.1.*",
-    "magento/module-quote": "100.1.*",
-    "magento/module-backend": "100.1.*",
-    "magento/module-directory": "100.1.*",
-    "magento/module-theme": "100.1.*",
-    "magento/module-paypal": "100.1.*",
-    "magento/framework": "100.1.*",
     "adyen/php-api-library": "*"
   },
   "autoload": {


### PR DESCRIPTION
…mes with the core and allow all magento versions to work with this extension. Do not restrict future releases for now so merchants can quickly adopt and test the extension against the latest versions