### PR TITLE
Support combo cards for Mexico & Mexican Pesos

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/adyen-cc-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-cc-method.js
@@ -505,7 +505,12 @@ define(
                 }
                 var countryId = quote.billingAddress().countryId;
                 var currencyCode = quote.totals().quote_currency_code;
-                return currencyCode === "BRL" && countryId === "BR";
+                var allowedCurrenciesByCountry = {
+                    'BR': 'BRL',
+                    'MX': 'MXN'
+                };
+                return allowedCurrenciesByCountry[countryId] &&
+                    currencyCode === allowedCurrenciesByCountry[countryId];
             },
             setPlaceOrderHandler: function (handler) {
                 this.placeOrderHandler = handler;


### PR DESCRIPTION
As requested by merchants, this commit adds support to combo cards (cards that act both as credit and debit, by choice of the shopper) to the checkout process. If shipping address is in Mexico and currency is set to Mexican Pesos, the drop down to choose between options should show up.

I created the object to check this so extensibility is possible, but another solution should be used if this gets too long.
