### PR TITLE
remove unused method called continueToAdyen and fix javascript error …

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/adyen-apple-pay-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-apple-pay-method.js
@@ -145,16 +145,19 @@ define(
             isApplePayAllowed: function () {
                 var self = this;
 
-                // validate if applepay is allowed, it will be picked up by the isApplePayVisible method
-                var promise = window.ApplePaySession.canMakePaymentsWithActiveCard(self.getMerchantIdentifier());
-                promise.then(function (canMakePayments) {
-                    if (canMakePayments)
-                        canMakeApplePayPayments(true);
-                });
+                if (!!window.ApplePaySession) {
+                    // validate if applepay is allowed, it will be picked up by the isApplePayVisible method
+                    var promise = window.ApplePaySession.canMakePaymentsWithActiveCard(self.getMerchantIdentifier());
+                    promise.then(function (canMakePayments) {
+                        if (canMakePayments)
+                            canMakeApplePayPayments(true);
+                    });
 
-                if (window.ApplePaySession && window.ApplePaySession.supportsVersion(applePayVersion) ) {
-                    return true;
+                    if (window.ApplePaySession && window.ApplePaySession.supportsVersion(applePayVersion)) {
+                        return true;
+                    }
                 }
+
                 return false;
             },
             performValidation: function (validationURL) {
@@ -191,10 +194,10 @@ define(
                     }
                 );
             },
-            isApplePayVisible: function() {
+            isApplePayVisible: function () {
                 return canMakeApplePayPayments();
             },
-            getMerchantIdentifier: function() {
+            getMerchantIdentifier: function () {
                 return window.checkoutConfig.payment.adyen_apple_pay.merchant_identifier;
             }
         });

--- a/view/frontend/web/js/view/payment/method-renderer/adyen-hpp-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-hpp-method.js
@@ -518,13 +518,6 @@ define(
                     }
                 });
             },
-            /** Redirect to adyen */
-            continueToAdyen: function () {
-                if (this.validate() && additionalValidators.validate()) {
-                    this.placeRedirectOrder(this.getData());
-                    return false;
-                }
-            },
             continueToAdyenBrandCode: function () {
                 // set payment method to adyen_hpp
                 var self = this;
@@ -616,7 +609,9 @@ define(
                         fullScreenLoader.stopLoader();
                     }
                 ).done(
-                    function () {
+                    function (orderId) {
+                        // todo: redirect directly to HPP
+                        debugger;
                         self.afterPlaceOrder();
                         $.mage.redirect(
                             window.checkoutConfig.payment[quote.paymentMethod().method].redirectUrl

--- a/view/frontend/web/js/view/payment/method-renderer/adyen-hpp-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-hpp-method.js
@@ -609,9 +609,7 @@ define(
                         fullScreenLoader.stopLoader();
                     }
                 ).done(
-                    function (orderId) {
-                        // todo: redirect directly to HPP
-                        debugger;
+                    function () {
                         self.afterPlaceOrder();
                         $.mage.redirect(
                             window.checkoutConfig.payment[quote.paymentMethod().method].redirectUrl


### PR DESCRIPTION
…if window.ApplePaySession does not exists important fix as this will result in javascript errors on non safari browsers

<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

**Fixed issue**:  <!-- #-prefixed issue number -->