### PR TITLE
[PW-2124] Replace ISO Country Code config field with Shopper Country dependent dropdown

### DIFF
--- a/Gateway/Command/PayByMailCommand.php
+++ b/Gateway/Command/PayByMailCommand.php
@@ -74,7 +74,7 @@ class PayByMailCommand implements CommandInterface
         $stateObject->setState(\Magento\Sales\Model\Order::STATE_NEW);
         $stateObject->setStatus($this->_adyenHelper->getAdyenAbstractConfigData('order_status'));
         $stateObject->setIsNotified(false);
-        
+
         return $this;
     }
 
@@ -139,7 +139,7 @@ class PayByMailCommand implements CommandInterface
             $skinCode = $this->_adyenHelper->getAdyenHppConfigData('skin_code');
             $hmacKey           = $this->_adyenHelper->getHmac();
             $shopperLocale     = trim($this->_adyenHelper->getAdyenHppConfigData('shopper_locale', $storeId));
-            $countryCode       = trim($this->_adyenHelper->getAdyenHppConfigData('country_code', $storeId));
+            $countryCode       = trim($this->_adyenHelper->getAdyenCountryCodeConfigData($storeId));
         } else {
             // use pay_by_mail skin and hmac
             $hmacKey = $this->_adyenHelper->getHmacPayByMail();
@@ -184,7 +184,7 @@ class PayByMailCommand implements CommandInterface
         $formFields['shopperEmail']      = $shopperEmail;
         // recurring
         $recurringType                   = $this->_adyenHelper->getRecurringTypeFromOneclickRecurringSetting($storeId);
-        
+
         $sessionValidity = $this->_adyenHelper->getAdyenPayByMailConfigData('session_validity', $storeId);
 
         if ($sessionValidity == "") {

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -1901,4 +1901,21 @@ class Data extends AbstractHelper
         );
 
     }
+
+    /**
+     * Gives back CountryCode configuration values
+     *
+     * @param null $storeId
+     * @return mixed
+     */
+    public function getAdyenCountryCodeConfigData($storeId = null)
+    {
+        $shopperLocale = trim($this->_adyenHelper->getAdyenHppConfigData('shopper_locale', $storeId));
+        $countryCode = trim($this->_adyenHelper->getAdyenHppConfigData('country_code', $storeId));
+        if ($countryCode == false && $shopperLocale == 1) {
+            return $this->getConfigData($countryCode, 'adyen_hpp', $storeId);
+        } else {
+            return "";
+        }
+    }
 }

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -1910,10 +1910,10 @@ class Data extends AbstractHelper
      */
     public function getAdyenCountryCodeConfigData($storeId = null)
     {
-        $shopperLocale = trim($this->_adyenHelper->getAdyenHppConfigData('shopper_locale', $storeId));
-        $countryCode = trim($this->_adyenHelper->getAdyenHppConfigData('country_code', $storeId));
-        if ($countryCode == false && $shopperLocale == 1) {
-            return $this->getConfigData($countryCode, 'adyen_hpp', $storeId);
+        $shopperCountry = trim($this->getConfigData('shopper_country', 'adyen_hpp', $storeId));
+        $countryCode = trim($this->getConfigData('country_code', 'adyen_hpp', $storeId));
+        if ($shopperCountry == 1) {
+            return $countryCode;
         } else {
             return "";
         }

--- a/Helper/PaymentMethods.php
+++ b/Helper/PaymentMethods.php
@@ -260,7 +260,7 @@ class PaymentMethods extends AbstractHelper
     protected function getCurrentCountryCode($store, $country)
     {
         // if fixed countryCode is setup in config use this
-        $countryCode = $this->adyenHelper->getAdyenHppConfigData('country_code', $store->getId());
+        $countryCode = $this->adyenHelper->getAdyenCountryCodeConfigData($store->getId());
 
         if ($countryCode != "") {
             return $countryCode;

--- a/Model/Config/Source/ShopperCountryMode.php
+++ b/Model/Config/Source/ShopperCountryMode.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2020 Adyen BV (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\Payment\Model\Config\Source;
+
+class ShopperCountryMode implements \Magento\Framework\Option\ArrayInterface
+{
+    const OPTIONS = [
+        [
+            'value' => 0,
+            'label' => 'Based on address'
+        ],
+        [
+            'value' => 1,
+            'label' => 'Costum'
+        ],
+    ];
+
+    /**
+     * @return array
+     */
+    public function toOptionArray()
+    {
+        return self::OPTIONS;
+    }
+}

--- a/Model/Config/Source/ShopperCountryMode.php
+++ b/Model/Config/Source/ShopperCountryMode.php
@@ -32,7 +32,7 @@ class ShopperCountryMode implements \Magento\Framework\Option\ArrayInterface
         ],
         [
             'value' => 1,
-            'label' => 'Costum'
+            'label' => 'Custom'
         ],
     ];
 

--- a/Setup/UpgradeData.php
+++ b/Setup/UpgradeData.php
@@ -185,6 +185,8 @@ class UpgradeData implements UpgradeDataInterface
 
         $this->setKarCaptureMode($connection);
 
+        $this->setShopperCountry($connection);
+
         $this->reinitableConfig->reinit();
 
     }
@@ -305,5 +307,38 @@ class UpgradeData implements UpgradeDataInterface
                 $configCaptureValue['core_config_data_scope_id']
             );
         }
