### PR TITLE
[PW-2173]: Added recurring model to ApplePay BuilderComposite virtual type

### DIFF
--- a/etc/di.xml
+++ b/etc/di.xml
@@ -660,6 +660,7 @@
                 <item name="payment" xsi:type="string">Adyen\Payment\Gateway\Request\PaymentDataBuilder</item>
                 <item name="browserinfo" xsi:type="string">Adyen\Payment\Gateway\Request\BrowserInfoDataBuilder</item>
                 <item name="transaction" xsi:type="string">Adyen\Payment\Gateway\Request\ApplePayAuthorizationDataBuilder</item>
+                <item name="recurring" xsi:type="string">Adyen\Payment\Gateway\Request\RecurringDataBuilder</item>
             </argument>
         </arguments>
     </virtualType>


### PR DESCRIPTION
**Description**
This ensures that recurring-related fields get set for ApplePay for each payment request. Payments were being set as Subscription by default when those params were left unset.

**Tested scenarios**
Payment with ApplePay with recurring billing agreement enabled and disabled

**Fixed issue**:  PW-2173