### PR TITLE
[PW-2015]: Fix orders not being created but card getting charged when Persistent Cart and Guest Checkout enabled

### DIFF
--- a/Gateway/Validator/InstallmentValidator.php
+++ b/Gateway/Validator/InstallmentValidator.php
@@ -40,11 +40,6 @@ class InstallmentValidator extends AbstractValidator
     private $adyenHelper;
 
     /**
-     * @var \Magento\Checkout\Model\Session
-     */
-    private $session;
-
-    /**
      * @var \Magento\Framework\Serialize\SerializerInterface
      */
     private $serializer;
@@ -59,7 +54,6 @@ class InstallmentValidator extends AbstractValidator
      * @param \Magento\Payment\Gateway\Validator\ResultInterfaceFactory $resultFactory
      * @param \Adyen\Payment\Logger\AdyenLogger $adyenLogger
      * @param \Adyen\Payment\Helper\Data $adyenHelper
-     * @param \Magento\Checkout\Model\Session $session
      * @param \Magento\Framework\Serialize\SerializerInterface $serializer
      * @param \Magento\Quote\Model\QuoteRepository $quoteRepository
      */
@@ -67,14 +61,12 @@ class InstallmentValidator extends AbstractValidator
         \Magento\Payment\Gateway\Validator\ResultInterfaceFactory $resultFactory,
         \Adyen\Payment\Logger\AdyenLogger $adyenLogger,
         \Adyen\Payment\Helper\Data $adyenHelper,
-        \Magento\Checkout\Model\Session $session,
         \Magento\Framework\Serialize\SerializerInterface $serializer,
         \Magento\Quote\Model\QuoteRepository $quoteRepository
 
     ) {
         $this->adyenLogger = $adyenLogger;
         $this->adyenHelper = $adyenHelper;
-        $this->session = $session;
         $this->serializer = $serializer;
         $this->quoteRepository = $quoteRepository;
         parent::__construct($resultFactory);

--- a/Gateway/Validator/InstallmentValidator.php
+++ b/Gateway/Validator/InstallmentValidator.php
@@ -78,7 +78,7 @@ class InstallmentValidator extends AbstractValidator
         $isValid = true;
         $fails = [];
         $payment = $validationSubject['payment'];
-        $quoteId = $payment->getOrderId();
+        $quoteId = $payment->getQuoteId();
         //This validator also runs for other payments that don't necesarily have a quoteId
         $quote = $quoteId?$this->quoteRepository->get($quoteId):false;
         $installmentsEnabled = $this->adyenHelper->getAdyenCcConfigData('enable_installments');

--- a/Gateway/Validator/InstallmentValidator.php
+++ b/Gateway/Validator/InstallmentValidator.php
@@ -80,7 +80,11 @@ class InstallmentValidator extends AbstractValidator
         $payment = $validationSubject['payment'];
         $quoteId = $payment->getQuoteId();
         //This validator also runs for other payments that don't necesarily have a quoteId
-        $quote = $quoteId?$this->quoteRepository->get($quoteId):false;
+        if ($quoteId) {
+            $quote = $this->quoteRepository->get($quoteId);
+        } else {
+            $quote = false;
+        }
         $installmentsEnabled = $this->adyenHelper->getAdyenCcConfigData('enable_installments');
         if ($quote && $installmentsEnabled) {
             $grandTotal = $quote->getGrandTotal();

--- a/Gateway/Validator/InstallmentValidator.php
+++ b/Gateway/Validator/InstallmentValidator.php
@@ -50,24 +50,33 @@ class InstallmentValidator extends AbstractValidator
     private $serializer;
 
     /**
+     * @var \Magento\Quote\Model\QuoteRepository
+     */
+    private $quoteRepository;
+
+    /**
      * InstallmentValidator constructor.
      * @param \Magento\Payment\Gateway\Validator\ResultInterfaceFactory $resultFactory
      * @param \Adyen\Payment\Logger\AdyenLogger $adyenLogger
      * @param \Adyen\Payment\Helper\Data $adyenHelper
      * @param \Magento\Checkout\Model\Session $session
      * @param \Magento\Framework\Serialize\SerializerInterface $serializer
+     * @param \Magento\Quote\Model\QuoteRepository $quoteRepository
      */
     public function __construct(
         \Magento\Payment\Gateway\Validator\ResultInterfaceFactory $resultFactory,
         \Adyen\Payment\Logger\AdyenLogger $adyenLogger,
         \Adyen\Payment\Helper\Data $adyenHelper,
         \Magento\Checkout\Model\Session $session,
-        \Magento\Framework\Serialize\SerializerInterface $serializer
+        \Magento\Framework\Serialize\SerializerInterface $serializer,
+        \Magento\Quote\Model\QuoteRepository $quoteRepository
+
     ) {
         $this->adyenLogger = $adyenLogger;
         $this->adyenHelper = $adyenHelper;
         $this->session = $session;
         $this->serializer = $serializer;
+        $this->quoteRepository = $quoteRepository;
         parent::__construct($resultFactory);
     }
 
@@ -77,7 +86,7 @@ class InstallmentValidator extends AbstractValidator
         $isValid = true;
         $fails = [];
         $payment = $validationSubject['payment'];
-        $quote = $this->session->getQuote();
+        $quote = $this->quoteRepository->get($validationSubject['payment']->getQuoteId());
         $installmentsEnabled = $this->adyenHelper->getAdyenCcConfigData('enable_installments');
         if ($quote && $installmentsEnabled) {
             $grandTotal = $quote->getGrandTotal();

--- a/Gateway/Validator/InstallmentValidator.php
+++ b/Gateway/Validator/InstallmentValidator.php
@@ -78,7 +78,9 @@ class InstallmentValidator extends AbstractValidator
         $isValid = true;
         $fails = [];
         $payment = $validationSubject['payment'];
-        $quote = $this->quoteRepository->get($validationSubject['payment']->getQuoteId());
+        $quoteId = $payment->getOrderId();
+        //This validator also runs for other payments that don't necesarily have a quoteId
+        $quote = $quoteId?$this->quoteRepository->get($quoteId):false;
         $installmentsEnabled = $this->adyenHelper->getAdyenCcConfigData('enable_installments');
         if ($quote && $installmentsEnabled) {
             $grandTotal = $quote->getGrandTotal();


### PR DESCRIPTION
**Description**
Replacing quote fetch method in Installment Validator so the order flow is interrupted organically when the session has been unset. Instead of relying on session a new repository query has been introduced.

**Tested scenarios**
Placing order with Persistent Cart and Guest Checkout enabled, after manually unsetting session cookie. Credit Card payment method.

**Fixed issue**:  #629 