### PR TITLE
PW-1173: Ignore OFFER_CLOSED for already authorised orders, or for or…

### DIFF
--- a/Model/Cron.php
+++ b/Model/Cron.php
@@ -898,6 +898,41 @@ class Cron
                 }
                 break;
             case Notification::OFFER_CLOSED:
+                $previousSuccess = $this->_order->getData('adyen_notification_event_code_success');
+
+                // Order is already Authorised
+                if ($previousSuccess) {
+                    $this->_adyenLogger->addAdyenNotificationCronjob("Order is already authorised, skipping OFFER_CLOSED");
+                    break;
+                }
+
+                /*
+                 * For cards, it can be 'visa', 'maestro',...
+                 * For alternatives, it can be 'ideal', 'directEbanking',...
+                 */
+                $notificationPaymentMethod = $this->_paymentMethod;
+
+                /*
+                * For cards, it can be 'VI', 'MI',...
+                * For alternatives, it can be 'ideal', 'directEbanking',...
+                */
+                $orderPaymentMethod = $this->_order->getPayment()->getCcType();
+
+                $isOrderCc = strcmp($this->_paymentMethodCode(),
+                        'adyen_cc') == 0 || strcmp($this->_paymentMethodCode(), 'adyen_oneclick') == 0;
+
+                /*
+                 * If the order was made with an Alternative payment method,
+                 * continue with the cancellation only if the payment method of
+                 * the notification matches the payment method of the order.
+                 */
+                if (!$isOrderCc && strcmp($notificationPaymentMethod, $orderPaymentMethod) !== 0) {
+                    $this->_adyenLogger->addAdyenNotificationCronjob("Order is not a credit card, 
+                    or the payment method in the notification does not match the payment method of the order, 
+                    skipping OFFER_CLOSED");
+                    break;
+                }
+
                 if (!$this->_order->canCancel()) {
                     // Move the order from PAYMENT_REVIEW to NEW, so that can be cancelled
                     $this->_order->setState(\Magento\Sales\Model\Order::STATE_NEW);
@@ -1139,9 +1174,14 @@ class Cron
     protected function _authorizePayment()
     {
         $this->_adyenLogger->addAdyenNotificationCronjob('Authorisation of the order');
+
+        // Set adyen_notification_event_code_success to true so that we ignore a possible OFFER_CLOSED
+        if (strcmp($this->_success, 'true') == 0) {
+            $this->_order->setData('adyen_notification_event_code_success', 1);
+        }
         $fraudManualReviewStatus = $this->_getFraudManualReviewStatus();
 
-        // If manual review is active and a seperate status is used then ignore the pre authorized status
+        // If manual review is active and a separate status is used then ignore the pre authorized status
         if ($this->_fraudManualReview != true || $fraudManualReviewStatus == "") {
             $this->_setPrePaymentAuthorized();
         } else {

--- a/Model/Cron.php
+++ b/Model/Cron.php
@@ -901,7 +901,7 @@ class Cron
                 $previousSuccess = $this->_order->getData('adyen_notification_event_code_success');
 
                 // Order is already Authorised
-                if ($previousSuccess) {
+                if (!empty($previousSuccess)) {
                     $this->_adyenLogger->addAdyenNotificationCronjob("Order is already authorised, skipping OFFER_CLOSED");
                     break;
                 }

--- a/Observer/AdyenBoletoDataAssignObserver.php
+++ b/Observer/AdyenBoletoDataAssignObserver.php
@@ -47,6 +47,16 @@ class AdyenBoletoDataAssignObserver extends AbstractDataAssignObserver
     ];
 
     /**
+     * @var \Adyen\Payment\Helper\Data
+     */
+    private $adyenHelper;
+
+    public function __construct(
+        \Adyen\Payment\Helper\Data $adyenHelper
+    ) {
+        $this->adyenHelper = $adyenHelper;
+    }
+    /**
      * @param Observer $observer
      * @return void
      */
@@ -60,8 +70,11 @@ class AdyenBoletoDataAssignObserver extends AbstractDataAssignObserver
         }
 
         $paymentInfo = $this->readPaymentModelArgument($observer);
-        
-        $paymentInfo->setCcType('boleto');
+        if (!empty($additionalData[self::BOLETO_TYPE])) {
+            $paymentInfo->setCcType($additionalData[self::BOLETO_TYPE]);
+        } else {
+            $paymentInfo->setCcType($this->adyenHelper->getAdyenBoletoConfigData('boletotypes'));
+        }
 
         foreach ($this->additionalInformationList as $additionalInformationKey) {
             if (isset($additionalData[$additionalInformationKey])) {

--- a/Plugin/PaymentInformationManagement.php
+++ b/Plugin/PaymentInformationManagement.php
@@ -150,6 +150,8 @@ class PaymentInformationManagement
         // PaymentDataBuilder
         $currencyCode = $quote->getQuoteCurrencyCode();
         $amount = $quote->getGrandTotal();
+        // Setting the orderid to null, so that we generate a new one for each /payments call
+        $quote->setReservedOrderId(null);
         $reference = $quote->reserveOrderId()->getReservedOrderId();
         $request = $this->adyenRequestHelper->buildPaymentData($request, $amount, $currencyCode, $reference);
 


### PR DESCRIPTION
…ders that are not matching the paymentmethod of the notification
Set the ccType of boleto payments to the proper boleto variant.
reset order id on card placeorder

**Tested scenarios**
1) Credit card -> 3ds2 -> refresh page on challengeShopper ->  pay with boleto:
receive offerclosed for creditcard -> no action
receive offerclosed for boleto -> cancel order

2) Credit card -> 3ds2 -> refresh page on challengeShopper -> Credit card -> new order id so no action required

**Fixed issue**:  <!-- #-prefixed issue number -->