### PR TITLE
[PW-1782] Use idempotency key only for redirect payment methods

### DIFF
--- a/Gateway/Http/Client/TransactionAuthorization.php
+++ b/Gateway/Http/Client/TransactionAuthorization.php
@@ -70,7 +70,12 @@ class TransactionAuthorization implements ClientInterface
     {
         $request = $transferObject->getBody();
 
-        $requestOptions['idempotencyKey'] = $request['reference'];
+        $requestOptions = [];
+
+        if (!empty($request['idempotencyKeyRequired']) && $request['idempotencyKeyRequired'] === true) {
+            $requestOptions['idempotencyKey'] = $request['reference'];
+            unset($requestOptions['idempotencyKey']);
+        }
         
         // call lib
         $service = new \Adyen\Service\Payment($this->_client);

--- a/Gateway/Http/Client/TransactionAuthorization.php
+++ b/Gateway/Http/Client/TransactionAuthorization.php
@@ -69,12 +69,12 @@ class TransactionAuthorization implements ClientInterface
     public function placeRequest(\Magento\Payment\Gateway\Http\TransferInterface $transferObject)
     {
         $request = $transferObject->getBody();
+        $headers = $transferObject->getHeaders();
 
         $requestOptions = [];
 
-        if (!empty($request['idempotencyKeyRequired']) && $request['idempotencyKeyRequired'] === true) {
-            $requestOptions['idempotencyKey'] = $request['reference'];
-            unset($requestOptions['idempotencyKey']);
+        if (!empty($headers['idempotencyKey'])) {
+            $requestOptions['idempotencyKey'] = $headers['idempotencyKey'];
         }
         
         // call lib

--- a/Gateway/Http/Client/TransactionPayment.php
+++ b/Gateway/Http/Client/TransactionPayment.php
@@ -65,7 +65,13 @@ class TransactionPayment implements ClientInterface
         $client = $this->adyenHelper->initializeAdyenClient();
 
         $service = new \Adyen\Service\Checkout($client);
-        $requestOptions['idempotencyKey'] = $request['reference'];
+
+        $requestOptions = [];
+
+        if (!empty($request['idempotencyKeyRequired']) && $request['idempotencyKeyRequired'] === true) {
+            $requestOptions['idempotencyKey'] = $request['reference'];
+            unset($requestOptions['idempotencyKey']);
+        }
 
         try {
             $response = $service->payments($request, $requestOptions);

--- a/Gateway/Http/Client/TransactionPayment.php
+++ b/Gateway/Http/Client/TransactionPayment.php
@@ -55,6 +55,7 @@ class TransactionPayment implements ClientInterface
     public function placeRequest(\Magento\Payment\Gateway\Http\TransferInterface $transferObject)
     {
         $request = $transferObject->getBody();
+        $headers = $transferObject->getHeaders();
 
         // If the payments call is already done return the request
         if (!empty($request['resultCode'])) {
@@ -68,9 +69,8 @@ class TransactionPayment implements ClientInterface
 
         $requestOptions = [];
 
-        if (!empty($request['idempotencyKeyRequired']) && $request['idempotencyKeyRequired'] === true) {
-            $requestOptions['idempotencyKey'] = $request['reference'];
-            unset($requestOptions['idempotencyKey']);
+        if (!empty($headers['idempotencyKey'])) {
+            $requestOptions['idempotencyKey'] = $headers['idempotencyKey'];
         }
 
         try {

--- a/Gateway/Http/TransferFactory.php
+++ b/Gateway/Http/TransferFactory.php
@@ -52,8 +52,14 @@ class TransferFactory implements TransferFactoryInterface
      */
     public function create(array $request)
     {
-        return $this->transferBuilder
-            ->setBody($request)
+        if (!empty($request['headers'])) {
+            $this->transferBuilder->setHeaders($request['headers']);
+        }
+
+        $transfer = $this->transferBuilder
+            ->setBody($request['body'])
             ->build();
+
+        return $transfer;
     }
 }

--- a/Gateway/Request/AddressDataBuilder.php
+++ b/Gateway/Request/AddressDataBuilder.php
@@ -61,6 +61,8 @@ class AddressDataBuilder implements BuilderInterface
 		$billingAddress = $order->getBillingAddress();
         $shippingAddress = $order->getShippingAddress();
 
-		return $this->adyenRequestsHelper->buildAddressData([], $billingAddress, $shippingAddress);
+        $request['body'] = $this->adyenRequestsHelper->buildAddressData([], $billingAddress, $shippingAddress);
+
+		return $request;
     }
 }

--- a/Gateway/Request/ApplePayAuthorizationDataBuilder.php
+++ b/Gateway/Request/ApplePayAuthorizationDataBuilder.php
@@ -55,12 +55,12 @@ class ApplePayAuthorizationDataBuilder implements BuilderInterface
 
     public function build(array $buildSubject)
     {
-        $request = [];
+        $requestBody = [];
         $paymentDataObject = \Magento\Payment\Gateway\Helper\SubjectReader::readPayment($buildSubject);
         $payment = $paymentDataObject->getPayment();
         $token = $payment->getAdditionalInformation('token');
 
-        $request['paymentMethod']['type'] = 'applepay';
+        $requestBody['paymentMethod']['type'] = 'applepay';
 
         // get payment data
         if ($token) {
@@ -68,13 +68,15 @@ class ApplePayAuthorizationDataBuilder implements BuilderInterface
             $paymentData = $parsedToken->token->paymentData;
             try {
                 $paymentData = base64_encode(json_encode($paymentData));
-				$request['paymentMethod']['applepay.token'] = $paymentData;
+                $requestBody['paymentMethod']['applepay.token'] = $paymentData;
             } catch (\Exception $exception) {
                 $this->_adyenLogger->addAdyenDebug("exception: " . $exception->getMessage());
             }
         } else {
             $this->_adyenLogger->addAdyenDebug("PaymentToken is empty");
         }
+
+        $request['body'] = $requestBody;
 
         return $request;
     }

--- a/Gateway/Request/BrowserInfoDataBuilder.php
+++ b/Gateway/Request/BrowserInfoDataBuilder.php
@@ -52,6 +52,7 @@ class BrowserInfoDataBuilder implements BuilderInterface
      */
     public function build(array $buildSubject)
     {
-        return $this->adyenRequestsHelper->buildBrowserData();
+        $request['body'] = $this->adyenRequestsHelper->buildBrowserData();
+        return $request;
     }
 }

--- a/Gateway/Request/CancelDataBuilder.php
+++ b/Gateway/Request/CancelDataBuilder.php
@@ -60,9 +60,11 @@ class CancelDataBuilder implements BuilderInterface
         $payment = $paymentDataObject->getPayment();
         $pspReference = $payment->getCcTransId();
 
-        return [
+        $request['body'] = [
             "reference" => $order->getOrderIncrementId(),
             "originalReference" => $pspReference
         ];
+
+        return $request;
     }
 }

--- a/Gateway/Request/CaptureDataBuilder.php
+++ b/Gateway/Request/CaptureDataBuilder.php
@@ -67,7 +67,7 @@ class CaptureDataBuilder implements BuilderInterface
         $amount = $this->adyenHelper->formatAmount($amount, $currency);
 
         $modificationAmount = ['currency' => $currency, 'value' => $amount];
-        $request = [
+        $requestBody = [
             "modificationAmount" => $modificationAmount,
             "reference" => $payment->getOrder()->getIncrementId(),
             "originalReference" => $pspReference
@@ -79,8 +79,10 @@ class CaptureDataBuilder implements BuilderInterface
 
         if ($this->adyenHelper->isPaymentMethodOpenInvoiceMethod($brandCode)) {
             $openInvoiceFields = $this->getOpenInvoiceData($payment);
-            $request["additionalData"] = $openInvoiceFields;
+            $requestBody["additionalData"] = $openInvoiceFields;
         }
+
+        $request['body'] = $requestBody;
 
         return $request;
     }

--- a/Gateway/Request/CcAuthorizationDataBuilder.php
+++ b/Gateway/Request/CcAuthorizationDataBuilder.php
@@ -42,7 +42,7 @@ class CcAuthorizationDataBuilder implements BuilderInterface
         if ($response = $payment->getAdditionalInformation("paymentsResponse")) {
             // the payments response needs to be passed to the next process because after this point we don't have
             // access to the payment object therefore to the additionalInformation array
-            $request = $response;
+            $request['body'] = $response;
             // Remove from additional data
             $payment->unsAdditionalInformation("paymentsResponse");
         } else {

--- a/Gateway/Request/CcBackendAuthorizationDataBuilder.php
+++ b/Gateway/Request/CcBackendAuthorizationDataBuilder.php
@@ -61,24 +61,25 @@ class CcBackendAuthorizationDataBuilder implements BuilderInterface
         /** @var \Magento\Payment\Gateway\Data\PaymentDataObject $paymentDataObject */
         $paymentDataObject = \Magento\Payment\Gateway\Helper\SubjectReader::readPayment($buildSubject);
         $payment = $paymentDataObject->getPayment();
-        $request = [];
-
+        $order = $paymentDataObject->getOrder();
+        $storeId = $order->getStoreId();
+        $requestBody = [];
         // If ccType is set use this. For bcmc you need bcmc otherwise it will fail
-        $request['paymentMethod']['type'] = 'scheme';
+        $requestBody['paymentMethod']['type'] = 'scheme';
         if ($cardNumber = $payment->getAdditionalInformation(AdyenCcDataAssignObserver::ENCRYPTED_CREDIT_CARD_NUMBER)) {
-            $request['paymentMethod']['encryptedCardNumber'] = $cardNumber;
+            $requestBody['paymentMethod']['encryptedCardNumber'] = $cardNumber;
         }
         if ($expiryMonth = $payment->getAdditionalInformation(AdyenCcDataAssignObserver::ENCRYPTED_EXPIRY_MONTH)) {
-            $request['paymentMethod']['encryptedExpiryMonth'] = $expiryMonth;
+            $requestBody['paymentMethod']['encryptedExpiryMonth'] = $expiryMonth;
         }
         if ($expiryYear = $payment->getAdditionalInformation(AdyenCcDataAssignObserver::ENCRYPTED_EXPIRY_YEAR)) {
-            $request['paymentMethod']['encryptedExpiryYear'] = $expiryYear;
+            $requestBody['paymentMethod']['encryptedExpiryYear'] = $expiryYear;
         }
         if ($holderName = $payment->getAdditionalInformation(AdyenCcDataAssignObserver::HOLDER_NAME)) {
-            $request['paymentMethod']['holderName'] = $holderName;
+            $requestBody['paymentMethod']['holderName'] = $holderName;
         }
         if ($securityCode = $payment->getAdditionalInformation(AdyenCcDataAssignObserver::ENCRYPTED_SECURITY_CODE)) {
-            $request['paymentMethod']['encryptedSecurityCode'] = $securityCode;
+            $requestBody['paymentMethod']['encryptedSecurityCode'] = $securityCode;
         }
         // Remove from additional data
         $payment->unsAdditionalInformation(AdyenCcDataAssignObserver::ENCRYPTED_CREDIT_CARD_NUMBER);
@@ -89,22 +90,24 @@ class CcBackendAuthorizationDataBuilder implements BuilderInterface
         /**
          * On Backend always use MOTO
          */
-        $request['shopperInteraction'] = "Moto";
+        $requestBody['shopperInteraction'] = "Moto";
         // if installments is set add it into the request
         if ($payment->getAdditionalInformation(AdyenCcDataAssignObserver::NUMBER_OF_INSTALLMENTS) &&
             $payment->getAdditionalInformation(AdyenCcDataAssignObserver::NUMBER_OF_INSTALLMENTS) > 0
         ) {
-            $request['installments']['value'] = $payment->getAdditionalInformation(AdyenCcDataAssignObserver::NUMBER_OF_INSTALLMENTS);
+            $requestBody['installments']['value'] = $payment->getAdditionalInformation(AdyenCcDataAssignObserver::NUMBER_OF_INSTALLMENTS);
         }
 
         // Flow for Billing agreements, for Vault check VaultDataBuilder
         if (!$this->adyenHelper->isCreditCardVaultEnabled()) {
             if ($payment->getAdditionalInformation(AdyenCcDataAssignObserver::STORE_CC)) {
-                $request['enableRecurring'] = true;
+                $requestBody['enableRecurring'] = true;
             } else {
-                $request['enableRecurring'] = false;
+                $requestBody['enableRecurring'] = false;
             }
         }
+
+        $request['body'] = $requestBody;
 
         return $request;
     }

--- a/Gateway/Request/CheckoutDataBuilder.php
+++ b/Gateway/Request/CheckoutDataBuilder.php
@@ -69,31 +69,31 @@ class CheckoutDataBuilder implements BuilderInterface
 		$payment = $paymentDataObject->getPayment();
 		$order = $payment->getOrder();
 		$storeId = $order->getStoreId();
-		$request = [];
+		$requestBody = [];
 
         // do not send email
         $order->setCanSendNewEmailFlag(false);
 
-        $request['paymentMethod']['type'] = $payment->getAdditionalInformation(AdyenHppDataAssignObserver::BRAND_CODE);
+        $requestBody['paymentMethod']['type'] = $payment->getAdditionalInformation(AdyenHppDataAssignObserver::BRAND_CODE);
 
         // Additional data for payment methods with issuer list
         if ($payment->getAdditionalInformation(AdyenHppDataAssignObserver::ISSUER_ID)) {
-            $request['paymentMethod']['issuer'] = $payment->getAdditionalInformation(AdyenHppDataAssignObserver::ISSUER_ID);
+            $requestBody['paymentMethod']['issuer'] = $payment->getAdditionalInformation(AdyenHppDataAssignObserver::ISSUER_ID);
         }
 
-        $request['returnUrl'] = $this->storeManager->getStore()->getBaseUrl(\Magento\Framework\UrlInterface::URL_TYPE_LINK) . 'adyen/process/result';
+        $requestBody['returnUrl'] = $this->storeManager->getStore()->getBaseUrl(\Magento\Framework\UrlInterface::URL_TYPE_LINK) . 'adyen/process/result';
 
         // Additional data for ACH
         if ($payment->getAdditionalInformation("bankAccountNumber")) {
-            $request['bankAccount']['bankAccountNumber'] = $payment->getAdditionalInformation("bankAccountNumber");
+            $requestBody['bankAccount']['bankAccountNumber'] = $payment->getAdditionalInformation("bankAccountNumber");
         }
 
         if ($payment->getAdditionalInformation("bankLocationId")) {
-            $request['bankAccount']['bankLocationId'] = $payment->getAdditionalInformation("bankLocationId");
+            $requestBody['bankAccount']['bankLocationId'] = $payment->getAdditionalInformation("bankLocationId");
         }
 
         if ($payment->getAdditionalInformation("bankAccountOwnerName")) {
-            $request['bankAccount']['ownerName'] = $payment->getAdditionalInformation("bankAccountOwnerName");
+            $requestBody['bankAccount']['ownerName'] = $payment->getAdditionalInformation("bankAccountOwnerName");
         }
 
 		// Additional data for open invoice payment
@@ -101,31 +101,31 @@ class CheckoutDataBuilder implements BuilderInterface
 			$order->setCustomerGender(\Adyen\Payment\Model\Gender::getMagentoGenderFromAdyenGender(
 				$payment->getAdditionalInformation("gender"))
 			);
-			$request['paymentMethod']['personalDetails']['gender'] = $payment->getAdditionalInformation("gender");
+            $requestBody['paymentMethod']['personalDetails']['gender'] = $payment->getAdditionalInformation("gender");
 		}
 
         if ($payment->getAdditionalInformation("dob")) {
             $order->setCustomerDob($payment->getAdditionalInformation("dob"));
 
-			$request['paymentMethod']['personalDetails']['dateOfBirth']= $this->adyenHelper->formatDate($payment->getAdditionalInformation("dob"), 'Y-m-d') ;
+            $requestBody['paymentMethod']['personalDetails']['dateOfBirth']= $this->adyenHelper->formatDate($payment->getAdditionalInformation("dob"), 'Y-m-d') ;
 		}
 
 		if ($payment->getAdditionalInformation("telephone")) {
 			$order->getBillingAddress()->setTelephone($payment->getAdditionalInformation("telephone"));
-			$request['paymentMethod']['personalDetails']['telephoneNumber']= $payment->getAdditionalInformation("telephone");
+            $requestBody['paymentMethod']['personalDetails']['telephoneNumber']= $payment->getAdditionalInformation("telephone");
 		}
 
         if ($payment->getAdditionalInformation("ssn")) {
-            $request['paymentMethod']['personalDetails']['socialSecurityNumber']= $payment->getAdditionalInformation("ssn");
+            $requestBody['paymentMethod']['personalDetails']['socialSecurityNumber']= $payment->getAdditionalInformation("ssn");
         }
 
         // Additional data for sepa direct debit
         if ($payment->getAdditionalInformation("ownerName")) {
-            $request['paymentMethod']['sepa.ownerName'] = $payment->getAdditionalInformation("ownerName");
+            $requestBody['paymentMethod']['sepa.ownerName'] = $payment->getAdditionalInformation("ownerName");
         }
 
         if ($payment->getAdditionalInformation("ibanNumber")) {
-            $request['paymentMethod']['sepa.ibanNumber'] = $payment->getAdditionalInformation("ibanNumber");
+            $requestBody['paymentMethod']['sepa.ibanNumber'] = $payment->getAdditionalInformation("ibanNumber");
         }
 
 		if ($this->adyenHelper->isPaymentMethodOpenInvoiceMethod(
@@ -137,27 +137,27 @@ class CheckoutDataBuilder implements BuilderInterface
             )
         ) {
 			$openInvoiceFields = $this->getOpenInvoiceData($order);
-			$request = array_merge($request, $openInvoiceFields);
+            $requestBody = array_merge($requestBody, $openInvoiceFields);
 		}
 
         // Ratepay specific Fingerprint
         if ($payment->getAdditionalInformation("df_value") && $this->adyenHelper->isPaymentMethodRatepayMethod(
                 $payment->getAdditionalInformation(AdyenHppDataAssignObserver::BRAND_CODE)
             )) {
-            $request['deviceFingerprint'] = $payment->getAdditionalInformation("df_value");
+            $requestBody['deviceFingerprint'] = $payment->getAdditionalInformation("df_value");
         }
 
         //Boleto data
         if ($payment->getAdditionalInformation("social_security_number")) {
-            $request['socialSecurityNumber'] = $payment->getAdditionalInformation("social_security_number");
+            $requestBody['socialSecurityNumber'] = $payment->getAdditionalInformation("social_security_number");
         }
 
         if ($payment->getAdditionalInformation("firstname")) {
-            $request['shopperName']['firstName'] = $payment->getAdditionalInformation("firstname");
+            $requestBody['shopperName']['firstName'] = $payment->getAdditionalInformation("firstname");
         }
 
         if ($payment->getAdditionalInformation("lastName")) {
-            $request['shopperName']['lastName'] = $payment->getAdditionalInformation("lastName");
+            $requestBody['shopperName']['lastName'] = $payment->getAdditionalInformation("lastName");
         }
 
         if ($payment->getMethod() == \Adyen\Payment\Model\Ui\AdyenBoletoConfigProvider::CODE) {
@@ -165,11 +165,11 @@ class CheckoutDataBuilder implements BuilderInterface
             $boletoTypes = explode(',', $boletoTypes);
 
             if (count($boletoTypes) == 1) {
-                $request['selectedBrand'] = $boletoTypes[0];
-                $request['paymentMethod']['type'] = $boletoTypes[0];
+                $requestBody['selectedBrand'] = $boletoTypes[0];
+                $requestBody['paymentMethod']['type'] = $boletoTypes[0];
             } else {
-                $request['selectedBrand'] = $payment->getAdditionalInformation("boleto_type");
-                $request['paymentMethod']['type'] = $payment->getAdditionalInformation("boleto_type");
+                $requestBody['selectedBrand'] = $payment->getAdditionalInformation("boleto_type");
+                $requestBody['paymentMethod']['type'] = $payment->getAdditionalInformation("boleto_type");
             }
 
             $deliveryDays = (int)$this->adyenHelper->getAdyenBoletoConfigData("delivery_days", $storeId);
@@ -186,10 +186,13 @@ class CheckoutDataBuilder implements BuilderInterface
                 )
             );
 
-            $request['deliveryDate'] = $deliveryDate;
+            $requestBody['deliveryDate'] = $deliveryDate;
 
             $order->setCanSendNewEmailFlag(true);
         }
+
+        $request['body'] = $requestBody;
+        
         return $request;
     }
 

