### PR TITLE
Expose last 4 digits of API keys

### DIFF
--- a/Model/Comment/ApiKeyEnding.php
+++ b/Model/Comment/ApiKeyEnding.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Adyen\Payment\Model\Comment;
+
+use Magento\Config\Model\Config\CommentInterface;
+use Magento\Framework\Encryption\EncryptorInterface;
+
+class ApiKeyEnding implements CommentInterface
+{
+    /**
+     * @var EncryptorInterface
+     */
+    private $encryptor;
+
+    /**
+     * ApiKeyEnding constructor.
+     *
+     * @param EncryptorInterface $encryptor Magento encryptor, used to decrypt the API key.
+     */
+    public function __construct(EncryptorInterface $encryptor)
+    {
+        $this->encryptor = $encryptor;
+    }
+
+    /**
+     * Method magically called by Magento. This returns the last 4 digits in the merchant's API key.
+     *
+     * @param string $elementValue The value of the field with this commented. In this case, an encrypted API key.
+     * @return string Some HTML markup to be displayed in the admin panel.
+     */
+    public function getCommentText($elementValue)
+    {
+        $apiKeyEnding = substr($this->encryptor->decrypt(trim($elementValue)), -4);
+        return "API key ending with: <strong>$apiKeyEnding</strong>";
+    }
+}

--- a/Test/Unit/Comment/ApiKeyEndingTest.php
+++ b/Test/Unit/Comment/ApiKeyEndingTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Adyen\Payment\Test\Comment;
+
+use Adyen\Payment\Model\Comment\ApiKeyEnding;
+use Magento\Framework\Encryption\Encryptor;
+
+class ApiKeyEndingTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var ApiKeyEnding
+     */
+    private $apiKeyEndingComment;
+
+    public function setUp()
+    {
+        $encryptor = $this->createMock(Encryptor::class);
+        $map = [
+            ['4321', '1234'],
+            ['asdfasdfasdf', 'qwerqwerqwer']
+        ];
+        $encryptor->method('decrypt')
+            ->will($this->returnValueMap($map));
+
+        $this->apiKeyEndingComment = new ApiKeyEnding($encryptor);
+    }
+
+    public function testSomething()
+    {
+        $this->assertEquals('API key ending with: <strong>1234</strong>', $this->apiKeyEndingComment->getCommentText('4321'));
+        $this->assertEquals('API key ending with: <strong>qwer</strong>', $this->apiKeyEndingComment->getCommentText('asdfasdfasdf'));
+    }
+}

--- a/Test/Unit/Comment/ApiKeyEndingTest.php
+++ b/Test/Unit/Comment/ApiKeyEndingTest.php
@@ -25,7 +25,7 @@ class ApiKeyEndingTest extends \PHPUnit\Framework\TestCase
         $this->apiKeyEndingComment = new ApiKeyEnding($encryptor);
     }
 
-    public function testSomething()
+    public function testCommentReturnsJustTheEnding()
     {
         $this->assertEquals('API key ending with: <strong>1234</strong>', $this->apiKeyEndingComment->getCommentText('4321'));
         $this->assertEquals('API key ending with: <strong>qwer</strong>', $this->apiKeyEndingComment->getCommentText('asdfasdfasdf'));

--- a/etc/adminhtml/system/adyen_pos_cloud.xml
+++ b/etc/adminhtml/system/adyen_pos_cloud.xml
@@ -58,12 +58,14 @@
             <tooltip>Copy this from the Test Adyen Customer Area => Settings => Users => System => [web service user]=> Checkout API Key.</tooltip>
             <backend_model>Magento\Config\Model\Config\Backend\Encrypted</backend_model>
             <config_path>payment/adyen_pos_cloud/api_key_test</config_path>
+            <comment model="Adyen\Payment\Model\Comment\ApiKeyEnding" />
         </field>
         <field id="api_key_live" translate="label" type="obscure" sortOrder="70" showInDefault="1" showInWebsite="1" showInStore="0">
             <label>API key for Cloud API LIVE</label>
             <tooltip>Copy this from the Live Adyen Customer Area => Settings => Users => System => [web service user]=> Checkout API Key.</tooltip>
             <backend_model>Magento\Config\Model\Config\Backend\Encrypted</backend_model>
             <config_path>payment/adyen_pos_cloud/api_key_live</config_path>
+            <comment model="Adyen\Payment\Model\Comment\ApiKeyEnding" />
         </field>
         <field id="capture_mode_pos" translate="label" type="select" sortOrder="90" showInDefault="1" showInWebsite="1" showInStore="1">
             <label>Capture Delay</label>

--- a/etc/adminhtml/system/adyen_required_settings.xml
+++ b/etc/adminhtml/system/adyen_required_settings.xml
@@ -54,12 +54,14 @@
             <tooltip>If you don't know your Api-Key, log in to your Test Customer Area. Navigate to Settings > Users > System, and click on your webservice user, normally this will be ws@Company.YourCompanyAccount. Under Checkout token is your API Key.</tooltip>
             <backend_model>Magento\Config\Model\Config\Backend\Encrypted</backend_model>
             <config_path>payment/adyen_abstract/api_key_test</config_path>
+            <comment model="Adyen\Payment\Model\Comment\ApiKeyEnding" />
         </field>
         <field id="api_key_live" translate="label" type="obscure" sortOrder="60" showInDefault="1" showInWebsite="1" showInStore="0">
             <label>API key for Live</label>
             <tooltip>If you don't know your Api-Key, log in to your Live Customer Area. Navigate to Settings > Users > System, and click on your webservice user, normally this will be ws@Company.YourCompanyAccount. Under Checkout token is your API Key.</tooltip>
             <backend_model>Magento\Config\Model\Config\Backend\Encrypted</backend_model>
             <config_path>payment/adyen_abstract/api_key_live</config_path>
+            <comment model="Adyen\Payment\Model\Comment\ApiKeyEnding" />
         </field>
         <field id="live_endpoint_url_prefix" translate="label" type="text" sortOrder="70" showInDefault="1" showInWebsite="1" showInStore="0">
             <label>Live endpoint prefix</label>


### PR DESCRIPTION
To help debug issues, expose the last 4 digits of API keys.