+    }
+    /**
+     * Sets shoppercountry configuration by checking the value of payment/adyen_hpp/country_code
+     *
+     * @param Magento\Framework\DB\Adapter\Pdo\Mysql $connection
+     */
+    private function setShopperCountry($connection)
+    {
+        $countryCode = "payment/adyen_hpp/country_code";
+        $shoppercountry = "payment/adyen_hpp/shoppercountry";
+
+        $select = $connection->select()
+            ->from($this->configDataTable)
+            ->where('path = ?', $countryCode)
+            ->where('value <> "" AND value IS NOT NULL');
+        $configCountryCodeValues = $connection->fetchAll($select);
+
+        foreach ($configCountryCodeValues as $configCountryCodeValue) {
+            $scope = $configCountryCodeValue['scope'];
+            $scopeId = $configCountryCodeValue['scope_id'];
+
+            if (isset($configCountryCodeValue)) {
+                $shoppercountry = 1;
+            }
+            $this->configWriter->save(
+                $shoppercountry,
+                'store_level',
+                $scope,
+                $scopeId
+            );
+        }
+
+
     }
 }

--- a/Setup/UpgradeData.php
+++ b/Setup/UpgradeData.php
@@ -316,7 +316,7 @@ class UpgradeData implements UpgradeDataInterface
     private function setShopperCountry($connection)
     {
         $countryCode = "payment/adyen_hpp/country_code";
-        $shoppercountry = "payment/adyen_hpp/shoppercountry";
+        $shoppercountry = "payment/adyen_hpp/shopper_country";
 
         $select = $connection->select()
             ->from($this->configDataTable)
@@ -328,12 +328,9 @@ class UpgradeData implements UpgradeDataInterface
             $scope = $configCountryCodeValue['scope'];
             $scopeId = $configCountryCodeValue['scope_id'];
 
-            if (isset($configCountryCodeValue)) {
-                $shoppercountry = 1;
-            }
             $this->configWriter->save(
                 $shoppercountry,
-                'store_level',
+                1,
                 $scope,
                 $scopeId
             );

--- a/Setup/UpgradeData.php
+++ b/Setup/UpgradeData.php
@@ -266,7 +266,7 @@ class UpgradeData implements UpgradeDataInterface
                     'value AS auto_capture_openinvoice_value'
                 ])
             ->where('
-            core_config_data.path IN 
+            core_config_data.path IN
             ("payment/adyen_abstract/capture_on_shipment", "payment/adyen_abstract/auto_capture_openinvoice")
             ');
         $configCaptureValues = $connection->fetchAll($select);

--- a/etc/adminhtml/system/payment_methods/local_payment_methods/advanced_options.xml
+++ b/etc/adminhtml/system/payment_methods/local_payment_methods/advanced_options.xml
@@ -27,7 +27,7 @@
     <field id="shopper_country" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
         <label>Shopper country</label>
         <source_model>Adyen\Payment\Model\Config\Source\ShopperCountryMode</source_model>
-        <config_path>payment/adyen_hpp/shoppercountry</config_path>
+        <config_path>payment/adyen_hpp/shopper_country</config_path>
     </field>
     <field id="shopper_specific_country" translate="label" type="select" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="0">
         <label>Custom shopper country</label>

--- a/etc/adminhtml/system/payment_methods/local_payment_methods/advanced_options.xml
+++ b/etc/adminhtml/system/payment_methods/local_payment_methods/advanced_options.xml
@@ -26,32 +26,42 @@
     <label>Advanced options</label>
     <field id="shopper_country" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
         <label>Shopper country</label>
-        <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-        <!--config_path></config_path--> <!--TODO: New field? Yes-->
+        <source_model>Adyen\Payment\Model\Config\Source\ShopperCountryMode</source_model>
+        <config_path>payment/adyen_hpp/shoppercountry</config_path>
     </field>
-    <field id="ratepay_id" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
+    <field id="shopper_specific_country" translate="label" type="select" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="0">
+        <label>Custum shopper country</label>
+        <depends>
+            <field id="shopper_country">1</field>
+        </depends>
+        <source_model>Magento\Directory\Model\Config\Source\Country</source_model>
+        <can_be_empty>1</can_be_empty>
+        <config_path>payment/adyen_hpp/countrycode</config_path>
+    </field>
+    <field id="ratepay_id" translate="label" type="text" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
         <label>RatePAY Device Ident SId</label>
         <tooltip>Unique RatePAY Id provided by RatePAY integration consultant</tooltip>
         <config_path>payment/adyen_hpp/ratepay_id</config_path>
     </field>
-    <field id="split_payments_refund_strategy" translate="label" type="select" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
+
+    <field id="split_payments_refund_strategy" translate="label" type="select" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1">
         <label>Refunds that include gift cards</label>
         <comment><![CDATA[Learn more about refunds that include gift cards on <a href="https://docs.adyen.com/plugins/magento-2/set-up-the-plugin-in-magento/#split-payment" target="_blank">Adyen documentation</a>.]]></comment>
         <source_model>Adyen\Payment\Model\Config\Source\SplitPaymentRefundStrategy</source_model>
         <config_path>payment/adyen_abstract/split_payments_refund_strategy</config_path>
     </field>
-    <field id="allowspecific_local_payment_methods" translate="label" type="allowspecific" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="0">
+    <field id="allowspecific_local_payment_methods" translate="label" type="allowspecific" sortOrder="50" showInDefault="1" showInWebsite="1" showInStore="0">
         <label>Applicable countries</label>
         <source_model>Magento\Payment\Model\Config\Source\Allspecificcountries</source_model>
         <config_path>payment/adyen_hpp/allowspecific</config_path>
     </field>
-    <field id="specificcountry" translate="label" type="multiselect" sortOrder="50" showInDefault="1" showInWebsite="1" showInStore="0">
-        <label>Payment from specific countries</label>
-        <depends>
-            <field id="allowspecific_local_payment_methods">1</field>
-        </depends>
-        <source_model>Magento\Directory\Model\Config\Source\Country</source_model>
-        <can_be_empty>1</can_be_empty>
-        <config_path>payment/adyen_hpp/specificcountry</config_path>
+    <field id="specificcountry" translate="label" type="multiselect" sortOrder="60" showInDefault="1" showInWebsite="1" showInStore="0">
+    <label>Payment from specific countries</label>
+    <depends>
+        <field id="allowspecific_local_payment_methods">1</field>
+    </depends>
+    <source_model>Magento\Directory\Model\Config\Source\Country</source_model>
+    <can_be_empty>1</can_be_empty>
+    <config_path>payment/adyen_hpp/specificcountry</config_path>
     </field>
 </config>

--- a/etc/adminhtml/system/payment_methods/local_payment_methods/advanced_options.xml
+++ b/etc/adminhtml/system/payment_methods/local_payment_methods/advanced_options.xml
@@ -61,7 +61,7 @@
         <field id="allowspecific_local_payment_methods">1</field>
     </depends>
     <source_model>Magento\Directory\Model\Config\Source\Country</source_model>
-    <can_be_empty>1</can_be_empty>
+    <validate>required-entry</validate>
     <config_path>payment/adyen_hpp/specificcountry</config_path>
     </field>
 </config>

--- a/etc/adminhtml/system/payment_methods/local_payment_methods/advanced_options.xml
+++ b/etc/adminhtml/system/payment_methods/local_payment_methods/advanced_options.xml
@@ -30,7 +30,7 @@
         <config_path>payment/adyen_hpp/shoppercountry</config_path>
     </field>
     <field id="shopper_specific_country" translate="label" type="select" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="0">
-        <label>Custum shopper country</label>
+        <label>Custom shopper country</label>
         <depends>
             <field id="shopper_country">1</field>
         </depends>

--- a/etc/adminhtml/system/payment_methods/local_payment_methods/advanced_options.xml
+++ b/etc/adminhtml/system/payment_methods/local_payment_methods/advanced_options.xml
@@ -36,7 +36,7 @@
         </depends>
         <source_model>Magento\Directory\Model\Config\Source\Country</source_model>
         <can_be_empty>1</can_be_empty>
-        <config_path>payment/adyen_hpp/countrycode</config_path>
+        <config_path>payment/adyen_hpp/country_code</config_path>
     </field>
     <field id="ratepay_id" translate="label" type="text" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
         <label>RatePAY Device Ident SId</label>

--- a/etc/adminhtml/system/payment_methods/local_payment_methods/advanced_options.xml
+++ b/etc/adminhtml/system/payment_methods/local_payment_methods/advanced_options.xml
@@ -35,7 +35,7 @@
             <field id="shopper_country">1</field>
         </depends>
         <source_model>Magento\Directory\Model\Config\Source\Country</source_model>
-        <can_be_empty>1</can_be_empty>
+        <validate>required-entry</validate>
         <config_path>payment/adyen_hpp/country_code</config_path>
     </field>
     <field id="ratepay_id" translate="label" type="text" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -121,6 +121,7 @@
                 <allowspecific>0</allowspecific>
                 <ratepay_id>oj9GsQ</ratepay_id>
                 <sort_order>3</sort_order>
+                <shoppercountry>0</shoppercountry>
                 <payment_action>authorize</payment_action>
                 <can_initialize>1</can_initialize>
                 <is_gateway>1</is_gateway>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -121,7 +121,7 @@
                 <allowspecific>0</allowspecific>
                 <ratepay_id>oj9GsQ</ratepay_id>
                 <sort_order>3</sort_order>
-                <shoppercountry>0</shoppercountry>
+                <shopper_country>0</shopper_country>
                 <payment_action>authorize</payment_action>
                 <can_initialize>1</can_initialize>
                 <is_gateway>1</is_gateway>


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
The previous text config field "ISO Country Code" is being replaced with a country select field that is dependent on a Yes/No type of dropdown.

Migration script must be created to upgrade from the country code as text to the dropdown value. Then the backend logic must be modified where needed to use this new value.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

**Fixed issue**:  <!-- #-prefixed issue number -->