--- a/Gateway/Request/CustomerDataBuilder.php
+++ b/Gateway/Request/CustomerDataBuilder.php
@@ -62,6 +62,8 @@ class CustomerDataBuilder implements BuilderInterface
         $billingAddress = $order->getBillingAddress();
         $storeId = $order->getStoreId();
 
-        return $this->adyenRequestsHelper->buildCustomerData([], $customerId, $billingAddress, $storeId, $payment);
+        $request['body'] = $this->adyenRequestsHelper->buildCustomerData([], $customerId, $billingAddress, $storeId, $payment);
+
+        return $request;
     }
 }

--- a/Gateway/Request/CustomerIpDataBuilder.php
+++ b/Gateway/Request/CustomerIpDataBuilder.php
@@ -60,6 +60,8 @@ class CustomerIpDataBuilder implements BuilderInterface
             $shopperIp = $order-> getXForwardedFor();
         }
 
-        return $this->adyenRequestsHelper->buildCustomerIpData([], $shopperIp);
+        $request['body'] = $this->adyenRequestsHelper->buildCustomerIpData([], $shopperIp);
+
+        return $request;
     }
 }

--- a/Gateway/Request/GooglePayAuthorizationDataBuilder.php
+++ b/Gateway/Request/GooglePayAuthorizationDataBuilder.php
@@ -55,23 +55,25 @@ class GooglePayAuthorizationDataBuilder implements BuilderInterface
 
     public function build(array $buildSubject)
     {
-        $request = [];
+        $requestBody = [];
         $paymentDataObject = \Magento\Payment\Gateway\Helper\SubjectReader::readPayment($buildSubject);
         $payment = $paymentDataObject->getPayment();
         $token = $payment->getAdditionalInformation('token');
 
-        $request['paymentMethod']['type'] = 'paywithgoogle';
+        $requestBody['paymentMethod']['type'] = 'paywithgoogle';
         // get payment data
         if ($token) {
             $parsedToken = json_decode($token);
             try {
-				$request['paymentMethod']['paywithgoogle.token'] = $parsedToken;
+                $requestBody['paymentMethod']['paywithgoogle.token'] = $parsedToken;
             } catch (\Exception $exception) {
                 $this->adyenLogger->addAdyenDebug("exception: " . $exception->getMessage());
             }
         } else {
             $this->adyenLogger->addAdyenDebug("PaymentToken is empty");
         }
+
+        $request['body'] = $requestBody;
 
         return $request;
     }

