### PR TITLE
Update RefundDataBuilder.php

### DIFF
--- a/Gateway/Request/RefundDataBuilder.php
+++ b/Gateway/Request/RefundDataBuilder.php
@@ -191,7 +191,7 @@ class RefundDataBuilder implements BuilderInterface
 
         foreach ($creditMemo->getAllItems() as $refundItem) {
             ++$count;
-            $numberOfItems = $refundItem->getQty();
+            $numberOfItems = (int)$refundItem->getQty();
 
             $formFields = $this->adyenHelper->createOpenInvoiceLineItem(
                 $formFields,


### PR DESCRIPTION
Should refunditem->getQty be casted to int like in capturedatabuilder? this to prevent decimal value in request and server producing an error?

<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

**Fixed issue**:  <!-- #-prefixed issue number -->