### PR TITLE
[PW-2128]: Migration script for setting terminal_selection based on pos_store_id

### DIFF
--- a/etc/config.xml
+++ b/etc/config.xml
@@ -155,6 +155,7 @@
                 <total_timeout>120</total_timeout>
                 <recurring_type>NONE</recurring_type>
                 <group>adyen</group>
+                <terminal_selection>merchant_account_level</terminal_selection>
             </adyen_pos_cloud>
             <adyen_pay_by_mail>
                 <active>0</active>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -24,7 +24,7 @@
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
 
-    <module name="Adyen_Payment" setup_version="5.4.0">
+    <module name="Adyen_Payment" setup_version="6.0.0-alpha1">
         <sequence>
             <module name="Magento_Sales"/>
             <module name="Magento_Quote"/>


### PR DESCRIPTION
**Description**
A new config dropdown has been introduced to hide/show the pos_store_id text field. This terminal_selection config will now be used to check if the terminals to be queried are merchant account level or store level.

The new config usage has already been merged to the feature branch here https://github.com/Adyen/adyen-magento2/blob/c80a0332dce9a4a2a81e3aad204a8c50d25492e6/Helper/PaymentMethods.php#L376

**Tested scenarios**
* setup:upgrade for scopes with no pos_store_id set: No changes are made

* setup:upgrade for scopes with pos_store_id set: config is created for terminal_selection=store_level

* setup:upgrade for scopes with pos_store_id empty: config is created for terminal_selection=merchant_account_level

**Fixed issue**:  PW-2128