--- a/Gateway/Request/MerchantAccountDataBuilder.php
+++ b/Gateway/Request/MerchantAccountDataBuilder.php
@@ -56,6 +56,8 @@ class MerchantAccountDataBuilder implements BuilderInterface
         $storeId = $order->getStoreId();
         $method = $payment->getMethod();
 
-        return $this->adyenRequestsHelper->buildMerchantAccountData([], $method, $storeId);
+        $request['body'] = $this->adyenRequestsHelper->buildMerchantAccountData([], $method, $storeId);
+
+        return $request;
     }
 }

--- a/Gateway/Request/PaymentDataBuilder.php
+++ b/Gateway/Request/PaymentDataBuilder.php
@@ -60,7 +60,8 @@ class PaymentDataBuilder implements BuilderInterface
         $currencyCode = $fullOrder->getOrderCurrencyCode();
         $amount = $fullOrder->getGrandTotal();
         $reference = $order->getOrderIncrementId();
+        $paymentMethod = $payment->getMethod();
 
-        return $this->adyenRequestsHelper->buildPaymentData([], $amount, $currencyCode, $reference);
+        return $this->adyenRequestsHelper->buildPaymentData([], $amount, $currencyCode, $reference, $paymentMethod);
     }
 }

--- a/Gateway/Request/PaymentDataBuilder.php
+++ b/Gateway/Request/PaymentDataBuilder.php
@@ -62,6 +62,10 @@ class PaymentDataBuilder implements BuilderInterface
         $reference = $order->getOrderIncrementId();
         $paymentMethod = $payment->getMethod();
 
