### PR TITLE
specify sort order to ensure that this method should run last

### DIFF
--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1030,6 +1030,6 @@
         <plugin name="AdyenPaymentVaultDeleteToken" type="Adyen\Payment\Plugin\PaymentVaultDeleteToken" sortOrder="10"/>
     </type>
     <type name="Magento\Checkout\Api\PaymentInformationManagementInterface">
-        <plugin name="AdyenPaymentInformationManagementAddPaymentInfo" type="Adyen\Payment\Plugin\PaymentInformationManagement"/>
+        <plugin name="AdyenPaymentInformationManagementAddPaymentInfo" type="Adyen\Payment\Plugin\PaymentInformationManagement" sortOrder="10"/>
     </type>
 </config>


### PR DESCRIPTION
Defined sort_order to ensure that, this plugin should run last.
As **afterSavePaymentInformationAndPlaceOrder** plugin changing the response of original method and some other extension's also using the same plugin, so due to the invalid response other extensions will stopped working.