### PR TITLE
PW-515: added fix for Test Notifications

### DIFF
--- a/Controller/Process/Json.php
+++ b/Controller/Process/Json.php
@@ -99,7 +99,7 @@ class Json extends \Magento\Framework\App\Action\Action
 
             $notificationMode = isset($notificationItems['live']) ? $notificationItems['live'] : "";
 
-            if ($notificationMode != "" && $this->_validateNotificationMode($notificationMode)) {
+            if ($notificationMode != "" || $notificationMode !== "" && $this->_validateNotificationMode($notificationMode)) {
                 foreach ($notificationItems['notificationItems'] as $notificationItem) {
 
 
@@ -154,7 +154,7 @@ class Json extends \Magento\Framework\App\Action\Action
     {
         $mode = $this->_adyenHelper->getAdyenAbstractConfigData('demo_mode');
 
-        if (($mode == '1' && $notificationMode == "false") || ($mode == '0' && $notificationMode == 'true')) {
+        if (($mode == '1' && ($notificationMode == "false" || $notificationMode == false)) || ($mode == '0' && ($notificationMode == 'true' || $notificationMode == true))) {
             return true;
         }
         return false;


### PR DESCRIPTION
**Description**
On test notifications, the field "live" is a boolean instead of a string.
A check has been added so that we cover both cases.