### PR TITLE
Imrankln patch 1

### DIFF
--- a/Block/Info/PaymentLink.php
+++ b/Block/Info/PaymentLink.php
@@ -41,9 +41,9 @@ class PaymentLink extends AbstractInfo
         \Adyen\Payment\Helper\Data $adyenHelper,
         \Adyen\Payment\Model\ResourceModel\Order\Payment\CollectionFactory $adyenOrderPaymentCollectionFactory,
         Template\Context $context,
-        array $data = [],
         \Magento\Framework\Registry $registry,
-        \Adyen\Payment\Gateway\Command\PayByMailCommand $payByMailCommand
+        \Adyen\Payment\Gateway\Command\PayByMailCommand $payByMailCommand,
+        array $data = []
     ) {
         $this->registry = $registry;
         $this->payByMail = $payByMailCommand;

--- a/Block/Redirect/Redirect.php
+++ b/Block/Redirect/Redirect.php
@@ -89,14 +89,14 @@ class Redirect extends \Magento\Payment\Block\Form
 	 */
     public function __construct(
         \Magento\Framework\View\Element\Template\Context $context,
-        array $data = [],
         \Magento\Sales\Model\OrderFactory $orderFactory,
         \Magento\Checkout\Model\Session $checkoutSession,
         \Adyen\Payment\Helper\Data $adyenHelper,
         \Magento\Framework\Locale\ResolverInterface $resolver,
         \Adyen\Payment\Logger\AdyenLogger $adyenLogger,
         \Magento\Tax\Model\Config $taxConfig,
-        \Magento\Tax\Model\Calculation $taxCalculation
+        \Magento\Tax\Model\Calculation $taxCalculation,
+        array $data = []
     ) {
         $this->_orderFactory = $orderFactory;
         $this->_checkoutSession = $checkoutSession;


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Calling of `array $data = []` in the middle of constructor throws exception, "class not found".
If we call the above code at the end of constructor argument, everything works fine.
Following two files need modification:
Block/Redirect/Redirect.php
Block/Info/PaymentLink.php

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

**Fixed issue**:  <!-- #-prefixed issue number -->