### PR TITLE
Remove idempotency key from paymentsDetails calls

### DIFF
--- a/Model/AdyenThreeDS2Process.php
+++ b/Model/AdyenThreeDS2Process.php
@@ -97,7 +97,6 @@ class AdyenThreeDS2Process implements AdyenThreeDS2ProcessInterface
         try {
             $client = $this->adyenHelper->initializeAdyenClient($quote->getStoreId());
             $service = $this->adyenHelper->createAdyenCheckoutService($client);
-            $requestOptions['idempotencyKey'] = $quote->reserveOrderId()->getReservedOrderId();
 
             $result = $service->paymentsDetails($request);
         } catch (\Adyen\AdyenException $e) {

--- a/Model/Api/PaymentRequest.php
+++ b/Model/Api/PaymentRequest.php
@@ -118,8 +118,7 @@ class PaymentRequest extends DataObject
         try {
             $client = $this->_adyenHelper->initializeAdyenClient($storeId);
             $service = $this->_adyenHelper->createAdyenCheckoutService($client);
-            $requestOptions['idempotencyKey'] = $order->getIncrementId();
-            $result = $service->paymentsDetails($request, $requestOptions);
+            $result = $service->paymentsDetails($request);
         } catch (\Adyen\AdyenException $e) {
             throw new \Magento\Framework\Exception\LocalizedException(__('3D secure failed'));
         }


### PR DESCRIPTION
**Description**
Removing unnecessary idempotency key from the paymentsDetails calls. 
Using the idempotency key is only important in the payments request in our case.


**Fixed issue**:  <!-- #-prefixed issue number -->
#537 