### PR TITLE
Replace "Place order" by "Place Order" like Magento

### DIFF
--- a/i18n/en_US.csv
+++ b/i18n/en_US.csv
@@ -11,7 +11,7 @@
 "Select your Bank","Select your Bank"
 "You will be redirected to the Adyen website.","You will be redirected to the Adyen website."
 "Update","Update"
-"Place order","Place order"
+"Place Order","Place Order"
 "Continue to Adyen","Continue to Adyen"
 "Unknown","Unknown"
 "Mismatch between Live/Test modes of Magento store and the Adyen platform","Mismatch between Live/Test modes of Magento store and the Adyen platform"

--- a/i18n/nl_NL.csv
+++ b/i18n/nl_NL.csv
@@ -11,7 +11,7 @@
 "Select Your Bank","Selecteer uw bank"
 "You will be redirected to the Adyen website.","U wordt doorverwezen naar de Adyen-website."
 "Update","Bijwerken"
-"Place order","Plaats bestelling"
+"Place Order","Plaats bestelling"
 "Continue to Adyen","Doorgaan naar Adyen"
 "Unknown","Onbekend"
 "Mismatch between Live/Test modes of Magento store and the Adyen platform","Niet-overeenstemming tussen Live / Test-modi van Magento-winkel en het Adyen-platform"

--- a/view/frontend/web/template/payment/hpp-form.html
+++ b/view/frontend/web/template/payment/hpp-form.html
@@ -174,7 +174,7 @@
                                 type="submit"
                                 data-bind="click: $parent.continueToAdyenBrandCode, enable: (value == $parent.isBrandCodeChecked())"
                                 disabled>
-                            <span data-bind="text: $t('Place order')"></span>
+                            <span data-bind="text: $t('Place Order')"></span>
                         </button>
                     </div>
                 </div>


### PR DESCRIPTION
Hello,

**Description**
This PR replaces `Place order` by `Place Order` because that's what Magento is using.
Currently we have to translate `Place Order` and `Place order` which is not very convenient and can cause some misunderstandings.

What do you think? 
