### PR TITLE
PW-1665 Recurring is not set to true when recurring is enable

### DIFF
--- a/Helper/Requests.php
+++ b/Helper/Requests.php
@@ -437,14 +437,16 @@ class Requests extends AbstractHelper
      */
     public function buildVaultData($request = [], $payload)
     {
-        if (!empty($payload[PaymentInterface::KEY_ADDITIONAL_DATA][VaultConfigProvider::IS_ACTIVE_CODE]) &&
-            $payload[PaymentInterface::KEY_ADDITIONAL_DATA][VaultConfigProvider::IS_ACTIVE_CODE] === true
-        ) {
-            // store it only as oneclick otherwise we store oneclick tokens (maestro+bcmc) that will fail
-            $request['enableRecurring'] = true;
-        } else {
-            // explicity turn this off as merchants have recurring on by default
-            $request['enableRecurring'] = false;
+        if ($this->adyenHelper->isCreditCardVaultEnabled()) {
+            if (!empty($payload[PaymentInterface::KEY_ADDITIONAL_DATA][VaultConfigProvider::IS_ACTIVE_CODE]) &&
+                $payload[PaymentInterface::KEY_ADDITIONAL_DATA][VaultConfigProvider::IS_ACTIVE_CODE] === true
+            ) {
+                // store it only as oneclick otherwise we store oneclick tokens (maestro+bcmc) that will fail
+                $request['enableRecurring'] = true;
+            } else {
+                // explicity turn this off as merchants have recurring on by default
+                $request['enableRecurring'] = false;
+            }
         }
 
         return $request;


### PR DESCRIPTION
**Description**
When only recurring is enabled in the payments request the enable recurring flag is still set to false, which results in not storing the recurring details.

