### PR TITLE
Make adyen/process/json compatible with Magento 2.3-develop

### DIFF
--- a/Controller/Process/Json.php
+++ b/Controller/Process/Json.php
@@ -20,6 +20,7 @@
  *
  * Author: Adyen <magento@adyen.com>
  */
+declare(strict_types=1);
 
 namespace Adyen\Payment\Controller\Process;
 
@@ -29,7 +30,7 @@ use Symfony\Component\Config\Definition\Exception\Exception;
  * Class Json
  * @package Adyen\Payment\Controller\Process
  */
-class Json extends \Magento\Framework\App\Action\Action
+class Json extends \Magento\Framework\App\Action\Action implements \Magento\Framework\App\CsrfAwareActionInterface
 {
     /**
      * @var \Magento\Framework\ObjectManagerInterface
@@ -69,6 +70,23 @@ class Json extends \Magento\Framework\App\Action\Action
         $this->_resultFactory = $context->getResultFactory();
         $this->_adyenHelper = $adyenHelper;
         $this->_adyenLogger = $adyenLogger;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function createCsrfValidationException(
+        \Magento\Framework\App\RequestInterface $request
+    ): ?\Magento\Framework\App\Request\InvalidRequestException {
+        return null;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function validateForCsrf(\Magento\Framework\App\RequestInterface $request): ?bool
+    {
+        return true;
     }
 
     /**

--- a/Test/Unit/Helper/DataTest.php
+++ b/Test/Unit/Helper/DataTest.php
@@ -50,6 +50,8 @@ class DataTest extends \PHPUnit\Framework\TestCase
         $notificationFactory = $this->getSimpleMock(\Adyen\Payment\Model\ResourceModel\Notification\CollectionFactory::class);
         $taxConfig = $this->getSimpleMock(\Magento\Tax\Model\Config::class);
         $taxCalculation = $this->getSimpleMock(\Magento\Tax\Model\Calculation::class);
+        $productMetadata = $this->getSimpleMock( \Magento\Framework\App\ProductMetadata::class);
+        $adyenLogger = $this->getSimpleMock(\Adyen\Payment\Logger\AdyenLogger::class);
 
         $this->dataHelper = new \Adyen\Payment\Helper\Data(
             $context,
@@ -62,7 +64,9 @@ class DataTest extends \PHPUnit\Framework\TestCase
             $assetSource,
             $notificationFactory,
             $taxConfig,
-            $taxCalculation
+            $taxCalculation,
+            $productMetadata,
+            $adyenLogger
         );
     }
 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
   ],
   "require": {
     "adyen/php-api-library": ">=1.5.2",
-    "magento/framework": ">=100.1.0"
+    "magento/framework": ">=102.0.0"
   },
   "autoload": {
     "files": [


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->

CSRF checks have been introduced on all requests in Magento 2.3. URLs that function as webhooks do not require these checks however. I have applied the same approach here as is used in other built in payment methods in M2.3

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
Click "test configuration" when testing the server communication settings (standard notification) in the Adyen portal.

Before PR: 302
After PR: 200 [accepted]

**Fixed issue**:  #327