### PR TITLE
Removed BCMC from manualcapture payment methods

### DIFF
--- a/Model/Cron.php
+++ b/Model/Cron.php
@@ -1309,7 +1309,6 @@ class Cron
             case 'mc':
             case 'uatp':
             case 'amex':
-            case 'bcmc':
             case 'maestro':
             case 'maestrouk':
             case 'diners':


### PR DESCRIPTION
**Description**
bcmc is an autocapture payment method, it is now removed from the manualCaptureAllowed list