### PR TITLE
[PW-2121]: Migration script for auto_capture_openinvoice / capture_on_shipment and usage of new config kar_capture_mode

### DIFF
--- a/Model/Config/Source/KarCaptureMode.php
+++ b/Model/Config/Source/KarCaptureMode.php
@@ -27,11 +27,15 @@ class KarCaptureMode implements \Magento\Framework\Option\ArrayInterface
 {
     const OPTIONS = [
         [
-            'value' => 0,
+            'value' => 'capture_on_shipment',
+            'label' => 'Capture on shipment'
+        ],
+        [
+            'value' => 'capture_immediately',
             'label' => 'Capture immediately'
         ],
         [
-            'value' => 1,
+            'value' => 'capture_manually',
             'label' => 'Capture manually'
         ],
     ];

--- a/Model/Cron.php
+++ b/Model/Cron.php
@@ -1429,7 +1429,7 @@ class Cron
             ));
             $_paymentCode = $this->_paymentMethodCode();
             $captureModeOpenInvoice = $this->_getConfigData(
-                'auto_capture_openinvoice',
+                'kar_capture_mode',
                 'adyen_abstract',
                 $this->_order->getStoreId()
             );
@@ -1478,12 +1478,12 @@ class Cron
                 }
             }
 
-            // if auto capture mode for openinvoice is turned on then use auto capture
-            if ($captureModeOpenInvoice == true &&
+            // if capture immediately for openinvoice is turned on then use auto capture
+            if (strcmp($captureModeOpenInvoice, 'capture_immediately') === 0 &&
                 $this->_adyenHelper->isPaymentMethodOpenInvoiceMethod($this->_paymentMethod)
             ) {
                 $this->_adyenLogger->addAdyenNotificationCronjob(
-                    'This payment method is configured to be working as auto capture '
+                    'This payment method is configured to be working as capture immediately'
                 );
                 return true;
             }

--- a/Observer/Adminhtml/BeforeShipmentObserver.php
+++ b/Observer/Adminhtml/BeforeShipmentObserver.php
@@ -54,9 +54,9 @@ class BeforeShipmentObserver extends AbstractDataAssignObserver
     {
         $shipment = $observer->getEvent()->getShipment();
         $order = $shipment->getOrder();
-        $captureOnShipment = $this->adyenHelper->getConfigData('capture_on_shipment', 'adyen_abstract', $order->getStoreId());
+        $captureOnShipment = $this->adyenHelper->getConfigData('kar_capture_mode', 'adyen_abstract', $order->getStoreId());
 
-        if ($this->isPaymentMethodAdyen($order) && $captureOnShipment) {
+        if ($this->isPaymentMethodAdyen($order) && strcmp($captureOnShipment, 'capture_on_shipment') === 0) {
             $payment = $order->getPayment();
             $brandCode = $payment->getAdditionalInformation(
                 \Adyen\Payment\Observer\AdyenHppDataAssignObserver::BRAND_CODE

--- a/etc/adminhtml/system/ecommerce_payments/advanced_options.xml
+++ b/etc/adminhtml/system/ecommerce_payments/advanced_options.xml
@@ -29,9 +29,9 @@
         <source_model>Adyen\Payment\Model\Config\Source\CaptureMode</source_model>
         <config_path>payment/adyen_abstract/capture_mode</config_path>
     </field>
-    <field id="capture_mode_kar" translate="label" type="select" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1"> <!--TODO: Combine fields 15 + 16 and aggregate fields into options-->
+    <field id="capture_mode_kar" translate="label" type="select" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
         <label>Capture delay for Klarna, AfterPay, and RatePAY</label>
-        <!--source_model>Adyen\Payment\Model\Config\Source\KarCaptureMode?</source_model-->
+        <source_model>Adyen\Payment\Model\Config\Source\KarCaptureMode</source_model>
         <config_path>payment/adyen_abstract/kar_capture_mode</config_path>
         <comment><![CDATA[This setting should only be changed when instructed by the Adyen <a href="https://support.adyen.com/hc/en-us/requests/new" target="_blank">support team</a>.]]></comment>
     </field>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -47,6 +47,7 @@
                 <fraud_manual_review_accept_status>processing</fraud_manual_review_accept_status>
                 <send_email_bank_sepa_on_pending>0</send_email_bank_sepa_on_pending>
                 <ignore_refund_notification>0</ignore_refund_notification>
+                <kar_capture_mode>capture_manually</kar_capture_mode>
             </adyen_abstract>
             <adyen_cc>
                 <active>1</active>


### PR DESCRIPTION
**Description**
We're combining the auto_capture_openinvoice and capture_on_shipment config into a new single config (kar_capture_mode, KAR as in Klarna, AfterPay, RatePay. Open to name suggestions...).

The new value corresponds to the assignment defined in the ticket PW-2121.

Also, the previous migration script has been moved to a separate private function.

**Tested scenarios**
setup:upgrade for:
Storeview with auto_capture_openinvoice=1 and capture_on_shipment=1
Storeview with auto_capture_openinvoice=0 and capture_on_shipment=1
Storeview with auto_capture_openinvoice=1 and capture_on_shipment=0
Storeview with auto_capture_openinvoice=0 and capture_on_shipment=0

**Fixed issue**:  PW-2121