### PR TITLE
Vault detail handler fix

### DIFF
--- a/Gateway/Response/VaultDetailsHandler.php
+++ b/Gateway/Response/VaultDetailsHandler.php
@@ -26,7 +26,6 @@ namespace Adyen\Payment\Gateway\Response;
 use Magento\Vault\Model\CreditCardTokenFactory;
 use Magento\Vault\Api\Data\PaymentTokenInterface;
 use Magento\Payment\Gateway\Response\HandlerInterface;
-use Magento\Payment\Model\InfoInterface;
 use Magento\Sales\Api\Data\OrderPaymentExtensionInterface;
 use Magento\Sales\Api\Data\OrderPaymentInterface;
 
@@ -62,10 +61,10 @@ class VaultDetailsHandler implements HandlerInterface
      */
     public function handle(array $handlingSubject, array $response)
     {
-        $payment = \Magento\Payment\Gateway\Helper\SubjectReader::readPayment($handlingSubject);
+        $paymentDataObject = \Magento\Payment\Gateway\Helper\SubjectReader::readPayment($handlingSubject);
 
         /** @var OrderPaymentInterface $payment */
-        $payment = $payment->getPayment();
+        $payment = $paymentDataObject->getPayment();
 
         // add vault payment token entity to extension attributes
         $paymentToken = $this->getVaultPaymentToken($response);
@@ -180,16 +179,13 @@ class VaultDetailsHandler implements HandlerInterface
 
     /**
      * Get payment extension attributes
-     * @param InfoInterface $payment
+     * @param OrderPaymentInterface $payment
      * @return OrderPaymentExtensionInterface
      */
-    private function getExtensionAttributes(InfoInterface $payment)
+    private function getExtensionAttributes(OrderPaymentInterface $payment)
     {
         $extensionAttributes = $payment->getExtensionAttributes();
-        if (null === $extensionAttributes) {
-            $extensionAttributes = $this->paymentExtensionFactory->create();
-            $payment->setExtensionAttributes($extensionAttributes);
-        }
+
         return $extensionAttributes;
     }
 }


### PR DESCRIPTION
Relates to pull request https://github.com/Adyen/adyen-magento2/pull/260

**Description**
Magento have changed how `PaymentTokenInterfaceFactory` can be used, as it wasn't part of the official API it has broken in the version I am integrating (2.1.12) there is a core issue and they suggested using the core concrete `CreditCardTokenFactory` class instead 
https://github.com/magento/magento2/issues/8083

Additionally I've removed some dead code and tidied up the code to be PSR compliant 

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
I can now successfully tokenize credit cards on 2.1.12 whilst placing admin orders, unfortunately I do not have a lower version of 2.1.* to test this on, it should be backwards compatible though.

**Fixed issue**:  <!-- #-prefixed issue number -->
Relates to #252 Register a new Vault entry when processing a RECURRING_CONTRACT notification (for CC)