### PR TITLE
PW-256 Support multiple partial Captures for open invoice payment methods

### DIFF
--- a/Api/Data/InvoiceInterface.php
+++ b/Api/Data/InvoiceInterface.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Payment Module
+ *
+ * Copyright (c) 2018 Adyen B.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\Payment\Api\Data;
+
+interface InvoiceInterface
+{
+    /**
+     * Constants for keys of data array. Identical to the name of the getter in snake case.
+     */
+
+    /*
+     * Entity ID.
+     */
+    const ENTITY_ID = 'entity_id';
+    /*
+     * Pspreference of the capture.
+     */
+    const PSPREFERENCE = 'pspreference';
+    /*
+     * Original Pspreference of the payment.
+     */
+    const ORIGINAL_REFERENCE = 'original_reference';
+    /*
+     * Acquirer reference.
+     */
+    const ACQUIRER_REFERENCE = 'acquirer_reference';
+    /*
+    * Invoice ID.
+    */
+    const INVOICE_ID = 'invoice_id';
+
+    /**
+     * Gets the ID for the invoice.
+     *
+     * @return int|null Entity ID.
+     */
+    public function getEntityId();
+
+    /**
+     * Sets entity ID.
+     *
+     * @param int $entityId
+     * @return $this
+     */
+    public function setEntityId($entityId);
+
+    /**
+     * Gets the Pspreference for the invoice(capture).
+     *
+     * @return int|null Pspreference.
+     */
+    public function getPspreference();
+
+    /**
+     * Sets Pspreference.
+     *
+     * @param string $pspreference
+     * @return $this
+     */
+    public function setPspreference($pspreference);
+
+    /**
+     * @return mixed
+     */
+    public function getOriginalReference();
+
+    /**
+     * @param $originalReference
+     * @return mixed
+     */
+    public function setOriginalReference($originalReference);
+
+    /**
+     * Gets the AcquirerReference for the invoice.
+     *
+     * @return int|null Acquirerreference.
+     */
+    public function getAcquirerReference();
+
+    /**
+     * Sets AcquirerReference.
+     *
+     * @param string $acquirerReference
+     * @return $this
+     */
+    public function setAcquirerReference($acquirerReference);
+
+    /**
+     * Gets the InvoiceID for the invoice.
+     *
+     * @return int|null Invoice ID.
+     */
+    public function getInvoiceId();
+
+    /**
+     * Sets InvoiceID.
+     *
+     * @param int $invoiceId
+     * @return $this
+     */
+    public function setInvoiceId($invoiceId);
+
+}

--- a/Block/Redirect/Redirect.php
+++ b/Block/Redirect/Redirect.php
@@ -465,8 +465,8 @@ class Redirect extends \Magento\Payment\Block\Form
 
             $numberOfItems = (int)$item->getQtyOrdered();
 
-            $formFields = $this->setOpenInvoiceLineData($formFields, $count, $currency, $description, $itemAmount,
-                $itemVatAmount, $itemVatPercentage, $numberOfItems);
+            $formFields = $this->_adyenHelper->getOpenInvoiceLineData($formFields, $count, $currency, $description, $itemAmount,
+                $itemVatAmount, $itemVatPercentage, $numberOfItems, $this->_order->getPayment());
         }
 
 
@@ -480,8 +480,8 @@ class Redirect extends \Magento\Payment\Block\Form
             $itemVatPercentage = "0";
             $numberOfItems = 1;
 
-            $formFields = $this->setOpenInvoiceLineData($formFields, $count, $currency, $description, $itemAmount,
-                $itemVatAmount, $itemVatPercentage, $numberOfItems);
+            $formFields = $this->_adyenHelper->getOpenInvoiceLineData($formFields, $count, $currency, $description, $itemAmount,
+                $itemVatAmount, $itemVatPercentage, $numberOfItems, $this->_order->getPayment());
         }
 
         // Shipping cost
@@ -507,47 +507,13 @@ class Redirect extends \Magento\Payment\Block\Form
             $itemVatPercentage = $this->_adyenHelper->getMinorUnitTaxPercent($rate);
             $numberOfItems = 1;
 
