### PR TITLE
Do not remove credit card method when using api retrieve-adyen-paymen…

### DIFF
--- a/Api/AdyenPaymentProcessInterface.php
+++ b/Api/AdyenPaymentProcessInterface.php
@@ -27,7 +27,7 @@ namespace Adyen\Payment\Api;
 interface AdyenPaymentProcessInterface
 {
     /**
-     * @param string $payload
+     * @param mixed $payload
      * @return string
      */
     public function initiate($payload);

--- a/Helper/PaymentMethods.php
+++ b/Helper/PaymentMethods.php
@@ -129,13 +129,13 @@ class PaymentMethods extends AbstractHelper
     /**
      * {@inheritDoc}
      */
-    public function getPaymentMethods($quoteId, $country = null)
+    public function getPaymentMethods($quoteId, $country = null, $includeSchemeType = false)
     {
         // get quote from quoteId
         $quote = $this->quoteRepository->getActive($quoteId);
         $store = $quote->getStore();
 
-        $paymentMethods = $this->addHppMethodsToConfig($store, $country);
+        $paymentMethods = $this->addHppMethodsToConfig($store, $country, $includeSchemeType);
         return $paymentMethods;
     }
 
@@ -143,7 +143,7 @@ class PaymentMethods extends AbstractHelper
      * @param $store
      * @return array
      */
-    protected function addHppMethodsToConfig($store, $country)
+    protected function addHppMethodsToConfig($store, $country, $includeSchemeType = false)
     {
         $paymentMethods = [];
 
@@ -154,7 +154,7 @@ class PaymentMethods extends AbstractHelper
         );
         $ccTypes = array_keys($this->adyenHelper->getCcTypesAltData());
 
-        foreach ($this->fetchAlternativeMethods($store, $country) as $methodCode => $methodData) {
+        foreach ($this->fetchAlternativeMethods($store, $country, $includeSchemeType) as $methodCode => $methodData) {
             /*
              * skip payment methods if it is a creditcard that is enabled in adyen_cc or a boleto method or wechat but
              * not wechatpay
@@ -178,7 +178,7 @@ class PaymentMethods extends AbstractHelper
      * @param $country
      * @return array
      */
-    protected function fetchAlternativeMethods($store, $country)
+    protected function fetchAlternativeMethods($store, $country, $includeSchemeType = false)
     {
         $merchantAccount = $this->adyenHelper->getAdyenAbstractConfigData('merchant_account');
 
@@ -215,7 +215,7 @@ class PaymentMethods extends AbstractHelper
         if (isset($responseData['paymentMethods'])) {
             foreach ($responseData['paymentMethods'] as $paymentMethod) {
 
-                if ($paymentMethod['type'] == "scheme") {
+                if ($paymentMethod['type'] == "scheme" && $includeSchemeType == false) {
                     continue;
                 }
 

--- a/Model/AdyenPaymentMethodManagement.php
+++ b/Model/AdyenPaymentMethodManagement.php
@@ -39,7 +39,6 @@ class AdyenPaymentMethodManagement implements \Adyen\Payment\Api\AdyenPaymentMet
         \Adyen\Payment\Helper\PaymentMethods $paymentMethodsHelper
     ) {
         $this->_paymentMethodsHelper = $paymentMethodsHelper;
-        $this->_quoteRepo = $quoteRepo;
     }
 
     /**

--- a/Model/AdyenPaymentMethodManagement.php
+++ b/Model/AdyenPaymentMethodManagement.php
@@ -52,6 +52,6 @@ class AdyenPaymentMethodManagement implements \Adyen\Payment\Api\AdyenPaymentMet
             $country = $shippingAddress->getCountryId();
         }
 
-        return $this->_paymentMethodsHelper->getPaymentMethods($cartId, $country);
+        return $this->_paymentMethodsHelper->getPaymentMethods($quoteId, $country, $includeSchemeType = true);
     }
 }

--- a/Model/AdyenPaymentMethodManagement.php
+++ b/Model/AdyenPaymentMethodManagement.php
@@ -29,15 +29,13 @@ class AdyenPaymentMethodManagement implements \Adyen\Payment\Api\AdyenPaymentMet
      * @var \Adyen\Payment\Helper\PaymentMethods
      */
     protected $_paymentMethodsHelper;
-    protected $_quoteRepo;
 
     /**
      * AdyenPaymentMethodManagement constructor.
      *
      * @param \Adyen\Payment\Helper\PaymentMethods $paymentMethodsHelper
      */
-    public function __construct(
-         \Magento\Quote\Api\CartRepositoryInterface $quoteRepo,    
+    public function __construct(   
         \Adyen\Payment\Helper\PaymentMethods $paymentMethodsHelper
     ) {
         $this->_paymentMethodsHelper = $paymentMethodsHelper;
@@ -47,17 +45,14 @@ class AdyenPaymentMethodManagement implements \Adyen\Payment\Api\AdyenPaymentMet
     /**
      * {@inheritDoc}
      */
-    public function getPaymentMethods($customerId, \Magento\Quote\Api\Data\AddressInterface $shippingAddress = null)
+    public function getPaymentMethods($cartId, \Magento\Quote\Api\Data\AddressInterface $shippingAddress = null)
     {
         // if shippingAddress is provided use this country
-        $quote = $this->_quoteRepo->getActiveForCustomer($customerId);
-        $quoteId = $quote->getId();
-        
         $country = null;
         if ($shippingAddress) {
             $country = $shippingAddress->getCountryId();
         }
 
-        return $this->_paymentMethodsHelper->getPaymentMethods($quoteId, $country, $includeSchemeType = true);
+        return $this->_paymentMethodsHelper->getPaymentMethods($cartId, $country, $includeSchemeType = true);
     }
 }

--- a/Model/AdyenPaymentMethodManagement.php
+++ b/Model/AdyenPaymentMethodManagement.php
@@ -29,6 +29,7 @@ class AdyenPaymentMethodManagement implements \Adyen\Payment\Api\AdyenPaymentMet
      * @var \Adyen\Payment\Helper\PaymentMethods
      */
     protected $_paymentMethodsHelper;
+    protected $_quoteRepo;
 
     /**
      * AdyenPaymentMethodManagement constructor.
@@ -36,17 +37,22 @@ class AdyenPaymentMethodManagement implements \Adyen\Payment\Api\AdyenPaymentMet
      * @param \Adyen\Payment\Helper\PaymentMethods $paymentMethodsHelper
      */
     public function __construct(
+         \Magento\Quote\Api\CartRepositoryInterface $quoteRepo,    
         \Adyen\Payment\Helper\PaymentMethods $paymentMethodsHelper
     ) {
         $this->_paymentMethodsHelper = $paymentMethodsHelper;
+        $this->_quoteRepo = $quoteRepo;
     }
 
     /**
      * {@inheritDoc}
      */
-    public function getPaymentMethods($cartId, \Magento\Quote\Api\Data\AddressInterface $shippingAddress = null)
+    public function getPaymentMethods($customerId, \Magento\Quote\Api\Data\AddressInterface $shippingAddress = null)
     {
         // if shippingAddress is provided use this country
+        $quote = $this->_quoteRepo->getActiveForCustomer($customerId);
+        $quoteId = $quote->getId();
+        
         $country = null;
         if ($shippingAddress) {
             $country = $shippingAddress->getCountryId();

--- a/Model/AdyenPaymentProcess.php
+++ b/Model/AdyenPaymentProcess.php
@@ -124,9 +124,13 @@ class AdyenPaymentProcess implements AdyenPaymentProcessInterface
                 throw new \Magento\Framework\Exception\LocalizedException('Error with payment method please select different payment method.');
             }
         }
-
-        $maskedQuote = $this->quoteMaskFactory->create()->load($payload["quote_id"], 'masked_id');
-        $quote = $this->quoteRepo->get($maskedQuote->getQuoteId());
+        $quoteId = $payload['quote_id'];
+        //if the quoteId is not an nummeric value then we assume that its a maked quote id from a guest card 
+        if(!is_numeric($payload[$quoteId])){
+            $maskedQuote = $this->quoteMaskFactory->create()->load($quoteId, 'masked_id');
+            $quoteId =  $maskedQuote->getQuoteId();
+        } 
+        $quote = $this->quoteRepo->get($quoteId);
 
         // Get payment and cart information from session
         //$quote = $this->checkoutSession->getQuote();

--- a/Model/AdyenPaymentProcess.php
+++ b/Model/AdyenPaymentProcess.php
@@ -126,7 +126,7 @@ class AdyenPaymentProcess implements AdyenPaymentProcessInterface
         }
         $quoteId = $payload['quote_id'];
         //if the quoteId is not an nummeric value then we assume that its a maked quote id from a guest card 
-        if(!is_numeric($payload[$quoteId])){
+        if(!is_numeric($quoteId)){
             $maskedQuote = $this->quoteMaskFactory->create()->load($quoteId, 'masked_id');
             $quoteId =  $maskedQuote->getQuoteId();
         } 

--- a/Model/AdyenPaymentProcess.php
+++ b/Model/AdyenPaymentProcess.php
@@ -126,7 +126,7 @@ class AdyenPaymentProcess implements AdyenPaymentProcessInterface
         }
 
         $maskedQuote = $this->quoteMaskFactory->create()->load($payload["quote_id"], 'masked_id');
-        $quote = $quoteRepo->get($maskedQuote->getQuoteId());
+        $quote = $this->quoteRepo->get($maskedQuote->getQuoteId());
 
         // Get payment and cart information from session
         //$quote = $this->checkoutSession->getQuote();

--- a/Model/GuestAdyenPaymentMethodManagement.php
+++ b/Model/GuestAdyenPaymentMethodManagement.php
@@ -63,6 +63,6 @@ class GuestAdyenPaymentMethodManagement implements \Adyen\Payment\Api\GuestAdyen
             $country = $shippingAddress->getCountryId();
         }
 
-        return $this->_paymentMethodsHelper->getPaymentMethods($quoteId, $country);
+        return $this->_paymentMethodsHelper->getPaymentMethods($quoteId, $country, $includeSchemeType = true);
     }
 }

--- a/etc/webapi.xml
+++ b/etc/webapi.xml
@@ -40,7 +40,7 @@
             <resource ref="self"/>
         </resources>
         <data>
-            <parameter name="customerId" force="true">%customer_id%</parameter>
+            <parameter name="cartId" force="true">%cart_id%</parameter>
         </data>
     </route>
 

--- a/etc/webapi.xml
+++ b/etc/webapi.xml
@@ -40,7 +40,7 @@
             <resource ref="self"/>
         </resources>
         <data>
-            <parameter name="cartId" force="true">%cart_id%</parameter>
+            <parameter name="customerId" force="true">%customer_id%</parameter>
         </data>
     </route>
 


### PR DESCRIPTION
…t-methods endpoint

<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
When retrieving payment methods using /V1/guest-carts/:cartId/retrieve-adyen-payment-methods, the credit card payment method is filtered at this point:

https://github.com/Adyen/adyen-magento2/blob/develop/Helper/PaymentMethods.php#L219

This is the reason that Adyen support gave us for this:

_You are right, the backend will filter out a few payment methods, because in the default implementation we have a setting for credit cards separately and we render it on the frontend if we have the credit card payment method enabled._

The proposed solution is a new parameter $includeSchemeType which is set to true when retrieving payment methods array from api.