-        return $this->adyenRequestsHelper->buildPaymentData([], $amount, $currencyCode, $reference, $paymentMethod);
+        $request['body'] = $this->adyenRequestsHelper->buildPaymentData([], $amount, $currencyCode, $reference, $paymentMethod);
+
+        $request['headers'] = $this->adyenRequestsHelper->addIdempotencyKey([], $paymentMethod, $reference);
+
+        return $request;
     }
 }

--- a/Gateway/Request/PosCloudBuilder.php
+++ b/Gateway/Request/PosCloudBuilder.php
@@ -38,11 +38,13 @@ class PosCloudBuilder implements BuilderInterface
 
         $payment = $paymentDataObject->getPayment();
 
-        return [
+        $request['body'] = [
             "response" => $payment->getAdditionalInformation("terminalResponse"),
             "serviceID" => $payment->getAdditionalInformation("serviceID"),
             "initiateDate" => $payment->getAdditionalInformation("initiateDate"),
             "terminalID" => $payment->getAdditionalInformation("terminal_id")
         ];
+
+        return $request;
     }
 }

--- a/Gateway/Request/RecurringDataBuilder.php
+++ b/Gateway/Request/RecurringDataBuilder.php
@@ -65,6 +65,8 @@ class RecurringDataBuilder implements BuilderInterface
         $storeId = $payment->getOrder()->getStoreId();
         $areaCode = $this->appState->getAreaCode();
 
