### PR TITLE
Update notification cron job group name in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ If you need to setup your cronjob in Magento <a href="http://devdocs.magento.com
 
 We have defined this:
 ```
-<group id="index">
+<group id="adyen_payment">
     <job name="adyen_payment_process_notification" instance="Adyen\Payment\Model\Cron" method="processNotification">
         <schedule>*/1 * * * *</schedule>
     </job>


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
The cronjob group in readme.md is not up to date. When Magento cronjobs are triggered per group (e.g. `bin/magento cron:run --group=index`), the adyen notification cronjob is easily missed.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->


**Fixed issue**:  <!-- #-prefixed issue number -->