### PR TITLE
B: Only delete Vault token remotely when payment method is Adyen

### DIFF
--- a/Plugin/PaymentVaultDeleteToken.php
+++ b/Plugin/PaymentVaultDeleteToken.php
@@ -27,7 +27,6 @@ use Magento\Vault\Api\Data\PaymentTokenInterface;
 
 class PaymentVaultDeleteToken
 {
-
     /**
      * @var \Adyen\Payment\Model\Api\PaymentRequest
      */
@@ -52,6 +51,10 @@ class PaymentVaultDeleteToken
 
     public function beforeDelete(\Magento\Vault\Api\PaymentTokenRepositoryInterface $subject, PaymentTokenInterface $paymentToken)
     {
+        if (strpos($paymentToken->getPaymentMethodCode(), 'adyen_') !== 0) {
+            return $paymentToken;
+        }
+
         try {
             $this->_paymentRequest->disableRecurringContract(
                 $paymentToken->getGatewayToken(),
@@ -61,7 +64,5 @@ class PaymentVaultDeleteToken
         } catch(\Exception $e) {
             throw new \Magento\Framework\Exception\LocalizedException(__('Failed to disable this contract'));
         }
-
     }
-
 }

--- a/Plugin/PaymentVaultDeleteToken.php
+++ b/Plugin/PaymentVaultDeleteToken.php
@@ -52,7 +52,7 @@ class PaymentVaultDeleteToken
     public function beforeDelete(\Magento\Vault\Api\PaymentTokenRepositoryInterface $subject, PaymentTokenInterface $paymentToken)
     {
         if (strpos($paymentToken->getPaymentMethodCode(), 'adyen_') !== 0) {
-            return $paymentToken;
+            return [$paymentToken];
         }
 
         try {


### PR DESCRIPTION
Fixes #297

<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
Only try to delete a Vault token remotely at Adyen, when payment method of token is Adyen.

**Tested scenarios**
Running the integration test `\Magento\Braintree\Controller\Cards\DeleteActionTest::testExecute`.

**Fixed issue**:  #297