### PR TITLE
Fix filtering of Bancontact HPP payment methods

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/adyen-hpp-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-hpp-method.js
@@ -43,7 +43,7 @@ define(
         var paymentMethod = ko.observable(null);
         var messageComponents;
         var shippingAddressCountryCode = quote.shippingAddress().countryId;
-        var unsupportedPaymentMethods = ['scheme', 'boleto', 'bcmc_mobile_QR', 'wechatpay', 'bcmc'];
+        var unsupportedPaymentMethods = ['scheme', 'boleto', 'bcmc_mobile_QR', 'wechatpay', /^bcmc$/ ];
         /**
          * Shareble adyen checkout component
          * @type {AdyenCheckout}


### PR DESCRIPTION
**Description**
This fixes removing of all Bancontact HPP methods caused by https://github.com/Adyen/adyen-magento2/pull/615 by asserting begin/end of string, due to String.match() being used to match payment methods