-            $formFields = $this->setOpenInvoiceLineData($formFields, $count, $currency, $description, $itemAmount,
-                $itemVatAmount, $itemVatPercentage, $numberOfItems);
+            $formFields = $this->_adyenHelper->getOpenInvoiceLineData($formFields, $count, $currency, $description, $itemAmount,
+                $itemVatAmount, $itemVatPercentage, $numberOfItems, $this->_order->getPayment());
         }
 
         $formFields['openinvoicedata.refundDescription'] = "Refund / Correction for " . $formFields['merchantReference'];
         $formFields['openinvoicedata.numberOfLines'] = $count;
 
-        return $formFields;
-    }
-
-
-    /**
-     * Set the openinvoice line
-     *
-     * @param $count
-     * @param $currencyCode
-     * @param $description
-     * @param $itemAmount
-     * @param $itemVatAmount
-     * @param $itemVatPercentage
-     * @param $numberOfItems
-     */
-    protected function setOpenInvoiceLineData($formFields, $count, $currencyCode, $description, $itemAmount,
-                                              $itemVatAmount, $itemVatPercentage, $numberOfItems
-    )
-    {
-        $linename = "line" . $count;
-        $formFields['openinvoicedata.' . $linename . '.currencyCode'] = $currencyCode;
-        $formFields['openinvoicedata.' . $linename . '.description'] = $description;
-        $formFields['openinvoicedata.' . $linename . '.itemAmount'] = $itemAmount;
-        $formFields['openinvoicedata.' . $linename . '.itemVatAmount'] = $itemVatAmount;
-        $formFields['openinvoicedata.' . $linename . '.itemVatPercentage'] = $itemVatPercentage;
-        $formFields['openinvoicedata.' . $linename . '.numberOfItems'] = $numberOfItems;
-
-        if ($this->_adyenHelper->isVatCategoryHigh($this->_order->getPayment()->getAdditionalInformation(
-            \Adyen\Payment\Observer\AdyenHppDataAssignObserver::BRAND_CODE))
-        ) {
-            $formFields['openinvoicedata.' . $linename . '.vatCategory'] = "High";
-        } else {
-            $formFields['openinvoicedata.' . $linename . '.vatCategory'] = "None";
-        }
         return $formFields;
     }
 

--- a/Gateway/Request/CaptureDataBuilder.php
+++ b/Gateway/Request/CaptureDataBuilder.php
@@ -40,12 +40,9 @@ class CaptureDataBuilder implements BuilderInterface
      * CaptureDataBuilder constructor.
      *
      * @param \Adyen\Payment\Helper\Data $adyenHelper
-     * @param \Magento\Tax\Model\Config $taxConfig
-     * @param \Magento\Tax\Model\Calculation $taxCalculation
      */
