### PR TITLE
Config import with serialized value

### DIFF
--- a/Model/Config/Backend/Installments.php
+++ b/Model/Config/Backend/Installments.php
@@ -62,6 +62,10 @@ class Installments extends \Magento\Framework\App\Config\Value
     public function beforeSave()
     {
         $value = $this->getValue();
+        $unserialized = @unserialize($value);
+        if ($unserialized !== false) {
+            $value = $unserialized;
+        }
 
         $result = [];
         foreach ($value as $data) {

--- a/Model/Config/Backend/Installments.php
+++ b/Model/Config/Backend/Installments.php
@@ -64,7 +64,7 @@ class Installments extends \Magento\Framework\App\Config\Value
         $value = $this->getValue();
         $unserialized = @unserialize($value);
         if ($unserialized !== false) {
-            $value = $unserialized;
+            return $this;
         }
 
         $result = [];


### PR DESCRIPTION
**Description**
I have added a check if the configuration value is already serialized. When using the app:config:import command of M2.2 (http://devdocs.magento.com/guides/v2.2/config-guide/cli/config-cli-subcommands-config-mgmt-import.html), the configuration import for Adyen fails because it is already serialized. I think it isn't necessary to parse the config again so I just return $this, but I could be mistaken.

**Tested scenarios**
Tested import with config and configuration saving from backend

**Fixed issue**: -