-        return $this->adyenRequestsHelper->buildRecurringData([], $areaCode, $storeId, $payment);
+        $request['body'] = $this->adyenRequestsHelper->buildRecurringData([], $areaCode, $storeId, $payment);
+
+        return $request;
     }
 }

--- a/Gateway/Request/RecurringVaultDataBuilder.php
+++ b/Gateway/Request/RecurringVaultDataBuilder.php
@@ -33,17 +33,20 @@ class RecurringVaultDataBuilder implements BuilderInterface
      */
     public function build(array $buildSubject)
     {
-        $result = [];
+        $requestBody = [];
         $recurring = ['contract' => \Adyen\Payment\Model\RecurringType::RECURRING];
-        $result['recurring'] = $recurring;
+        $requestBody['recurring'] = $recurring;
         /** @var \Magento\Payment\Gateway\Data\PaymentDataObject $paymentDataObject */
         $paymentDataObject = \Magento\Payment\Gateway\Helper\SubjectReader::readPayment($buildSubject);
         $payment = $paymentDataObject->getPayment();
         $extensionAttributes = $payment->getExtensionAttributes();
         $paymentToken = $extensionAttributes->getVaultPaymentToken();
 
-        $result['selectedRecurringDetailReference'] = $paymentToken->getGatewayToken();
-        $result['shopperInteraction'] = 'ContAuth';
-        return $result;
+        $requestBody['selectedRecurringDetailReference'] = $paymentToken->getGatewayToken();
+        $requestBody['shopperInteraction'] = 'ContAuth';
+
+        $request['body'] = $requestBody;
+
+        return $request;
     }
 }

