### PR TITLE
Cron notification processing: Save payment after making changes to it.

### DIFF
--- a/Model/Cron.php
+++ b/Model/Cron.php
@@ -670,6 +670,8 @@ class Cron
         if (isset($authCode) && $authCode != "") {
             $this->_order->getPayment()->setAdditionalInformation('adyen_auth_code', $authCode);
         }
+
+        $this->_order->getPayment()->save();
     }
 
     /**
@@ -1135,6 +1137,8 @@ class Cron
 
         // set transaction
         $paymentObj->setTransactionId($this->_pspReference);
+
+        $paymentObj->save();
 
         //capture mode
         if (!$this->_isAutoCapture()) {


### PR DESCRIPTION
Sending capture for Klarna invoices when making an invoice in Magneto (2.1.10) does not seem to work without this.

<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->

Save payment in two places after making changes to it. Otherwise the data in sales_order_payment will not be updated.

**Tested scenarios**

* Make a test order with Klarna open invoice as the payment method (within HPP)
* From Magento's order view, create invoice, choose "Capture Online", we get "We can't save the invoice right now." error in admin and in adyen/error.log we can see the originalReference field sent in the capture request is empty

After changes, the invoice can be created, the capture request is sent successfully and in ca I can see status of payment advance to "SentForSettle".

Module version tested is 2.1.3.