### PR TITLE
Fix for invalid form key error message

### DIFF
--- a/Controller/Process/Redirect.php
+++ b/Controller/Process/Redirect.php
@@ -29,8 +29,11 @@ use Magento\Sales\Api\Data\OrderPaymentExtensionInterface;
 use Magento\Sales\Api\Data\OrderPaymentExtensionInterfaceFactory;
 use Magento\Sales\Model\ResourceModel\Order\Payment as OrderPaymentResource;
 use Magento\Payment\Model\InfoInterface;
+use Magento\Framework\App\CsrfAwareActionInterface;
+use Magento\Framework\App\Request\InvalidRequestException;
+use Magento\Framework\App\RequestInterface;
 
-class Redirect extends \Magento\Framework\App\Action\Action
+class Redirect extends \Magento\Framework\App\Action\Action implements CsrfAwareActionInterface
 {
 
     /**
@@ -351,5 +354,21 @@ class Redirect extends \Magento\Framework\App\Action\Action
             $payment->setExtensionAttributes($extensionAttributes);
         }
         return $extensionAttributes;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function createCsrfValidationException(
+        RequestInterface $request
+    ): ?InvalidRequestException {
+        return null;
+    }
+    /**
+     * @inheritDoc
+     */
+    public function validateForCsrf(RequestInterface $request): ?bool
+    {
+        return true;
     }
 }


### PR DESCRIPTION
**Description**
I get the following error after placing an order with Bancontact: 'Invalid Form Key. Please refresh the page.'

This is after the redirect from the 3DS page. This is caused by the CSRF validation that is new in Magento 2.3.X.

**Tested scenarios**
1. Add a product to shopping cart
2. Choose 'Bancontact / Mr. Cash' as payment method
3. Fill in test card numbers from Adyen documentation
4. Fill in username and password on 3DS page
5. Redirect to order success page is working again

**Fixed issue**:  #476 