### PR TITLE
Remove extra greater character

### DIFF
--- a/view/frontend/templates/info/adyen_boleto.phtml
+++ b/view/frontend/templates/info/adyen_boleto.phtml
@@ -33,5 +33,5 @@ $_info = $this->getInfo();
     <dt class="title"><?php echo $_info->getAdditionalInformation('boleto_type'); ?></dt>
     <dt class="title"><?php echo $_info->getAdditionalInformation('firstname'); ?></dt>
     <dt class="title"><?php echo $_info->getAdditionalInformation('lastname'); ?></dt>
-    <dt class="title">><a target="_blank" href="<?php echo $this->getMethod()->getInfoInstance()->getAdditionalInformation('url'); ?>"><?php echo __("Click here to download Boleto PDF."); ?></a></dt>
+    <dt class="title"><a target="_blank" href="<?php echo $this->getMethod()->getInfoInstance()->getAdditionalInformation('url'); ?>"><?php echo __("Click here to download Boleto PDF."); ?></a></dt>
 </dl>


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
I noticed that on the order detail page, when the payment method is bill of exchange, the bill of thumb print link has a "greater" sign before the link, I think it is an extra character and should be removed.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

**Fixed issue**:  <!-- #-prefixed issue number -->