--- a/Gateway/Request/RefundDataBuilder.php
+++ b/Gateway/Request/RefundDataBuilder.php
@@ -107,7 +107,7 @@ class RefundDataBuilder implements BuilderInterface
             }
 
             // loop over payment methods and refund them all
-            $result = [];
+            $requestBody = [];
             foreach ($orderPaymentCollection as $splitPayment) {
                 // could be that not all the split payments need a refund
                 if ($amount > 0) {
@@ -140,7 +140,7 @@ class RefundDataBuilder implements BuilderInterface
                         'value' => $this->adyenHelper->formatAmount($modificationAmount, $currency)
                     ];
 
-                    $result[] = [
+                    $requestBody[] = [
                         "modificationAmount" => $modificationAmountObject,
                         "reference" => $payment->getOrder()->getIncrementId(),
                         "originalReference" => $splitPayment->getPspreference(),
@@ -153,7 +153,7 @@ class RefundDataBuilder implements BuilderInterface
             $amount = $this->adyenHelper->formatAmount($amount, $currency);
             $modificationAmount = ['currency' => $currency, 'value' => $amount];
 
-            $result = [
+            $requestBody = [
                 [
                     "modificationAmount" => $modificationAmount,
                     "reference" => $payment->getOrder()->getIncrementId(),
@@ -170,11 +170,13 @@ class RefundDataBuilder implements BuilderInterface
                 $openInvoiceFields = $this->getOpenInvoiceData($payment);
 
                 //There is only one payment, so we add the fields to the first(and only) result
-                $result[0]["additionalData"] = $openInvoiceFields;
+                $requestBody[0]["additionalData"] = $openInvoiceFields;
             }
         }
 
-        return $result;
+        $request['body'] = $requestBody;
+
+        return $request;
     }
 
     /**

--- a/Gateway/Request/VaultDataBuilder.php
+++ b/Gateway/Request/VaultDataBuilder.php
@@ -54,6 +54,8 @@ class VaultDataBuilder implements BuilderInterface
         $payment = $paymentDataObject->getPayment();
         $additionalInformation = $payment->getAdditionalInformation();
 
-        return $this->adyenRequestsHelper->buildVaultData([], $additionalInformation);
+        $request['body'] = $this->adyenRequestsHelper->buildVaultData([], $additionalInformation);
+
+        return $request;
     }
 }

--- a/Helper/Requests.php
+++ b/Helper/Requests.php
@@ -262,22 +262,24 @@ class Requests extends AbstractHelper
     }
 
     /**
-     * @param $request
+     * @param array $request
      * @param $amount
      * @param $currencyCode
      * @param $reference
-     * @return mixed
+     * @param $paymentMethod
+     * @return array
      */
-    public function buildPaymentData($request = [], $amount, $currencyCode, $reference)
+    public function buildPaymentData($request = [], $amount, $currencyCode, $reference, $paymentMethod)
     {
         $request['amount'] = [
             'currency' => $currencyCode,
             'value' => $this->adyenHelper->formatAmount($amount, $currencyCode)
         ];
 
-
         $request["reference"] = $reference;
         $request["fraudOffset"] = "0";
+
+        $request = $this->addIdempotencyKeyFlag($request, $paymentMethod);
 
         return $request;
     }
@@ -481,5 +483,23 @@ class Requests extends AbstractHelper
         }
 
         return $address;
+    }
+
+    /**
+     * Adds a parameter: idempotencyKeyRequired to the payment request object with a value true
+     * We are checking this flag before creating the client to add or not the idempotency key and then we remove this
+     * flag
+     *
+     * @param array $request
+     * @param $paymentMethod
+     * @return array
+     */
+    private function addIdempotencyKeyFlag($request = [], $paymentMethod)
+    {
+        if (!empty($paymentMethod) && $paymentMethod == 'adyen_hpp') {
+            $request['idempotencyKeyRequired'] = true;
+        }
+
+        return $request;
     }
 }

