### PR TITLE
Fix for showing only selected boleto types in checkout

### DIFF
--- a/Model/Ui/AdyenBoletoConfigProvider.php
+++ b/Model/Ui/AdyenBoletoConfigProvider.php
@@ -34,7 +34,7 @@ class AdyenBoletoConfigProvider implements ConfigProviderInterface
      * @var PaymentHelper
      */
     protected $_paymentHelper;
-    
+
     /**
      * @var \Adyen\Payment\Helper\Data
      */
@@ -86,11 +86,31 @@ class AdyenBoletoConfigProvider implements ConfigProviderInterface
                         'checkout/onepage/success/', ['_secure' => $this->_getRequest()->isSecure()])
                 ],
                 'adyenBoleto' => [
-                    'boletoTypes' => $this->_adyenHelper->getBoletoTypes()
+                    'boletoTypes' => $this->getBoletoAvailableTypes()
                 ]
             ]
         ];
     }
+
+    /**
+     * @return array
+     */
+    protected function getBoletoAvailableTypes()
+    {
+        $types = [];
+        $boletoTypes = $this->_adyenHelper->getBoletoTypes();
+        $availableTypes = $this->_adyenHelper->getAdyenBoletoConfigData('boletotypes');
+        if ($availableTypes) {
+            $availableTypes = explode(',', $availableTypes);
+            foreach ($boletoTypes as $boletoType) {
+                if (in_array($boletoType['value'], $availableTypes)) {
+                    $types[] = $boletoType;
+                }
+            }
+        }
+        return $types;
+    }
+
 
     /**
      * Retrieve request object


### PR DESCRIPTION
**Description**
Only show the Boleto types from the config instead of all the Boleto types

**Tested scenarios**
Configured Boleto with a few boletotypes instead of all of them

**Fixed issue**:  All boleto types were shown in the checkout even if only a few were configured