### PR TITLE
PW-882: Fix 3dsecure for M2.3, fix captureonshipment

### DIFF
--- a/Controller/Process/Validate3d.php
+++ b/Controller/Process/Validate3d.php
@@ -22,6 +22,7 @@
  */
 
 namespace Adyen\Payment\Controller\Process;
+use Magento\Framework\App\Request\Http as HttpRequest;
 
 class Validate3d extends \Magento\Framework\App\Action\Action
 {
@@ -75,6 +76,13 @@ class Validate3d extends \Magento\Framework\App\Action\Action
         $this->_adyenHelper = $adyenHelper;
         $this->_paymentRequest = $paymentRequest;
         $this->_orderRepository = $orderRepository;
+        // Fix for Magento2.3 adding isAjax to the request params
+        if(interface_exists("\Magento\Framework\App\CsrfAwareActionInterface")) {
+            $request = $this->getRequest();
+            if ($request instanceof HttpRequest && $request->isPost()) {
+                $request->setParam('isAjax', true);
+            }
+        }
     }
 
     /**

--- a/Observer/Adminhtml/BeforeShipmentObserver.php
+++ b/Observer/Adminhtml/BeforeShipmentObserver.php
@@ -54,7 +54,7 @@ class BeforeShipmentObserver extends AbstractDataAssignObserver
     {
         $shipment = $observer->getEvent()->getShipment();
         $order = $shipment->getOrder();
-        $captureOnShipment = $this->_adyenHelper->getConfigData('capture_on_shipment', 'adyen_abstract', $order->getStoreId());
+        $captureOnShipment = $this->adyenHelper->getConfigData('capture_on_shipment', 'adyen_abstract', $order->getStoreId());
 
         if ($this->isPaymentMethodAdyen($order) && $captureOnShipment) {
             $payment = $order->getPayment();


### PR DESCRIPTION
**Description**
Set isAjax to true in Validate3d controller to prevent Invalid form key error(magento 2.3)
Fix for capture on shipment method.

**Fixed issue**:  #362