### PR TITLE
[PW-2073]Pass the correct store id from order for the modification requests re…

### DIFF
--- a/Gateway/Http/Client/TransactionCancel.php
+++ b/Gateway/Http/Client/TransactionCancel.php
@@ -62,8 +62,8 @@ class TransactionCancel implements ClientInterface
     public function placeRequest(\Magento\Payment\Gateway\Http\TransferInterface $transferObject)
     {
         $request = $transferObject->getBody();
-        $this->_client = $this->_adyenHelper->initializeAdyenClient($request['storeId']);
-        unset($request['storeId']);
+        $clientConfig = $transferObject->getClientConfig();
+        $this->_client = $this->_adyenHelper->initializeAdyenClient($clientConfig['storeId']);
         // call lib
         $service = new \Adyen\Service\Modification($this->_client);
 

--- a/Gateway/Http/Client/TransactionCancel.php
+++ b/Gateway/Http/Client/TransactionCancel.php
@@ -42,7 +42,7 @@ class TransactionCancel implements ClientInterface
     public function __construct(
         \Adyen\Payment\Helper\Data $adyenHelper
     ) {
-        $this->_adyenHelper = $adyenHelper;
+        $this->adyenHelper = $adyenHelper;
     }
 
     /**
@@ -54,7 +54,7 @@ class TransactionCancel implements ClientInterface
         $request = $transferObject->getBody();
         // call lib
         $service = new \Adyen\Service\Modification(
-            $this->_adyenHelper->initializeAdyenClient($transferObject->getClientConfig()['storeId'])
+            $this->adyenHelper->initializeAdyenClient($transferObject->getClientConfig()['storeId'])
         );
 
         try {

--- a/Gateway/Http/Client/TransactionCancel.php
+++ b/Gateway/Http/Client/TransactionCancel.php
@@ -62,7 +62,8 @@ class TransactionCancel implements ClientInterface
     public function placeRequest(\Magento\Payment\Gateway\Http\TransferInterface $transferObject)
     {
         $request = $transferObject->getBody();
-
+        $this->_client = $this->_adyenHelper->initializeAdyenClient($request['storeId']);
+        unset($request['storeId']);
         // call lib
         $service = new \Adyen\Service\Modification($this->_client);
 

--- a/Gateway/Http/Client/TransactionCancel.php
+++ b/Gateway/Http/Client/TransactionCancel.php
@@ -30,29 +30,19 @@ use Magento\Payment\Gateway\Http\ClientInterface;
  */
 class TransactionCancel implements ClientInterface
 {
+    /**
+     * @var \Adyen\Payment\Helper\Data
+     */
+    private $adyenHelper;
 
     /**
      * PaymentRequest constructor.
-     *
-     * @param \Magento\Framework\Model\Context $context
-     * @param \Magento\Framework\Encryption\EncryptorInterface $encryptor
      * @param \Adyen\Payment\Helper\Data $adyenHelper
-     * @param \Adyen\Payment\Model\RecurringType $recurringType
-     * @param array $data
      */
     public function __construct(
-        \Magento\Framework\Model\Context $context,
-        \Magento\Framework\Encryption\EncryptorInterface $encryptor,
-        \Adyen\Payment\Helper\Data $adyenHelper,
-        \Adyen\Payment\Model\RecurringType $recurringType,
-        array $data = []
+        \Adyen\Payment\Helper\Data $adyenHelper
     ) {
-        $this->_encryptor = $encryptor;
         $this->_adyenHelper = $adyenHelper;
-        $this->_recurringType = $recurringType;
-        $this->_appState = $context->getAppState();
-
-        $this->_client = $this->_adyenHelper->initializeAdyenClient();
     }
 
     /**
@@ -62,17 +52,16 @@ class TransactionCancel implements ClientInterface
     public function placeRequest(\Magento\Payment\Gateway\Http\TransferInterface $transferObject)
     {
         $request = $transferObject->getBody();
-        $clientConfig = $transferObject->getClientConfig();
-        $this->_client = $this->_adyenHelper->initializeAdyenClient($clientConfig['storeId']);
         // call lib
-        $service = new \Adyen\Service\Modification($this->_client);
+        $service = new \Adyen\Service\Modification(
+            $this->_adyenHelper->initializeAdyenClient($transferObject->getClientConfig()['storeId'])
+        );
 
         try {
             $response = $service->cancel($request);
         } catch (\Adyen\AdyenException $e) {
             $response = null;
         }
-
         return $response;
     }
 }

--- a/Gateway/Http/Client/TransactionCapture.php
+++ b/Gateway/Http/Client/TransactionCapture.php
@@ -65,8 +65,8 @@ class TransactionCapture implements ClientInterface
     public function placeRequest(\Magento\Payment\Gateway\Http\TransferInterface $transferObject)
     {
         $request = $transferObject->getBody();
-        $this->_client = $this->_adyenHelper->initializeAdyenClient($request['storeId']);
-        unset($request['storeId']);
+        $clientConfig = $transferObject->getClientConfig();
+        $this->_client = $this->_adyenHelper->initializeAdyenClient($clientConfig['storeId']);
         // call lib
         $service = new \Adyen\Service\Modification($this->_client);
 

--- a/Gateway/Http/Client/TransactionCapture.php
+++ b/Gateway/Http/Client/TransactionCapture.php
@@ -65,7 +65,8 @@ class TransactionCapture implements ClientInterface
     public function placeRequest(\Magento\Payment\Gateway\Http\TransferInterface $transferObject)
     {
         $request = $transferObject->getBody();
-
+        $this->_client = $this->_adyenHelper->initializeAdyenClient($request['storeId']);
+        unset($request['storeId']);
         // call lib
         $service = new \Adyen\Service\Modification($this->_client);
 

--- a/Gateway/Http/Client/TransactionCapture.php
+++ b/Gateway/Http/Client/TransactionCapture.php
@@ -30,32 +30,19 @@ use Magento\Payment\Gateway\Http\ClientInterface;
  */
 class TransactionCapture implements ClientInterface
 {
+    /**
+     * @var \Adyen\Payment\Helper\Data
+     */
+    private $adyenHelper;
 
     /**
      * PaymentRequest constructor.
-     *
-     * @param \Magento\Framework\Model\Context $context
-     * @param \Magento\Framework\Encryption\EncryptorInterface $encryptor
      * @param \Adyen\Payment\Helper\Data $adyenHelper
-     * @param \Adyen\Payment\Logger\AdyenLogger $adyenLogger
-     * @param \Adyen\Payment\Model\RecurringType $recurringType
-     * @param array $data
      */
     public function __construct(
-        \Magento\Framework\Model\Context $context,
-        \Magento\Framework\Encryption\EncryptorInterface $encryptor,
-        \Adyen\Payment\Helper\Data $adyenHelper,
-        \Adyen\Payment\Logger\AdyenLogger $adyenLogger,
-        \Adyen\Payment\Model\RecurringType $recurringType,
-        array $data = []
+        \Adyen\Payment\Helper\Data $adyenHelper
     ) {
-        $this->_encryptor = $encryptor;
         $this->_adyenHelper = $adyenHelper;
-        $this->_adyenLogger = $adyenLogger;
-        $this->_recurringType = $recurringType;
-        $this->_appState = $context->getAppState();
-
-        $this->_client = $this->_adyenHelper->initializeAdyenClient();
     }
 
     /**
@@ -65,10 +52,10 @@ class TransactionCapture implements ClientInterface
     public function placeRequest(\Magento\Payment\Gateway\Http\TransferInterface $transferObject)
     {
         $request = $transferObject->getBody();
-        $clientConfig = $transferObject->getClientConfig();
-        $this->_client = $this->_adyenHelper->initializeAdyenClient($clientConfig['storeId']);
         // call lib
-        $service = new \Adyen\Service\Modification($this->_client);
+        $service = new \Adyen\Service\Modification(
+            $this->_adyenHelper->initializeAdyenClient($transferObject->getClientConfig()['storeId'])
+        );
 
         try {
             $response = $service->capture($request);

--- a/Gateway/Http/Client/TransactionCapture.php
+++ b/Gateway/Http/Client/TransactionCapture.php
@@ -42,7 +42,7 @@ class TransactionCapture implements ClientInterface
     public function __construct(
         \Adyen\Payment\Helper\Data $adyenHelper
     ) {
-        $this->_adyenHelper = $adyenHelper;
+        $this->adyenHelper = $adyenHelper;
     }
 
     /**
@@ -54,7 +54,7 @@ class TransactionCapture implements ClientInterface
         $request = $transferObject->getBody();
         // call lib
         $service = new \Adyen\Service\Modification(
-            $this->_adyenHelper->initializeAdyenClient($transferObject->getClientConfig()['storeId'])
+            $this->adyenHelper->initializeAdyenClient($transferObject->getClientConfig()['storeId'])
         );
 
         try {

--- a/Gateway/Http/Client/TransactionRefund.php
+++ b/Gateway/Http/Client/TransactionRefund.php
@@ -51,7 +51,6 @@ class TransactionRefund implements ClientInterface
         $this->_adyenHelper = $adyenHelper;
         $this->_recurringType = $recurringType;
         $this->_appState = $context->getAppState();
-
         $this->_client = $this->_adyenHelper->initializeAdyenClient();
     }
 

--- a/Gateway/Http/Client/TransactionRefund.php
+++ b/Gateway/Http/Client/TransactionRefund.php
@@ -30,28 +30,20 @@ use Magento\Payment\Gateway\Http\ClientInterface;
  */
 class TransactionRefund implements ClientInterface
 {
+    /**
+     * @var \Adyen\Payment\Helper\Data
+     */
+    private $adyenHelper;
 
     /**
      * PaymentRequest constructor.
-     *
-     * @param \Magento\Framework\Model\Context $context
-     * @param \Magento\Framework\Encryption\EncryptorInterface $encryptor
      * @param \Adyen\Payment\Helper\Data $adyenHelper
-     * @param \Adyen\Payment\Model\RecurringType $recurringType
-     * @param array $data
      */
     public function __construct(
-        \Magento\Framework\Model\Context $context,
-        \Magento\Framework\Encryption\EncryptorInterface $encryptor,
-        \Adyen\Payment\Helper\Data $adyenHelper,
-        \Adyen\Payment\Model\RecurringType $recurringType,
-        array $data = []
+
+        \Adyen\Payment\Helper\Data $adyenHelper
     ) {
-        $this->_encryptor = $encryptor;
         $this->_adyenHelper = $adyenHelper;
-        $this->_recurringType = $recurringType;
-        $this->_appState = $context->getAppState();
-        $this->_client = $this->_adyenHelper->initializeAdyenClient();
     }
 
     /**
@@ -64,12 +56,10 @@ class TransactionRefund implements ClientInterface
         $responses = [];
 
         foreach ($requests as $request) {
-            $clientConfig = $transferObject->getClientConfig();
-            $this->_client = $this->_adyenHelper->initializeAdyenClient($clientConfig['storeId']);
-
             // call lib
-            $service = new \Adyen\Service\Modification($this->_client);
-
+            $service = new \Adyen\Service\Modification(
+                $this->_adyenHelper->initializeAdyenClient($transferObject->getClientConfig()['storeId'])
+            );
             try {
                 $responses[] = $service->refund($request);
             } catch (\Adyen\AdyenException $e) {

--- a/Gateway/Http/Client/TransactionRefund.php
+++ b/Gateway/Http/Client/TransactionRefund.php
@@ -43,7 +43,7 @@ class TransactionRefund implements ClientInterface
 
         \Adyen\Payment\Helper\Data $adyenHelper
     ) {
-        $this->_adyenHelper = $adyenHelper;
+        $this->adyenHelper = $adyenHelper;
     }
 
     /**
@@ -58,7 +58,7 @@ class TransactionRefund implements ClientInterface
         foreach ($requests as $request) {
             // call lib
             $service = new \Adyen\Service\Modification(
-                $this->_adyenHelper->initializeAdyenClient($transferObject->getClientConfig()['storeId'])
+                $this->adyenHelper->initializeAdyenClient($transferObject->getClientConfig()['storeId'])
             );
             try {
                 $responses[] = $service->refund($request);

--- a/Gateway/Http/Client/TransactionRefund.php
+++ b/Gateway/Http/Client/TransactionRefund.php
@@ -65,8 +65,8 @@ class TransactionRefund implements ClientInterface
         $responses = [];
 
         foreach ($requests as $request) {
-            $this->_client = $this->_adyenHelper->initializeAdyenClient($request['storeId']);
-            unset($request['storeId']);
+            $clientConfig = $transferObject->getClientConfig();
+            $this->_client = $this->_adyenHelper->initializeAdyenClient($clientConfig['storeId']);
 
             // call lib
             $service = new \Adyen\Service\Modification($this->_client);

--- a/Gateway/Http/Client/TransactionRefund.php
+++ b/Gateway/Http/Client/TransactionRefund.php
@@ -65,6 +65,9 @@ class TransactionRefund implements ClientInterface
         $responses = [];
 
         foreach ($requests as $request) {
+            $this->_client = $this->_adyenHelper->initializeAdyenClient($request['storeId']);
+            unset($request['storeId']);
+
             // call lib
             $service = new \Adyen\Service\Modification($this->_client);
 

--- a/Gateway/Http/TransferFactory.php
+++ b/Gateway/Http/TransferFactory.php
@@ -56,6 +56,10 @@ class TransferFactory implements TransferFactoryInterface
             $this->transferBuilder->setHeaders($request['headers']);
         }
 
+        if (!empty($request['clientConfig'])) {
+            $this->transferBuilder->setClientConfig($request['clientConfig']);
+        }
+
         $transfer = $this->transferBuilder
             ->setBody($request['body'])
             ->build();

--- a/Gateway/Request/CancelDataBuilder.php
+++ b/Gateway/Request/CancelDataBuilder.php
@@ -62,7 +62,8 @@ class CancelDataBuilder implements BuilderInterface
 
         $request['body'] = [
             "reference" => $order->getOrderIncrementId(),
-            "originalReference" => $pspReference
+            "originalReference" => $pspReference,
+            "storeId" => $payment->getOrder()->getStoreId()
         ];
 
         return $request;

--- a/Gateway/Request/CancelDataBuilder.php
+++ b/Gateway/Request/CancelDataBuilder.php
@@ -62,10 +62,9 @@ class CancelDataBuilder implements BuilderInterface
 
         $request['body'] = [
             "reference" => $order->getOrderIncrementId(),
-            "originalReference" => $pspReference,
-            "storeId" => $payment->getOrder()->getStoreId()
+            "originalReference" => $pspReference
         ];
-
+        $request['clientConfig']=[ "storeId" => $payment->getOrder()->getStoreId()];
         return $request;
     }
 }

--- a/Gateway/Request/CaptureDataBuilder.php
+++ b/Gateway/Request/CaptureDataBuilder.php
@@ -70,7 +70,8 @@ class CaptureDataBuilder implements BuilderInterface
         $requestBody = [
             "modificationAmount" => $modificationAmount,
             "reference" => $payment->getOrder()->getIncrementId(),
-            "originalReference" => $pspReference
+            "originalReference" => $pspReference,
+            "storeId" => $payment->getOrder()->getStoreId()
         ];
 
         $brandCode = $payment->getAdditionalInformation(

--- a/Gateway/Request/CaptureDataBuilder.php
+++ b/Gateway/Request/CaptureDataBuilder.php
@@ -40,10 +40,14 @@ class CaptureDataBuilder implements BuilderInterface
      * CaptureDataBuilder constructor.
      *
      * @param \Adyen\Payment\Helper\Data $adyenHelper
+     * @param \Adyen\Payment\Logger\AdyenLogger $adyenLogger
+
      */
-    public function __construct(\Adyen\Payment\Helper\Data $adyenHelper)
+    public function __construct(\Adyen\Payment\Helper\Data $adyenHelper,\Adyen\Payment\Logger\AdyenLogger $adyenLogger)
     {
         $this->adyenHelper = $adyenHelper;
+        $this->_adyenLogger = $adyenLogger;
+
     }
 
     /**
@@ -70,8 +74,7 @@ class CaptureDataBuilder implements BuilderInterface
         $requestBody = [
             "modificationAmount" => $modificationAmount,
             "reference" => $payment->getOrder()->getIncrementId(),
-            "originalReference" => $pspReference,
-            "storeId" => $payment->getOrder()->getStoreId()
+            "originalReference" => $pspReference
         ];
 
         $brandCode = $payment->getAdditionalInformation(
@@ -82,12 +85,10 @@ class CaptureDataBuilder implements BuilderInterface
             $openInvoiceFields = $this->getOpenInvoiceData($payment);
             $requestBody["additionalData"] = $openInvoiceFields;
         }
-
         $request['body'] = $requestBody;
-
+        $request['clientConfig']=[ "storeId" => $payment->getOrder()->getStoreId()];
         return $request;
     }
-
 
     /**
      * @param $payment

--- a/Gateway/Request/CaptureDataBuilder.php
+++ b/Gateway/Request/CaptureDataBuilder.php
@@ -40,14 +40,10 @@ class CaptureDataBuilder implements BuilderInterface
      * CaptureDataBuilder constructor.
      *
      * @param \Adyen\Payment\Helper\Data $adyenHelper
-     * @param \Adyen\Payment\Logger\AdyenLogger $adyenLogger
-
      */
-    public function __construct(\Adyen\Payment\Helper\Data $adyenHelper,\Adyen\Payment\Logger\AdyenLogger $adyenLogger)
+    public function __construct(\Adyen\Payment\Helper\Data $adyenHelper)
     {
         $this->adyenHelper = $adyenHelper;
-        $this->_adyenLogger = $adyenLogger;
-
     }
 
     /**
@@ -86,7 +82,7 @@ class CaptureDataBuilder implements BuilderInterface
             $requestBody["additionalData"] = $openInvoiceFields;
         }
         $request['body'] = $requestBody;
-        $request['clientConfig']=[ "storeId" => $payment->getOrder()->getStoreId()];
+        $request['clientConfig'] = ["storeId" => $payment->getOrder()->getStoreId()];
         return $request;
     }
 

--- a/Gateway/Request/RefundDataBuilder.php
+++ b/Gateway/Request/RefundDataBuilder.php
@@ -173,9 +173,8 @@ class RefundDataBuilder implements BuilderInterface
                 $requestBody[0]["additionalData"] = $openInvoiceFields;
             }
         }
-        $request['clientConfig']=[ "storeId" => $payment->getOrder()->getStoreId()];
+        $request['clientConfig'] = ["storeId" => $payment->getOrder()->getStoreId()];
         $request['body'] = $requestBody;
-
         return $request;
     }
 

--- a/Gateway/Request/RefundDataBuilder.php
+++ b/Gateway/Request/RefundDataBuilder.php
@@ -144,7 +144,8 @@ class RefundDataBuilder implements BuilderInterface
                         "modificationAmount" => $modificationAmountObject,
                         "reference" => $payment->getOrder()->getIncrementId(),
                         "originalReference" => $splitPayment->getPspreference(),
-                        "merchantAccount" => $merchantAccount
+                        "merchantAccount" => $merchantAccount,
+                        "storeId" => $payment->getOrder()->getStoreId()
                     ];
                 }
             }
@@ -158,7 +159,8 @@ class RefundDataBuilder implements BuilderInterface
                     "modificationAmount" => $modificationAmount,
                     "reference" => $payment->getOrder()->getIncrementId(),
                     "originalReference" => $pspReference,
-                    "merchantAccount" => $merchantAccount
+                    "merchantAccount" => $merchantAccount,
+                    "storeId" => $payment->getOrder()->getStoreId()
                 ]
             ];
 

--- a/Gateway/Request/RefundDataBuilder.php
+++ b/Gateway/Request/RefundDataBuilder.php
@@ -144,8 +144,7 @@ class RefundDataBuilder implements BuilderInterface
                         "modificationAmount" => $modificationAmountObject,
                         "reference" => $payment->getOrder()->getIncrementId(),
                         "originalReference" => $splitPayment->getPspreference(),
-                        "merchantAccount" => $merchantAccount,
-                        "storeId" => $payment->getOrder()->getStoreId()
+                        "merchantAccount" => $merchantAccount
                     ];
                 }
             }
@@ -159,8 +158,7 @@ class RefundDataBuilder implements BuilderInterface
                     "modificationAmount" => $modificationAmount,
                     "reference" => $payment->getOrder()->getIncrementId(),
                     "originalReference" => $pspReference,
-                    "merchantAccount" => $merchantAccount,
-                    "storeId" => $payment->getOrder()->getStoreId()
+                    "merchantAccount" => $merchantAccount
                 ]
             ];
 
@@ -175,7 +173,7 @@ class RefundDataBuilder implements BuilderInterface
                 $requestBody[0]["additionalData"] = $openInvoiceFields;
             }
         }
-
+        $request['clientConfig']=[ "storeId" => $payment->getOrder()->getStoreId()];
         $request['body'] = $requestBody;
 
         return $request;


### PR DESCRIPTION
Description
Wrong store id is used for multi store merchants. When creating a credit memo, capture or cancel an order and there are multiple stores, the storeid is added to the request.

Tested scenarios

From a second store with different merchant account making the following actions
Capture
Cancel
Refund

Fixed issue: #494