### PR TITLE
Fixed mismatching method signatures (API)

### DIFF
--- a/Api/AdyenPaymentMethodManagementInterface.php
+++ b/Api/AdyenPaymentMethodManagementInterface.php
@@ -35,9 +35,10 @@ interface AdyenPaymentMethodManagementInterface
     /**
      * Get payment information
      *
-     * @param string $cartId
+     * @param  string $cartId
+     * @param  null|\Magento\Quote\Api\Data\AddressInterface
      * @return \Magento\Checkout\Api\Data\PaymentDetailsInterface
      */
-    public function getPaymentMethods($cartId, \Magento\Quote\Api\Data\AddressInterface $shippingAddress);
+    public function getPaymentMethods($cartId, \Magento\Quote\Api\Data\AddressInterface $shippingAddress = null);
     
 }

--- a/Api/GuestAdyenPaymentMethodManagementInterface.php
+++ b/Api/GuestAdyenPaymentMethodManagementInterface.php
@@ -35,9 +35,10 @@ interface GuestAdyenPaymentMethodManagementInterface
     /**
      * Get payment information
      *
-     * @param string $cartId
+     * @param  string $cartId
+     * @param  null|\Magento\Quote\Api\Data\AddressInterface
      * @return \Magento\Checkout\Api\Data\PaymentDetailsInterface
      */
-    public function getPaymentMethods($cartId, \Magento\Quote\Api\Data\AddressInterface $shippingAddress);
+    public function getPaymentMethods($cartId, \Magento\Quote\Api\Data\AddressInterface $shippingAddress = null);
     
 }


### PR DESCRIPTION
**Description**
The signatures of the methods in the interface and implementation do not match, which might cause confusion and breaks functionality when no ShippingAddress is provided. Why? Due to missing DocBlock(s) Magento cannot resolve an empty/null shipping address when digesting the request. Adding appropriate DocBlock(s) and adding null (by matching method signatures) we can resolve this issue.

**Tested scenarios**
We tested this by requesting payment methods from the API _without_ a valid (null) shipping address. This resulted in a 400 HTTP error due to Magento not being able to digest the request properly. After implementing these changes, it works as expected.