### PR TITLE
PW-1998: filter out bcmc from alternative payment methods

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/adyen-hpp-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-hpp-method.js
@@ -43,7 +43,7 @@ define(
         var paymentMethod = ko.observable(null);
         var messageComponents;
         var shippingAddressCountryCode = quote.shippingAddress().countryId;
-        var unsupportedPaymentMethods = ['scheme', 'boleto', 'bcmc_mobile_QR', 'wechatpay'];
+        var unsupportedPaymentMethods = ['scheme', 'boleto', 'bcmc_mobile_QR', 'wechatpay', 'bcmc'];
         /**
          * Shareble adyen checkout component
          * @type {AdyenCheckout}


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
BCMC is returned in the paymentMethods call outside of the "scheme" payment method:
"name" : "Bancontact card", "supportsRecurring" : true, "type" : "bcmc"

However, this payment method doesn't work outside of the credit card method.
Filter it out from the alternative paymentmethods call

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

**Fixed issue**:  <!-- #-prefixed issue number -->