### PR TITLE
 fix for payment methods that have fields different from "issuer"

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/adyen-hpp-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-hpp-method.js
@@ -279,7 +279,11 @@ define(
                      * @returns {boolean}
                      */
                     result.hasIssuersProperty = function () {
-                        if (typeof value.details !== 'undefined' && typeof value.details[0].items !== 'undefined') {
+                        if (
+                            typeof value.details !== 'undefined' &&
+                            typeof value.details[0].items !== 'undefined' &&
+                            value.details[0].key == 'issuer'
+                        ) {
                             return true;
                         }
 


### PR DESCRIPTION
fix for payment methods that have fields different from "issuer".
Qiwiwallet for example has a list of prefixes, that will be hidden