--- a/Helper/Requests.php
+++ b/Helper/Requests.php
@@ -279,8 +279,6 @@ class Requests extends AbstractHelper
         $request["reference"] = $reference;
         $request["fraudOffset"] = "0";
 
-        $request = $this->addIdempotencyKeyFlag($request, $paymentMethod);
-
         return $request;
     }
 
@@ -486,18 +484,17 @@ class Requests extends AbstractHelper
     }
 
     /**
-     * Adds a parameter: idempotencyKeyRequired to the payment request object with a value true
-     * We are checking this flag before creating the client to add or not the idempotency key and then we remove this
-     * flag
+     * Only adds idempotency key if payment method is adyen_hpp for now
      *
      * @param array $request
      * @param $paymentMethod
+     * @param $idempotencyKey
      * @return array
      */
-    private function addIdempotencyKeyFlag($request = [], $paymentMethod)
+    public function addIdempotencyKey($request = [], $paymentMethod, $idempotencyKey)
     {
         if (!empty($paymentMethod) && $paymentMethod == 'adyen_hpp') {
-            $request['idempotencyKeyRequired'] = true;
+            $request['idempotencyKey'] = $idempotencyKey;
         }
 
         return $request;

--- a/Model/AdyenPaymentProcess.php
+++ b/Model/AdyenPaymentProcess.php
@@ -121,25 +121,25 @@ class AdyenPaymentProcess implements AdyenPaymentProcessInterface
         $payment = $quote->getPayment();
 
         // Init request array
-        $request = [];
+        $requestBody = [];
 
         // Merchant account data builder
         $paymentMethod = $payment->getMethod();
         $storeId = $quote->getStoreId();
-        $request = $this->adyenRequestHelper->buildMerchantAccountData($request, $paymentMethod, $storeId);
+        $requestBody = $this->adyenRequestHelper->buildMerchantAccountData($requestBody, $paymentMethod, $storeId);
 
         // Customer data builder
         $customerId = $quote->getCustomerId();
         $billingAddress = $quote->getBillingAddress();
-        $request = $this->adyenRequestHelper->buildCustomerData($request, $customerId, $billingAddress, $storeId, null, $payload);
+        $requestBody = $this->adyenRequestHelper->buildCustomerData($requestBody, $customerId, $billingAddress, $storeId, null, $payload);
 
         // Customer Ip data builder
         $shopperIp = $quote->getXForwardedFor();
-        $request = $this->adyenRequestHelper->buildCustomerIpData($request, $shopperIp);
+        $requestBody = $this->adyenRequestHelper->buildCustomerIpData($requestBody, $shopperIp);
 
         // AddressDataBuilder
         $shippingAddress = $quote->getShippingAddress();
-        $request = $this->adyenRequestHelper->buildAddressData($request, $billingAddress, $shippingAddress);
+        $requestBody = $this->adyenRequestHelper->buildAddressData($requestBody, $billingAddress, $shippingAddress);
 
         // PaymentDataBuilder
         $currencyCode = $quote->getQuoteCurrencyCode();
@@ -148,26 +148,32 @@ class AdyenPaymentProcess implements AdyenPaymentProcessInterface
         // Setting the orderid to null, so that we generate a new one for each /payments call
         $quote->setReservedOrderId(null);
         $reference = $quote->reserveOrderId()->getReservedOrderId();
-        $request = $this->adyenRequestHelper->buildPaymentData($request, $amount, $currencyCode, $reference, $paymentMethod);
+        $requestBody = $this->adyenRequestHelper->buildPaymentData($requestBody, $amount, $currencyCode, $reference, $paymentMethod);
 
         // Browser data builder
-        $request = $this->adyenRequestHelper->buildBrowserData($request);
+        $requestBody = $this->adyenRequestHelper->buildBrowserData($requestBody);
 
         // 3DS2.0 data builder
         $isThreeDS2Enabled = $this->adyenHelper->isCreditCardThreeDS2Enabled($storeId);
         if ($isThreeDS2Enabled) {
-            $request = $this->adyenRequestHelper->buildThreeDS2Data($request, $payload, $quote->getStore());
+            $requestBody = $this->adyenRequestHelper->buildThreeDS2Data($requestBody, $payload, $quote->getStore());
         }
 
         // RecurringDataBuilder
         $areaCode = $this->context->getAppState()->getAreaCode();
-        $request = $this->adyenRequestHelper->buildRecurringData($request, $areaCode, $storeId, $payload);
+        $requestBody = $this->adyenRequestHelper->buildRecurringData($requestBody, $areaCode, $storeId, $payload);
 
         // CcAuthorizationDataBuilder
-        $request = $this->adyenRequestHelper->buildCCData($request, $payload, $storeId, $areaCode);
+        $requestBody = $this->adyenRequestHelper->buildCCData($requestBody, $payload, $storeId, $areaCode);
 
         // Vault data builder
-        $request = $this->adyenRequestHelper->buildVaultData($request, $payload);
+        $requestBody = $this->adyenRequestHelper->buildVaultData($requestBody, $payload);
+
+        // Add idempotency key if applicable
+        $requestHeaders = $this->adyenRequestHelper->addIdempotencyKey([], $paymentMethod, $reference);
+
+        $request['body'] = $requestBody;
+        $request['headers'] = $requestHeaders;
 
         // Create and send request
         $transferObject = $this->transferFactory->create($request);

--- a/Model/AdyenPaymentProcess.php
+++ b/Model/AdyenPaymentProcess.php
@@ -148,7 +148,7 @@ class AdyenPaymentProcess implements AdyenPaymentProcessInterface
         // Setting the orderid to null, so that we generate a new one for each /payments call
         $quote->setReservedOrderId(null);
         $reference = $quote->reserveOrderId()->getReservedOrderId();
-        $request = $this->adyenRequestHelper->buildPaymentData($request, $amount, $currencyCode, $reference);
+        $request = $this->adyenRequestHelper->buildPaymentData($request, $amount, $currencyCode, $reference, $paymentMethod);
 
         // Browser data builder
         $request = $this->adyenRequestHelper->buildBrowserData($request);


### PR DESCRIPTION
**Description**
Only add idempotency key if payment method is adyen_hpp

**Tested scenarios**
1
refused card payment 
authorised hpp payment (ideal)
2
refused card payment
authorised card payment
3
refused hpp payment (ideal)
authorised hpp payment (ideal)
4
refused direct alternative payment method (afterpay)
authorised direct alternative payment method (afterpay)

**Fixed issue**:
#537 