### PR TITLE
B: Change sort order of PaymentInformationManagement plugin

### DIFF
--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1030,9 +1030,9 @@
         <plugin name="AdyenPaymentVaultDeleteToken" type="Adyen\Payment\Plugin\PaymentVaultDeleteToken" sortOrder="10"/>
     </type>
     <type name="Magento\Checkout\Api\PaymentInformationManagementInterface">
-        <plugin name="AdyenPaymentInformationManagementAddPaymentInfo" type="Adyen\Payment\Plugin\PaymentInformationManagement" sortOrder="10"/>
+        <plugin name="AdyenPaymentInformationManagementAddPaymentInfo" type="Adyen\Payment\Plugin\PaymentInformationManagement" sortOrder="99999"/>
     </type>
     <type name="Magento\Checkout\Api\GuestPaymentInformationManagementInterface">
-        <plugin name="AdyenGuestPaymentInformationManagementAddPaymentInfo" type="Adyen\Payment\Plugin\GuestPaymentInformationManagement" sortOrder="10"/>
+        <plugin name="AdyenGuestPaymentInformationManagementAddPaymentInfo" type="Adyen\Payment\Plugin\GuestPaymentInformationManagement" sortOrder="99999"/>
     </type>
 </config>


### PR DESCRIPTION
So it always loads last, since it changes the return type and value,
workaround for https://github.com/Adyen/adyen-magento2/issues/590

<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

**Fixed issue**:  <!-- #-prefixed issue number -->