### PR TITLE
Show payment link in admin for remaining order balance

### DIFF
--- a/Block/Info/PaymentLink.php
+++ b/Block/Info/PaymentLink.php
@@ -86,6 +86,8 @@ class PaymentLink extends AbstractInfo
     public function _toHtml()
     {
         return strpos($this->getPayment()->getMethod(), 'adyen_') === 0
+            && $this->_scopeConfig->getValue('payment/adyen_hpp/active')
+            && $this->_scopeConfig->getValue('payment/adyen_pay_by_mail/active')
             && $this->getOrder()->getTotalInvoiced() > 0
             && $this->getOrder()->getTotalDue() > 0
                 ? parent::_toHtml()

--- a/Block/Info/PaymentLink.php
+++ b/Block/Info/PaymentLink.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2018 Adyen BV (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\Payment\Block\Info;
+
+use Magento\Framework\View\Element\Template;
+
+class PaymentLink extends AbstractInfo
+{
+    /**
+     * @var \Magento\Framework\Registry
+     */
+    private $registry;
+
+    /**
+     * @var \Adyen\Payment\Gateway\Command\PayByMailCommand
+     */
+    private $payByMail;
+
+    public function __construct(
+        \Adyen\Payment\Helper\Data $adyenHelper,
+        \Adyen\Payment\Model\ResourceModel\Order\Payment\CollectionFactory $adyenOrderPaymentCollectionFactory,
+        Template\Context $context,
+        array $data = [],
+        \Magento\Framework\Registry $registry,
+        \Adyen\Payment\Gateway\Command\PayByMailCommand $payByMailCommand
+    ) {
+        $this->registry = $registry;
+        $this->payByMail = $payByMailCommand;
+
+        parent::__construct($adyenHelper, $adyenOrderPaymentCollectionFactory, $context, $data);
+    }
+
+    /**
+     * @return \Magento\Sales\Model\Order
+     */
+    public function getOrder()
+    {
+        return $this->registry->registry('current_order');
+    }
+
+    /**
+     * @return \Magento\Sales\Model\Order\Payment
+     */
+    public function getPayment()
+    {
+        $order = $this->getOrder();
+
+        return $order->getPayment();
+    }
+
+    /**
+     * @return string
+     */
+    public function getPaymentLinkUrl()
+    {
+        return $this->payByMail->generatePaymentUrl($this->getPayment(), $this->getOrder()->getTotalDue());
+    }
+
+    /**
+     * Check if order was placed using Adyen payment method
+     * and if total due is greater than zero while one or more payments have been made
+     *
+     * @return string
+     */
+    public function _toHtml()
+    {
+        return strpos($this->getPayment()->getMethod(), 'adyen_') === 0
+            && $this->getOrder()->getTotalInvoiced() > 0
+            && $this->getOrder()->getTotalDue() > 0
+                ? parent::_toHtml()
+                : '';
+    }
+}

--- a/Gateway/Command/PayByMailCommand.php
+++ b/Gateway/Command/PayByMailCommand.php
@@ -80,13 +80,14 @@ class PayByMailCommand implements CommandInterface
     }
 
     /**
-     * @param $payment
+     * @param \Magento\Sales\Model\Order\Payment $payment
+     * @param float|bool $paymentAmount
      * @return string
      */
-    public function generatePaymentUrl($payment)
+    public function generatePaymentUrl($payment, $paymentAmount = false)
     {
         $url = $this->getFormUrl();
-        $fields = $this->getFormFields($payment);
+        $fields = $this->getFormFields($payment, $paymentAmount);
 
         $count = 1;
         $size = count($fields);
@@ -120,10 +121,11 @@ class PayByMailCommand implements CommandInterface
 
 
     /**
-     * @param $payment
+     * @param \Magento\Sales\Model\Order\Payment $payment
+     * @param float|bool $paymentAmount
      * @return array
      */
-    protected function getFormFields($payment)
+    protected function getFormFields($payment, $paymentAmount = false)
     {
         $order = $payment->getOrder();
 
@@ -144,7 +146,7 @@ class PayByMailCommand implements CommandInterface
             $hmacKey = $this->_adyenHelper->getHmacPayByMail();
         }
 
-        $amount            = $this->_adyenHelper->formatAmount($order->getGrandTotal(), $orderCurrencyCode);
+        $amount            = $this->_adyenHelper->formatAmount($paymentAmount ?: $order->getGrandTotal(), $orderCurrencyCode);
         $merchantAccount   = trim($this->_adyenHelper->getAdyenAbstractConfigData('merchant_account', $storeId));
         $shopperEmail      = $order->getCustomerEmail();
         $customerId        = $order->getCustomerId();

--- a/view/adminhtml/layout/sales_order_view.xml
+++ b/view/adminhtml/layout/sales_order_view.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<!--
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2018 Adyen BV (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+-->
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="admin-2columns-left" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceContainer name="payment_additional_info">
+            <block class="Adyen\Payment\Block\Info\PaymentLink" name="adyen_paymentlink" template="Adyen_Payment::info/adyen_paymentlink.phtml" />
+        </referenceContainer>
+    </body>
+</page>

--- a/view/adminhtml/templates/info/adyen_paymentlink.phtml
+++ b/view/adminhtml/templates/info/adyen_paymentlink.phtml
@@ -27,6 +27,18 @@
 <div class="admin__page-section-item-title">
     <span class="title"><?php echo __('Adyen Payment Link');?></span>
 </div>
-<a href="<?=$block->getPaymentLinkUrl();?>" target="_blank">
-    <?php echo __('Adyen Payment Link for remaining total due'); ?>
+<p id="paymentlink"></p>
+<a href="<?=$block->getPaymentLinkUrl();?>" onclick="copyToClipboard(event, '<?=$block->getPaymentLinkUrl();?>')" style="cursor:pointer;">
+    <?php echo __('Copy payment link to clipboard'); ?>
 </a>
+
+<script type="text/javascript">
+    function copyToClipboard(e, text) {
+        e.preventDefault();
+        var $temp = jQuery("<input>");
+        jQuery("body").append($temp);
+        $temp.val(text).select();
+        document.execCommand("copy");
+        $temp.remove();
+    }
+</script>

--- a/view/adminhtml/templates/info/adyen_paymentlink.phtml
+++ b/view/adminhtml/templates/info/adyen_paymentlink.phtml
@@ -1,0 +1,32 @@
+<?php
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2018 Adyen BV (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+/** @var \Adyen\Payment\Block\Info\PaymentLink $block */
+?>
+<br />
+<div class="admin__page-section-item-title">
+    <span class="title"><?php echo __('Adyen Payment Link');?></span>
+</div>
+<a href="<?=$block->getPaymentLinkUrl();?>" target="_blank">
+    <?php echo __('Adyen Payment Link for remaining total due'); ?>
+</a>


### PR DESCRIPTION
This link only shows when the original order payment method is an
Adyen method, the total due is greater than 0 and the invoiced total
is greater than 0.

Solves #254.

Payment info at order in backend:

![schermafbeelding 2018-02-22 om 15 12 57](https://user-images.githubusercontent.com/6301809/36543412-fbfbbe46-17e3-11e8-80e9-7630cb7e2952.png)