### PR TITLE
PW-2074 Hide Apple Pay in unsupported browsers

### DIFF
--- a/view/frontend/web/css/styles.css
+++ b/view/frontend/web/css/styles.css
@@ -113,6 +113,12 @@
     margin-right: 10px;
 }
 
+@supports not (-webkit-appearance: -apple-pay-button) {
+    #apple-pay-payment-method {
+        display: none;
+    }
+}
+
 .apple-pay-button-with-text {
     --apple-pay-scale: 1.5625; /* (height / 32) */
     display: inline-flex;

--- a/view/frontend/web/template/payment/apple-pay-form.html
+++ b/view/frontend/web/template/payment/apple-pay-form.html
@@ -21,8 +21,9 @@
  * Author: Adyen <magento@adyen.com>
  */
 -->
-<div id="apple-pay-payment-method">
+
 <!-- ko if: isApplePayAllowed() -->
+<div id="apple-pay-payment-method">
 <div class="payment-method" data-bind="css: {'_active': (getCode() == isChecked())}, visible: isApplePayVisible()">
     <div class="payment-method-title field choice">
         <input type="radio"
@@ -61,5 +62,5 @@
 
     </div>
 </div>
-<!--/ko-->
 </div>
+<!--/ko-->

--- a/view/frontend/web/template/payment/apple-pay-form.html
+++ b/view/frontend/web/template/payment/apple-pay-form.html
@@ -21,6 +21,7 @@
  * Author: Adyen <magento@adyen.com>
  */
 -->
+<div id="apple-pay-payment-method">
 <!-- ko if: isApplePayAllowed() -->
 <div class="payment-method" data-bind="css: {'_active': (getCode() == isChecked())}, visible: isApplePayVisible()">
     <div class="payment-method-title field choice">
@@ -61,3 +62,4 @@
     </div>
 </div>
 <!--/ko-->
+</div>


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
Display apple pay payment method only to supported browsers based on [apple docs](https://developer.apple.com/documentation/apple_pay_on_the_web/displaying_apple_pay_buttons)

**Tested scenarios**
Chrome -not displaying
Firefox -not displaying
Safari - displaying
ios13 safari - displaying

**Fixed issue**:  <!-- #-prefixed issue number -->