### PR TITLE
Set correct param type

### DIFF
--- a/Model/Method/Adapter.php
+++ b/Model/Method/Adapter.php
@@ -48,7 +48,7 @@ class Adapter extends Method\Adapter
      * @param PaymentDataObjectFactory $paymentDataObjectFactory
      * @param string $code
      * @param string $formBlockType
-     * @param CommandPoolInterface $infoBlockType
+     * @param string $infoBlockType
      * @param CommandPoolInterface|null $commandPool
      * @param ValidatorPoolInterface|null $validatorPool
      * @param CommandManagerInterface|null $commandExecutor


### PR DESCRIPTION
code compilation fails in Magento 2.2 because of mismatching type
with the parent class