### PR TITLE
Add 'Validating request' and 'Bug' labels as exemptLabels for Stale bot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -5,7 +5,9 @@ daysUntilStale: 14
 daysUntilClose: 7
 # Issues with these labels will never be considered stale
 exemptLabels:
+  - Validating request
   - Bug report
+  - Bug
   - Enhancement
 # Label to use when marking an issue as stale
 staleLabel: Stale


### PR DESCRIPTION
While validating a request we use the 'Validating request' label so the
bot should not stale the issue.
After validating the request if we tag the issue with the label 'Bug'
the bot should not close the issue, because it is a valid bug.