### PR TITLE
PW-1913: fixes #594, on OFFER_CLOSED, if order is already cancelled, …

### DIFF
--- a/Model/Cron.php
+++ b/Model/Cron.php
@@ -929,6 +929,12 @@ class Cron
                     break;
                 }
 
+                // Order is already Cancelled
+                if ($this->_order->isCanceled()){
+                    $this->_adyenLogger->addAdyenNotificationCronjob("Order is already cancelled, skipping OFFER_CLOSED");
+                    break;
+                }
+
                 /*
                  * For cards, it can be 'visa', 'maestro',...
                  * For alternatives, it can be 'ideal', 'directEbanking',...


### PR DESCRIPTION
…don't cancel it again

**Description**
If order is already cancelled, cancelling it again may let magento increase the stock incorrectly.
Prevent multiple cancellations by preventing OFFER_CLOSED to be processed multiple times

**Tested scenarios**
Ideal pending-> cancelled

**Fixed issue**:  #594