### PR TITLE
PW-642: Creating credit memos after notification from BO

### DIFF
--- a/Model/Cron.php
+++ b/Model/Cron.php
@@ -1076,19 +1076,15 @@ class Cron
         $lastTransactionId = $this->_order->getPayment()->getLastTransId();
         if ($lastTransactionId != $this->_pspReference) {
 
-            // refund is done through adyen backoffice so create an invoice
+            // refund is done through adyen backoffice so create a credit memo
             $order = $this->_order;
             if ($order->canCreditmemo()) {
 
-                // there is a bug in this function of Magento see #2656 magento\magento2 repo
-                // Invalid method Magento\Sales\Model\Order\Creditmemo::register
-                /*
                 $currency = $this->_order->getOrderCurrencyCode();
                 $amount = $this->_adyenHelper->originalAmount($this->_value, $currency);
                 $order->getPayment()->registerRefundNotification($amount);
-                */
 
-                $this->_adyenLogger->addAdyenNotificationCronjob('Please create your credit memo inside magento');
+                $this->_adyenLogger->addAdyenNotificationCronjob('Created credit memo for order');
             } else {
                 $this->_adyenLogger->addAdyenNotificationCronjob('Could not create a credit memo for order');
             }


### PR DESCRIPTION
**Description**
Uncommenting code after Magento2 core issue #2656 has been resolved.
Now creating Credit Memos after triggering a refund from Adyen Customer Area

**Tested scenarios**
Full amount credit memo successful.
Partial amount credit memo unsuccessful with comment on order:
`IPN "Refunded". Refund issued by merchant. Registered notification about refunded amount of €***. Transaction ID: "". Credit Memo has not been created. Please create offline Credit Memo.`