### PR TITLE
Add missing item from missing API response fields

### DIFF
--- a/Model/Billing/Agreement.php
+++ b/Model/Billing/Agreement.php
@@ -188,7 +188,7 @@ class Agreement extends \Magento\Paypal\Model\Billing\Agreement
             !isset($contractDetail['expiryDate']) ||
             !isset($contractDetail['paymentMethod'])
         ) {
-            $this->_errors[] = __('"In the Additional data in API response section, select: Card summary, Expiry Date, Cardholder name, Recurring details and Variant to create billing agreements immediately after the payment is authorized."');
+            $this->_errors[] = __('"In the Additional data in API response section, select: Card bin, Card summary, Expiry Date, Cardholder name, Recurring details and Variant to create billing agreements immediately after the payment is authorized."');
             return $this;
         }
         // Billing agreement is CC


### PR DESCRIPTION
This error message doesn't mention the requirement of Card bin information from the API responses, which caused a bit more trouble when debugging a problem.