### PR TITLE
Correct NL translation for Credit Card Owner

### DIFF
--- a/i18n/nl_NL.csv
+++ b/i18n/nl_NL.csv
@@ -2,7 +2,7 @@
 "Credit Card Information","Creditcard gegevens"
 "Credit Card Type","Creditcard type"
 "Credit Card Number","Creditcard Number"
-"Credit Card Owner","Creditcard houder"
+"Credit Card Owner","Creditcard Houder"
 "Expiration Date","Verloopdatum"
 "Card Verification Number","Creditcard Verificatie Nummer"
 "--Please Select--","--Selecteer--"

--- a/i18n/nl_NL.csv
+++ b/i18n/nl_NL.csv
@@ -2,7 +2,7 @@
 "Credit Card Information","Creditcard gegevens"
 "Credit Card Type","Creditcard type"
 "Credit Card Number","Creditcard Number"
-"Credit Card Owner","Creditcardnummer"
+"Credit Card Owner","Creditcard houder"
 "Expiration Date","Verloopdatum"
 "Card Verification Number","Creditcard Verificatie Nummer"
 "--Please Select--","--Selecteer--"


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

The translation for Credit Card Owner was incorrect in the Dutch i18. I changed it to be Creditcard Houder which roughly translates to "Credit Card Owner"
<!-- Please provide a description of the changes proposed in the Pull Request -->

**Fixed issue**:  No issue was found so I just fixed it in the PR right away.