### PR TITLE
Shopper ip address fall back for getRemoteIp()

### DIFF
--- a/Gateway/Request/CustomerIpDataBuilder.php
+++ b/Gateway/Request/CustomerIpDataBuilder.php
@@ -39,7 +39,8 @@ class CustomerIpDataBuilder implements BuilderInterface
      *
      * @param \Adyen\Payment\Helper\Requests $adyenRequestsHelper
      */
-    public function __construct(\Adyen\Payment\Helper\Requests $adyenRequestsHelper)
+    public function __construct(
+        \Adyen\Payment\Helper\Requests $adyenRequestsHelper)
     {
         $this->adyenRequestsHelper = $adyenRequestsHelper;
     }
@@ -52,7 +53,12 @@ class CustomerIpDataBuilder implements BuilderInterface
     {
         /** @var \Magento\Payment\Gateway\Data\PaymentDataObject $paymentDataObject */
         $paymentDataObject = \Magento\Payment\Gateway\Helper\SubjectReader::readPayment($buildSubject);
-        $shopperIp = $paymentDataObject->getPayment()->getOrder()->getXForwardedFor();
+        $order = $paymentDataObject->getPayment()->getOrder();
+        $shopperIp = $order->getXForwardedFor();
+
+        if (empty($shopperIp)) {
+            $shopperIp = $order->getRemoteIp();
+        }
 
         return $this->adyenRequestsHelper->buildCustomerIpData([], $shopperIp);
     }

--- a/Gateway/Request/CustomerIpDataBuilder.php
+++ b/Gateway/Request/CustomerIpDataBuilder.php
@@ -54,7 +54,7 @@ class CustomerIpDataBuilder implements BuilderInterface
         /** @var \Magento\Payment\Gateway\Data\PaymentDataObject $paymentDataObject */
         $paymentDataObject = \Magento\Payment\Gateway\Helper\SubjectReader::readPayment($buildSubject);
         $order = $paymentDataObject->getPayment()->getOrder();
-        $shopperIp = $order->getXForwardedFor();
+        $shopperIp = $order-> getRemoteIp();
 
         if (empty($shopperIp)) {
             $shopperIp = $order->getRemoteIp();

--- a/Gateway/Request/CustomerIpDataBuilder.php
+++ b/Gateway/Request/CustomerIpDataBuilder.php
@@ -57,7 +57,7 @@ class CustomerIpDataBuilder implements BuilderInterface
         $shopperIp = $order-> getRemoteIp();
 
         if (empty($shopperIp)) {
-            $shopperIp = $order->getRemoteIp();
+            $shopperIp = $order-> getXForwardedFor();
         }
 
         return $this->adyenRequestsHelper->buildCustomerIpData([], $shopperIp);


### PR DESCRIPTION
**Description**
Order->getXForwardedFor() can return null, in this case fall back for
Order->getRemoteIp()

**Tested scenarios**
afterpay where shopper ip is required