### PR TITLE
Use 3DS2 toggle configuration fix

### DIFF
--- a/Gateway/Request/ThreeDS2DataBuilder.php
+++ b/Gateway/Request/ThreeDS2DataBuilder.php
@@ -62,8 +62,9 @@ class ThreeDS2DataBuilder implements BuilderInterface
         /** @var \Magento\Payment\Gateway\Data\PaymentDataObject $paymentDataObject */
         $paymentDataObject = \Magento\Payment\Gateway\Helper\SubjectReader::readPayment($buildSubject);
         $payment = $paymentDataObject->getPayment();
+        $order = $paymentDataObject->getOrder();
         $additionalInformation = $payment->getAdditionalInformation();
-        $request['body'] = $this->adyenRequestsHelper->buildThreeDS2Data([], $additionalInformation);
+        $request['body'] = $this->adyenRequestsHelper->buildThreeDS2Data([], $additionalInformation, $order->getStoreId());
         return $request;
     }
 }

--- a/Helper/Requests.php
+++ b/Helper/Requests.php
@@ -298,26 +298,33 @@ class Requests extends AbstractHelper
 
     /**
      * @param array $request
-     * @param $payment
-     * @param $store
+     * @param $additionalData
+     * @param $storeId
      * @return array
      */
-    public function buildThreeDS2Data($request = [], $additionalData)
+    public function buildThreeDS2Data($request = [], $additionalData, $storeId)
     {
-        $request['additionalData']['allow3DS2'] = true;
-        $request['origin'] = $this->adyenHelper->getOrigin();
-        $request['channel'] = 'web';
-        $request['browserInfo']['screenWidth'] = $additionalData[AdyenCcDataAssignObserver::SCREEN_WIDTH];
-        $request['browserInfo']['screenHeight'] = $additionalData[AdyenCcDataAssignObserver::SCREEN_HEIGHT];
-        $request['browserInfo']['colorDepth'] = $additionalData[AdyenCcDataAssignObserver::SCREEN_COLOR_DEPTH];
-        $request['browserInfo']['timeZoneOffset'] = $additionalData[AdyenCcDataAssignObserver::TIMEZONE_OFFSET];
-        $request['browserInfo']['language'] = $additionalData[AdyenCcDataAssignObserver::LANGUAGE];
+        if ($this->adyenHelper->isCreditCardThreeDS2Enabled($storeId)) {
+            $request['additionalData']['allow3DS2'] = true;
+            $request['origin'] = $this->adyenHelper->getOrigin();
+            $request['channel'] = 'web';
+            $request['browserInfo']['screenWidth'] = $additionalData[AdyenCcDataAssignObserver::SCREEN_WIDTH];
+            $request['browserInfo']['screenHeight'] = $additionalData[AdyenCcDataAssignObserver::SCREEN_HEIGHT];
+            $request['browserInfo']['colorDepth'] = $additionalData[AdyenCcDataAssignObserver::SCREEN_COLOR_DEPTH];
+            $request['browserInfo']['timeZoneOffset'] = $additionalData[AdyenCcDataAssignObserver::TIMEZONE_OFFSET];
+            $request['browserInfo']['language'] = $additionalData[AdyenCcDataAssignObserver::LANGUAGE];
 
-        if ($javaEnabled = $additionalData[AdyenCcDataAssignObserver::JAVA_ENABLED]) {
-            $request['browserInfo']['javaEnabled'] = $javaEnabled;
+            if ($javaEnabled = $additionalData[AdyenCcDataAssignObserver::JAVA_ENABLED]) {
+                $request['browserInfo']['javaEnabled'] = $javaEnabled;
+            } else {
+                $request['browserInfo']['javaEnabled'] = false;
+            }
         } else {
-            $request['browserInfo']['javaEnabled'] = false;
+            $request['additionalData']['allow3DS2'] = false;
+            $request['origin'] = $this->adyenHelper->getOrigin();
+            $request['channel'] = 'web';
         }
+        
         return $request;
     }
 


### PR DESCRIPTION
**Description**
The 3DS2 toggle setting is ignored since version 5.0.0 because of a
major change. Add the check back in the Request buildThreeDS2Data()

**Fixed issue**:  <!-- #-prefixed issue number -->
#599

**Tested scenarios**
3DS2 enabled
3DS2 disabled