-    public function __construct(
-        \Adyen\Payment\Helper\Data $adyenHelper
-    ) {
+    public function __construct(\Adyen\Payment\Helper\Data $adyenHelper)
+    {
         $this->adyenHelper = $adyenHelper;
     }
 
@@ -73,7 +70,7 @@ class CaptureDataBuilder implements BuilderInterface
         $request = [
             "modificationAmount" => $modificationAmount,
             "reference" => $payment->getOrder()->getIncrementId(),
-            "originalReference" => $pspReference,
+            "originalReference" => $pspReference
         ];
 
         $brandCode = $payment->getAdditionalInformation(

--- a/Gateway/Request/CaptureDataBuilder.php
+++ b/Gateway/Request/CaptureDataBuilder.php
@@ -37,13 +37,30 @@ class CaptureDataBuilder implements BuilderInterface
     private $adyenHelper;
 
     /**
+     * @var \Magento\Tax\Model\Config
+     */
+    private $taxConfig;
+
+    /**
+     * @var \Magento\Tax\Model\Calculation
+     */
+    private $taxCalculation;
+
+    /**
      * CaptureDataBuilder constructor.
      *
      * @param \Adyen\Payment\Helper\Data $adyenHelper
+     * @param \Magento\Tax\Model\Config $taxConfig
+     * @param \Magento\Tax\Model\Calculation $taxCalculation
      */
-    public function __construct(\Adyen\Payment\Helper\Data $adyenHelper)
+    public function __construct(\Adyen\Payment\Helper\Data $adyenHelper,
+        \Magento\Tax\Model\Config $taxConfig,
+        \Magento\Tax\Model\Calculation $taxCalculation)
     {
         $this->adyenHelper = $adyenHelper;
+        $this->taxConfig = $taxConfig;
+        $this->taxCalculation = $taxCalculation;
+
     }
 
     /**
@@ -60,18 +77,136 @@ class CaptureDataBuilder implements BuilderInterface
         $amount =  \Magento\Payment\Gateway\Helper\SubjectReader::readAmount($buildSubject);
 
         $payment = $paymentDataObject->getPayment();
+
         $pspReference = $payment->getCcTransId();
         $currency = $payment->getOrder()->getOrderCurrencyCode();
 
-        //format the amount to minor units
         $amount = $this->adyenHelper->formatAmount($amount, $currency);
 
         $modificationAmount = ['currency' => $currency, 'value' => $amount];
-
-        return [
+        $request = [
             "modificationAmount" => $modificationAmount,
             "reference" => $payment->getOrder()->getIncrementId(),
-            "originalReference" => $pspReference
+            "originalReference" => $pspReference,
         ];
+
+        $brandCode = $payment->getAdditionalInformation(
+            \Adyen\Payment\Observer\AdyenHppDataAssignObserver::BRAND_CODE
+        );
+
+        if($this->adyenHelper->isPaymentMethodOpenInvoiceMethod($brandCode)){
+            $openInvoiceFields =  $this->setOpenInvoiceData($payment);
+            $request["additionalData"] = $openInvoiceFields;
+        }
+
+        return $request;
+    }
+
+
+    /**
+     * @param $payment
+     * @return mixed
+     * @internal param $formFields
+     */
+    protected function setOpenInvoiceData($payment)
+    {
+        $formFields = [];
+        $count = 0;
+        $currency = $payment->getOrder()->getOrderCurrencyCode();
+
+        $invoices = $payment->getOrder()->getInvoiceCollection();
+
+        // The latest invoice will contain only the selected items(and quantities) for the (partial) capture
+        $latestInvoice = $invoices->getLastItem();
+
+        foreach($latestInvoice->getItemsCollection() as $invoiceItem){
+            ++$count;
+
+            $description = str_replace("\n", '', trim($invoiceItem->getName()));
+            $itemAmount = $this->adyenHelper->formatAmount($invoiceItem->getPrice(), $currency);
+            $itemVatAmount =
+                ($invoiceItem->getTaxAmount() > 0 && $invoiceItem->getPriceInclTax() > 0) ?
+                    $this->adyenHelper->formatAmount(
+                        $invoiceItem->getPriceInclTax(),
+                        $currency
+                    ) - $this->adyenHelper->formatAmount(
+                        $invoiceItem->getPrice(),
+                        $currency
+                    ) : $this->adyenHelper->formatAmount($invoiceItem->getTaxAmount(), $currency);
+
+
+            // Calculate vat percentage
+            $itemVatPercentage = $this->adyenHelper->getMinorUnitTaxPercent($invoiceItem->getTaxPercent());
+
+            $numberOfItems = (int)$invoiceItem->getQty();
+
+            $formFields = $this->setOpenInvoiceLineData($formFields, $count, $currency, $description, $itemAmount,
+                $itemVatAmount, $itemVatPercentage, $numberOfItems, $payment);
+        }
+
+        // Shipping cost
+        if ($latestInvoice->getShippingAmount() > 0) {
+
+            ++$count;
+            $description = $payment->getOrder()->getShippingDescription();
+            $itemAmount = $this->adyenHelper->formatAmount($latestInvoice->getShippingAmount(), $currency);
+            $itemVatAmount = $this->adyenHelper->formatAmount($latestInvoice->getShippingTaxAmount(), $currency);
+
+            // Create RateRequest to calculate the Tax class rate for the shipping method
+            $rateRequest = $this->taxCalculation->getRateRequest(
+                $payment->getOrder()->getShippingAddress(),
+                $payment->getOrder()->getBillingAddress(),
+                null,
+                $payment->getOrder()->getStoreId(), $payment->getOrder()->getCustomerId()
+            );
+
+            $taxClassId = $this->taxConfig->getShippingTaxClass($payment->getOrder()->getStoreId());
+            $rateRequest->setProductClassId($taxClassId);
+            $rate = $this->taxCalculation->getRate($rateRequest);
+
+            $itemVatPercentage = $this->adyenHelper->getMinorUnitTaxPercent($rate);
+            $numberOfItems = 1;
+
+            $formFields = $this->setOpenInvoiceLineData($formFields, $count, $currency, $description, $itemAmount,
+                $itemVatAmount, $itemVatPercentage, $numberOfItems, $payment);
+        }
+
+        $formFields['openinvoicedata.numberOfLines'] = $count;
+
+        return $formFields;
+    }
+
+    /**
+     * Set the openinvoice line
+     *
+     * @param $count
+     * @param $currencyCode
+     * @param $description
+     * @param $itemAmount
+     * @param $itemVatAmount
+     * @param $itemVatPercentage
+     * @param $numberOfItems
+     * @param $payment
+     */
+    protected function setOpenInvoiceLineData($formFields, $count, $currencyCode, $description, $itemAmount,
+        $itemVatAmount, $itemVatPercentage, $numberOfItems, $payment
+    )
+    {
+        $linename = "line" . $count;
+        $formFields['openinvoicedata.' . $linename . '.currencyCode'] = $currencyCode;
+        $formFields['openinvoicedata.' . $linename . '.description'] = $description;
+        $formFields['openinvoicedata.' . $linename . '.itemAmount'] = $itemAmount;
+        $formFields['openinvoicedata.' . $linename . '.itemVatAmount'] = $itemVatAmount;
+        $formFields['openinvoicedata.' . $linename . '.itemVatPercentage'] = $itemVatPercentage;
+        $formFields['openinvoicedata.' . $linename . '.numberOfItems'] = $numberOfItems;
+
+        if ($this->adyenHelper->isVatCategoryHigh($payment->getAdditionalInformation(
+            \Adyen\Payment\Observer\AdyenHppDataAssignObserver::BRAND_CODE))
+        ) {
+            $formFields['openinvoicedata.' . $linename . '.vatCategory'] = "High";
+        } else {
+            $formFields['openinvoicedata.' . $linename . '.vatCategory'] = "None";
+        }
+        return $formFields;
     }
 }

--- a/Model/Cron.php
+++ b/Model/Cron.php
@@ -180,7 +180,7 @@ class Cron
     /**
      * @var ResourceModel\InvoiceFactory
      */
-    protected $_invoiceFactory;
+    protected $_adyenInvoiceFactory;
 
     /**
      * @var AreaList
@@ -219,7 +219,7 @@ class Cron
         \Adyen\Payment\Model\Api\PaymentRequest $paymentRequest,
         \Adyen\Payment\Model\Order\PaymentFactory $adyenOrderPaymentFactory,
         \Adyen\Payment\Model\ResourceModel\Order\Payment\CollectionFactory $adyenOrderPaymentCollectionFactory,
-        \Adyen\Payment\Model\InvoiceFactory $invoiceFactory,
+        \Adyen\Payment\Model\InvoiceFactory $adyenInvoiceFactory,
         AreaList $areaList
     ) {
         $this->_scopeConfig = $scopeConfig;
@@ -235,7 +235,7 @@ class Cron
         $this->_adyenPaymentRequest = $paymentRequest;
         $this->_adyenOrderPaymentFactory = $adyenOrderPaymentFactory;
         $this->_adyenOrderPaymentCollectionFactory = $adyenOrderPaymentCollectionFactory;
-        $this->_invoiceFactory = $invoiceFactory;
+        $this->_adyenInvoiceFactory = $adyenInvoiceFactory;
         $this->_areaList = $areaList;
     }
 
@@ -821,7 +821,7 @@ class Cron
                         $invoiceCollection = $this->_order->getInvoiceCollection();
                         foreach ($invoiceCollection as $invoice) {
                             if ($invoice->getTransactionId() == $this->_pspReference) {
-                                $this->_invoiceFactory->create()
+                                $this->_adyenInvoiceFactory->create()
                                     ->setInvoiceId($invoice->getEntityId())
                                     ->setPspreference($this->_pspReference)
                                     ->setOriginalReference($this->_originalReference)
@@ -1482,10 +1482,10 @@ class Cron
                 /*
                  * Add invoice in the adyen_invoice table
                  */
-                $this->_invoiceFactory->create()
+                $this->_adyenInvoiceFactory->create()
                     ->setInvoiceId($invoice->getEntityId())
                     ->setPspreference($this->_pspReference)
-                    ->setOriginalReference($this->_originalReference)
+                    ->setOriginalReference($this->_pspReference)
                     ->setAcquirerReference($this->_acquirerReference)
                     ->save();
 

--- a/Model/Invoice.php
+++ b/Model/Invoice.php
@@ -1,0 +1,143 @@
+<?php
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Payment Module
+ *
+ * Copyright (c) 2018 Adyen B.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\Payment\Model;
+
+use Adyen\Payment\Api\Data\InvoiceInterface;
+
+class Invoice extends \Magento\Framework\Model\AbstractModel
+    implements InvoiceInterface
+{
+    /**
+     * Notification constructor.
+     *
+     * @param \Magento\Framework\Model\Context $context
+     * @param \Magento\Framework\Registry $registry
+     * @param \Magento\Framework\Model\ResourceModel\AbstractResource|null $resource
+     * @param \Magento\Framework\Data\Collection\AbstractDb|null $resourceCollection
+     * @param array $data
+     */
+    public function __construct(
+        \Magento\Framework\Model\Context $context,
+        \Magento\Framework\Registry $registry,
+        \Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
+        \Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
+        array $data = []
+    ) {
+        parent::__construct($context, $registry, $resource, $resourceCollection, $data);
+    }
+
+    /**
+     * Initialize resource model
+     *
+     * @return void
+     */
+    protected function _construct()
+    {
+        $this->_init('Adyen\Payment\Model\ResourceModel\Invoice');
+    }
+
+    /**
+     * Gets the Pspreference for the invoice(capture).
+     *
+     * @return int|null Pspreference.
+     */
+    public function getPspreference()
+    {
+        return $this->getData(self::PSPREFERENCE);
+    }
+
+    /**
+     * Sets Pspreference.
+     *
+     * @param string $pspreference
+     * @return $this
+     */
+    public function setPspreference($pspreference)
+    {
+        return $this->setData(self::PSPREFERENCE, $pspreference);
+    }
+
+    /**
+     * Gets the Pspreference of the original Payment
+     * @return mixed
+     */
+    public function getOriginalReference()
+    {
+        return $this->getData(self::ORIGINAL_REFERENCE);
+    }
+
+    /**
+     * Sets the OriginalReference
+     *
+     * @param $originalReference
+     * @return $this
+     */
+    public function setOriginalReference($originalReference)
+    {
+        return $this->setData(self::ORIGINAL_REFERENCE, $originalReference);
+    }
+    /**
+     * Gets the AcquirerReference for the invoice.
+     *
+     * @return int|null Acquirerreference.
+     */
+    public function getAcquirerReference()
+    {
+        return $this->getData(self::ACQUIRER_REFERENCE);
+    }
+
+    /**
+     * Sets AcquirerReference.
+     *
+     * @param string $acquirerReference
+     * @return $this
+     */
+    public function setAcquirerReference($acquirerReference)
+    {
+        return $this->setData(self::ACQUIRER_REFERENCE, $acquirerReference);
+    }
+
+    /**
+     * Gets the InvoiceID for the invoice.
+     *
+     * @return int|null Invoice ID.
+     */
+    public function getInvoiceId()
+    {
+        return $this->getData(self::INVOICE_ID);
+    }
+
+    /**
+     * Sets InvoiceID.
+     *
+     * @param int $invoiceId
+     * @return $this
+     */
+    public function setInvoiceId($invoiceId)
+    {
+        return $this->setData(self::INVOICE_ID, $invoiceId);
+    }
+
+}

--- a/Model/ResourceModel/Invoice.php
+++ b/Model/ResourceModel/Invoice.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Payment Module
+ *
+ * Copyright (c) 2018 Adyen B.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\Payment\Model\ResourceModel;
+
+class Invoice extends \Magento\Framework\Model\ResourceModel\Db\AbstractDb
+{
+    /**
+     * Resource initialization
+     *
+     * @return void
+     */
+    protected function _construct()
+    {
+        $this->_init('adyen_invoice', 'entity_id');
+    }
+}

--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -310,7 +310,7 @@ class UpgradeSchema implements UpgradeSchemaInterface
                 \Magento\Framework\DB\Ddl\Table::TYPE_INTEGER,
                 null,
                 ['identity' => true, 'unsigned' => true, 'nullable' => false, 'primary' => true],
-                'Adyen Payment ID'
+                'Adyen Invoice Entity ID'
             )
             ->addColumn(
                 'pspreference',


### PR DESCRIPTION
**Description**
Support multiple partial Captures for open invoice payment methods:
- Openinvoice lines are sent in the capture request
- An entry in the new adyen_invoice table will be created after a CAPTURE notification(manual capture) or after an AUTHORISATION notification(autocapture)
- The entry contains the acquirer reference, which is mandatory for partial refunds.

**Tested scenarios**
Klarna partial captures(manual capture),
Credit card autocapture(the entry is created in the adyen_invoice table).