### PR TITLE
Change input type to "tel" to prevent spacing issue on firefox

### DIFF
--- a/view/frontend/web/template/payment/cc-form.html
+++ b/view/frontend/web/template/payment/cc-form.html
@@ -101,7 +101,7 @@
                         <span><!-- ko text: $t('Credit Card Number')--><!-- /ko --></span>
                     </label>
                     <div class="control">
-                        <input type="number" class="input-text" value=""
+                        <input type="tel" class="input-text" value=""
                                data-encrypted-name="number"
                                data-bind="attr: {
                                             autocomplete: off,


### PR DESCRIPTION
**Description**
Firefox browser has problems with spacing the credit card number, changing the input type to tel.