### PR TITLE
Only load 'return_path' config data if it's required.

### DIFF
--- a/Controller/Process/Result.php
+++ b/Controller/Process/Result.php
@@ -99,8 +99,6 @@ class Result extends \Magento\Framework\App\Action\Action
         $response = $this->getRequest()->getParams();
         $this->_adyenLogger->addAdyenResult(print_r($response, true));
 
-        $failReturnPath = $this->_adyenHelper->getAdyenAbstractConfigData('return_path');
-
         if ($response) {
             $result = $this->validateResponse($response);
 
@@ -110,10 +108,12 @@ class Result extends \Magento\Framework\App\Action\Action
                 $this->_redirect('checkout/onepage/success', ['_query' => ['utm_nooverride' => '1']]);
             } else {
                 $this->_cancel($response);
+                $failReturnPath = $this->_adyenHelper->getAdyenAbstractConfigData('return_path');
                 $this->_redirect($failReturnPath);
             }
         } else {
             // redirect to checkout page
+            $this->_adyenHelper->getAdyenAbstractConfigData('return_path');
             $this->_redirect($failReturnPath);
         }
     }

--- a/Controller/Process/Result.php
+++ b/Controller/Process/Result.php
@@ -113,7 +113,7 @@ class Result extends \Magento\Framework\App\Action\Action
             }
         } else {
             // redirect to checkout page
-            $this->_adyenHelper->getAdyenAbstractConfigData('return_path');
+            $failReturnPath = $this->_adyenHelper->getAdyenAbstractConfigData('return_path');
             $this->_redirect($failReturnPath);
         }
     }


### PR DESCRIPTION
**Description**
It doesn't make sense to retrieve the configuration for failure on each request.
It's enough to only do it on failure.