### PR TITLE
[PW-1947]: Added admin notice message for failed refund notifications

### DIFF
--- a/Model/Cron.php
+++ b/Model/Cron.php
@@ -1886,7 +1886,7 @@ class Cron
      *
      * @return void
      */
-    protected function _addRefundFailedNotice(){
+    protected function addRefundFailedNotice(){
         $this->notifierPool->addNotice(
             __("Adyen: Refund for order #%1 has failed", $this->_merchantReference),
             __("Reason: %1 | PSPReference: %2 | You can go to Adyen Customer Area and trigger this refund manually or contact our support.", $this->_reason, $this->_pspReference),

--- a/Model/Cron.php
+++ b/Model/Cron.php
@@ -865,6 +865,7 @@ class Cron
 
         switch ($this->_eventCode) {
             case Notification::REFUND_FAILED:
+                //Trigger admin notice for REFUND_FAILED notifications
                 $this->_addRefundFailedNotice();
                 break;
             case Notification::REFUND:

--- a/Model/Cron.php
+++ b/Model/Cron.php
@@ -226,6 +226,11 @@ class Cron
     private $serializer;
 
     /**
+     * @var \Magento\Framework\Notification\NotifierInterface
+     */
+    private $notifierPool;
+
+    /**
      * Cron constructor.
      *
      * @param \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
@@ -270,7 +275,8 @@ class Cron
         OrderRepository $orderRepository,
         \Adyen\Payment\Model\ResourceModel\Billing\Agreement $agreementResourceModel,
         \Magento\Sales\Model\Order\Payment\Transaction\Builder $transactionBuilder,
-        \Magento\Framework\Serialize\SerializerInterface $serializer
+        \Magento\Framework\Serialize\SerializerInterface $serializer,
+        \Magento\Framework\Notification\NotifierInterface $notifierPool
     ) {
         $this->_scopeConfig = $scopeConfig;
         $this->_adyenLogger = $adyenLogger;
@@ -293,6 +299,7 @@ class Cron
         $this->agreementResourceModel = $agreementResourceModel;
         $this->transactionBuilder = $transactionBuilder;
         $this->serializer = $serializer;
+        $this->notifierPool = $notifierPool;
     }
 
     /**
@@ -433,6 +440,10 @@ class Cron
                         $this->_adyenLogger->addAdyenNotificationCronjob(
                             'Order is already processed so ignore this notification state is:' . $this->_order->getState()
                         );
+                    }
+                    //Trigger admin notice for unsuccessful REFUND notifications
+                    if ($this->_eventCode == Notification::REFUND){
+                        $this->_addRefundFailedNotice();
                     }
                 } else {
                     // Notification is successful
@@ -854,7 +865,7 @@ class Cron
 
         switch ($this->_eventCode) {
             case Notification::REFUND_FAILED:
-                // do nothing only inform the merchant with order comment history
+                $this->_addRefundFailedNotice();
                 break;
             case Notification::REFUND:
                 $ignoreRefundNotification = $this->_getConfigData(
@@ -1867,5 +1878,18 @@ class Cron
     {
         $path = 'payment/' . $paymentMethodCode . '/' . $field;
         return $this->_scopeConfig->getValue($path, \Magento\Store\Model\ScopeInterface::SCOPE_STORE, $storeId);
+    }
+
+    /**
+     * Add admin notice message for refund failed notification
+     *
+     * @return void
+     */
+    protected function _addRefundFailedNotice(){
+        $this->notifierPool->addNotice(
+            __("Adyen: Refund for order #%1 has failed", $this->_merchantReference),
+            __("Reason: %1 | PSPReference: %2 | You can go to Adyen Customer Area and trigger this refund manually or contact our support.", $this->_reason, $this->_pspReference),
+            sprintf("https://ca-%s.adyen.com/ca/ca/accounts/showTx.shtml?pspReference=%s", $this->_live === 'true' ? 'live' : 'test',  $this->_pspReference)
+        );
     }
 }

--- a/Model/Cron.php
+++ b/Model/Cron.php
@@ -512,8 +512,9 @@ class Cron
         $this->_eventCode = $notification->getEventCode();
         $this->_success = $notification->getSuccess();
         $this->_paymentMethod = $notification->getPaymentMethod();
-        $this->_reason = $notification->getPaymentMethod();
+        $this->_reason = $notification->getReason();
         $this->_value = $notification->getAmountValue();
+        $this->_live = $notification->getLive();
 
         $additionalData = !empty($notification->getAdditionalData()) ? $this->serializer->unserialize($notification->getAdditionalData()) : "";
 

--- a/Model/Cron.php
+++ b/Model/Cron.php
@@ -443,7 +443,7 @@ class Cron
                     }
                     //Trigger admin notice for unsuccessful REFUND notifications
                     if ($this->_eventCode == Notification::REFUND){
-                        $this->_addRefundFailedNotice();
+                        $this->addRefundFailedNotice();
                     }
                 } else {
                     // Notification is successful

--- a/Model/Cron.php
+++ b/Model/Cron.php
@@ -866,7 +866,7 @@ class Cron
         switch ($this->_eventCode) {
             case Notification::REFUND_FAILED:
                 //Trigger admin notice for REFUND_FAILED notifications
-                $this->_addRefundFailedNotice();
+                $this->addRefundFailedNotice();
                 break;
             case Notification::REFUND:
                 $ignoreRefundNotification = $this->_getConfigData(


### PR DESCRIPTION
**Description**
When a notification is received with event_code REFUND_FAILED or unsuccessful REFUND a new admin notice is added with the relevant information.

**Tested scenarios**
Manually triggered the Adyen notification processing cronjob to pick up rows with event_code==REFUND_FAILED and event_code==REFUND&&success==false.

Since the new method _addRefundFailedNotice() is protected no unit tests have been developed, would be good to add tests to execute() but should it be broken down into smaller responsibilities first?

**Fixed issue**:  [PW-1947](https://youtrack.is.adyen.com/issue/PW-1947)