### PR TITLE
[PW-1993] Fix adyen_order_payment new entry creation issue during cron

### DIFF
--- a/Model/Cron.php
+++ b/Model/Cron.php
@@ -38,6 +38,7 @@ class Cron
 
     /**
      * Logging instance
+     *
      * @var \Adyen\Payment\Logger\AdyenLogger
      */
     protected $_logger;
@@ -296,6 +297,7 @@ class Cron
 
     /**
      * Process the notification
+     *
      * @return void
      */
     public function processNotification()
@@ -452,7 +454,8 @@ class Cron
             } catch (\Exception $e) {
                 $this->_updateNotification($notification, false, false);
                 $this->_adyenLogger->addAdyenNotificationCronjob(
-                    sprintf("Notification %s had an error: %s \n %s", $notification->getEntityId(), $e->getMessage(), $e->getTraceAsString())
+                    sprintf("Notification %s had an error: %s \n %s", $notification->getEntityId(), $e->getMessage(),
+                        $e->getTraceAsString())
                 );
             }
         }
@@ -780,6 +783,7 @@ class Cron
 
     /**
      * retrieve last 4 digits of card from the reason field
+     *
      * @param $reason
      * @return string
      */
@@ -934,7 +938,7 @@ class Cron
                 }
 
                 // Order is already Cancelled
-                if ($this->_order->isCanceled()){
+                if ($this->_order->isCanceled()) {
                     $this->_adyenLogger->addAdyenNotificationCronjob("Order is already cancelled, skipping OFFER_CLOSED");
                     break;
                 }
@@ -1138,6 +1142,7 @@ class Cron
 
     /**
      * Not implemented
+     *
      * @return bool
      */
     protected function _refundOrder()
@@ -1287,8 +1292,8 @@ class Cron
     }
 
     /**
-     * @throws Exception
      * @return void
+     * @throws Exception
      */
     protected function _prepareInvoice()
     {
@@ -1351,7 +1356,7 @@ class Cron
         // validate if amount is total amount
         $orderCurrencyCode = $this->_order->getOrderCurrencyCode();
         $amount = $this->_adyenHelper->originalAmount($this->_value, $orderCurrencyCode);
-        
+
         try {
             // add to order payment
             $date = new \DateTime();
@@ -1367,10 +1372,10 @@ class Cron
                 ->save();
         } catch (\Exception $e) {
             $this->_adyenLogger->addError(
-                'While processing a notification an exception occured. The payment has already been saved in the
-                 adyen_order_payment table but something went went wrong later. Please check your logs for potential
-                 error messages regarding the merchant reference (order id): "' . $this->_merchantReference . '" and PSP
-                 reference: "' . $this->_pspReference . '"'
+                'While processing a notification an exception occured. The payment has already been saved in the ' .
+                'adyen_order_payment table but something went wrong later. Please check your logs for potential ' .
+                'error messages regarding the merchant reference (order id): "' . $this->_merchantReference .
+                '" and PSP reference: "' . $this->_pspReference . '"'
             );
         }
 
@@ -1626,9 +1631,9 @@ class Cron
     }
 
     /**
-     * @throws Exception
-     * @throws \Magento\Framework\Exception\LocalizedException
      * @return void
+     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws Exception
      */
     protected function _createInvoice()
     {


### PR DESCRIPTION
**Description**
Add try catch into cron process when new adyen_order_payment entity is added

Turned out that other plugins can intercept into invoice creation and
these are potential sources of exceptions. After inserting a new
adyen_order_payment entity we start the invoice creation process and if
something goes wrong during that process we reprocess the notification in
the next batch. Therefore the adyen_order_payment is already saved and the
next run will violate the unique constraint setting of the table.

This is a quick solution to prevent the process to stop and the order to
get stuck because of this exception.

**Fixed issue**: 
Resolves GitHub issues: #603, #610