### PR TITLE
[PW-2157] Wrong magento/module-paypal require version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "adyen/php-api-library": "~6",
     "magento/framework": ">=101.0.8 <102 || >=102.0.1",
     "magento/module-vault": "101.*",
-    "magento/module-paypal": "100.3.*"
+    "magento/module-paypal": ">=100.2.6"
   },
   "require-dev": {
     "phpunit/phpunit": "~6.5.0",


### PR DESCRIPTION
**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Change required magento/module-paypal version to >=100.2.6
With this change we keep compatibility with Magento version 2.2.8

**Fixed issue**:  <!-- #-prefixed issue number -->
#658