### PR TITLE
fix-hpp-gender-layout: gender field in hpp did not layout correctly. …

### DIFF
--- a/view/frontend/web/template/payment/hpp-form.html
+++ b/view/frontend/web/template/payment/hpp-form.html
@@ -70,7 +70,7 @@
 
                     <!-- ko if: isPaymentMethodOpenInvoiceMethod() -->
                         <!-- ko if: showGender() -->
-                            <div class="field gender type required">
+                            <div class="field gender required">
                                     <label data-bind="attr: {for: getCode() + '_gender_type_' + value}" class="label">
                                         <span><!-- ko text: $t('Gender')--><!-- /ko --></span>
                                     </label>


### PR DESCRIPTION
…Fixed by removing type from class.
**Description**
In the hpp page, the layout of the gender field is not ok. See screenshot. Souce of this issue is a 'type' class for the gener field. This results in a margin setting for the control field. Removing the type class (so it is the same as the DoB field) results in not applying the margin-left, which results in a correct layout.
![image](https://user-images.githubusercontent.com/28998751/34716605-a71b54ca-f530-11e7-9e9c-22ddc17b79d1.png)

**Tested scenarios**
Removed class "type" which resulted in the correct rendering of the gender field.
