### PR TITLE
[PW-2007] Set showPayButton to true at Google Pay checkout component

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/adyen-google-pay-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-google-pay-method.js
@@ -100,6 +100,7 @@ define(
                     }
                 });
                 var googlepay = self.checkoutComponent.create('paywithgoogle', {
+                    showPayButton: true,
                     environment: self.getCheckoutEnvironment().toUpperCase(),
 
                     configuration: {


### PR DESCRIPTION
Different versions of checkout components have different default
settings for showing the pay button. In 3.2.0 therefore the Google Pay
button does not show while in 3.0.0 it does. With this new setting the
Google Pay button will be shown anyway.

By default we cannot set this property to true because other payment
methods does not require to render their own pay button and it is better
to use the Magento default place order button instead.