### PR TITLE
Place Order function race condition fix

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/adyen-cc-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-cc-method.js
@@ -152,6 +152,15 @@ define(
             isActive: function () {
                 return true;
             },
+
+            /**
+             * Returns state of place order button
+             * @returns {boolean}
+            */
+            isButtonActive: function() {
+              return this.isActive() && this.getCode() == this.isChecked() && this.isPlaceOrderActionAllowed();
+            },
+
             /**
              * @override
              */

--- a/view/frontend/web/template/payment/cc-form.html
+++ b/view/frontend/web/template/payment/cc-form.html
@@ -280,12 +280,9 @@
             <div class="primary">
                 <button class="action primary checkout"
                         type="submit"
-                        data-bind="
-                        click: placeOrder,
+                        data-bind="click: placeOrder,
                         attr: {title: $t('Place Order')},
-                        enable: (getCode() == isChecked()),
-                        css: {disabled: !isPlaceOrderActionAllowed()}
-                        "
+                        enable: isButtonActive()"
                         disabled>
                     <span data-bind="text: $t('Place Order')"></span>
                 </button>


### PR DESCRIPTION
**Description**
Migrate changes from Magento 2 race condition fix to Adyen Payment Module

**Tested scenarios**
1. Add items to cart
2. Enter order details
3. Select Adyen (CreditCard) payment type
4. Enter credentials (using adyen test mode and test credentials)
5. Continually click the "Place Order" button
6. Only one request should be sent to Adyen

**Todo**

- [ ] Apply fix on other payment methods where this could also be an issue

**Fixed issue**:  https://github.com/Adyen/adyen-magento2/issues/248