### PR TITLE
[PW-1696]: Update configuration UI - Developer options

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: Bug report
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: Enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -43,6 +43,7 @@
                 <include path="Adyen_Payment::system/adyen_checkout_experience.xml"/>
                 <include path="Adyen_Payment::system/adyen_manual_review.xml"/>
                 <include path="Adyen_Payment::system/adyen_split_payment.xml"/>
+                <include path="Adyen_Payment::system/adyen_developer_options.xml"/>
                 <include path="Adyen_Payment::system/adyen_cc.xml"/>
                 <include path="Adyen_Payment::system/adyen_oneclick.xml"/>
                 <include path="Adyen_Payment::system/adyen_hpp.xml"/>

--- a/etc/adminhtml/system/adyen_cc/store_payment_details_options.xml
+++ b/etc/adminhtml/system/adyen_cc/store_payment_details_options.xml
@@ -26,13 +26,12 @@
     <group id="adyen_cc_store_payment_details_options" translate="label" showInDefault="1" showInWebsite="1" sortOrder="150">
         <label>Store payment details options</label>
         <frontend_model>Magento\Config\Block\System\Config\Form\Fieldset</frontend_model>
-        <comment>Adyen can securely store credit card payment details of your shoppers, allowing you to accept recurring payments. For more information please visit our <a href="https://docs.adyen.com/plugins/magento-2">docs</a>.</comment>
+        <comment><![CDATA[Adyen can securely store credit card payment details of your shoppers, allowing you to accept recurring payments. For more information please visit our <a href="https://docs.adyen.com/plugins/magento-2">docs</a>.]]></comment>
         <field id="adyen_cc_vault" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="0">
             <label>Enable Vault</label>
             <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
             <config_path>payment/adyen_cc_vault/active</config_path>
         </field>
-        mment>
         <field id="store_oneclick" translate="label" type="select" sortOrder="50" showInDefault="1" showInWebsite="1">
             <label>Store one-click contracts</label>
             <source_model>Adyen\Payment\Model\Config\Source\YesNoBillingAgreements</source_model>

--- a/etc/adminhtml/system/adyen_developer_options.xml
+++ b/etc/adminhtml/system/adyen_developer_options.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<!--
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2015 Adyen BV (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+-->
+<include xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_include.xsd">
+    <group id="adyen_developer_options" translate="label" type="text" sortOrder="90" showInDefault="1" showInWebsite="1" showInStore="1">
+        <label><![CDATA[Developer options]]></label>
+        <frontend_model>Magento\Config\Block\System\Config\Form\Fieldset</frontend_model>
+        <field id="debug" translate="label" type="select" sortOrder="140" showInDefault="1" showInWebsite="1" showInStore="0">
+            <label>Enable debug logging</label>
+            <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+            <config_path>payment/adyen_abstract/debug</config_path>
+            <comment>We recommend you leave this turned on. The log files can be found in var/log/adyen/</comment>
+        </field>
+    </group>
+</include>


### PR DESCRIPTION
**Description**

* This config group belonged to adyen_required_settings.xml, which was deleted [on this commit](https://github.com/Adyen/adyen-magento2/pull/621/commits/fa7a14ab81541a5b239abb9a00f6bd21ad9dc148). With this PR it is being restored to a dedicated XML file.

* A fix is also introduced for a typo and a CDATA comment tag on store_payment_details_options.xml.