### PR TITLE
[PW-2174]: Removing sync order cancellation for 3DS1 failure response

### DIFF
--- a/Controller/Process/Redirect.php
+++ b/Controller/Process/Redirect.php
@@ -224,7 +224,7 @@ class Redirect extends \Magento\Framework\App\Action\Action
 
 						$this->_redirect('checkout/onepage/success', ['_query' => ['utm_nooverride' => '1']]);
 					} else {
-						$order->addStatusHistoryComment(__('3D-secure validation was unsuccessful. This order will be cancelled when the relevant notification has been processed.'))->save();
+						$order->addStatusHistoryComment(__('3D-secure validation was unsuccessful. This order will be cancelled when the related notification has been processed.'))->save();
 
 						// reactivate the quote
 						$session = $this->_getCheckout();

--- a/Controller/Process/Redirect.php
+++ b/Controller/Process/Redirect.php
@@ -224,6 +224,11 @@ class Redirect extends \Magento\Framework\App\Action\Action
 
 						$this->_redirect('checkout/onepage/success', ['_query' => ['utm_nooverride' => '1']]);
 					} else {
+					    /*
+					     * Since responseCode!='Authorised' the order could be cancelled immediately,
+					     * but redirect payments can have multiple conflicting responses.
+					     * The order will be cancelled if an Authorization Success=False notification is processed instead
+					    */
 						$order->addStatusHistoryComment(__('3D-secure validation was unsuccessful. This order will be cancelled when the related notification has been processed.'))->save();
 
 						// reactivate the quote

--- a/Controller/Process/Redirect.php
+++ b/Controller/Process/Redirect.php
@@ -224,12 +224,7 @@ class Redirect extends \Magento\Framework\App\Action\Action
 
 						$this->_redirect('checkout/onepage/success', ['_query' => ['utm_nooverride' => '1']]);
 					} else {
-						$order->addStatusHistoryComment(__('3D-secure validation was unsuccessful.'))->save();
-
-						// Move the order from PAYMENT_REVIEW to NEW, so that can be cancelled
-						$order->setState(\Magento\Sales\Model\Order::STATE_NEW);
-						$this->_adyenHelper->cancelOrder($order);
-						$this->messageManager->addErrorMessage("3D-secure validation was unsuccessful");
+						$order->addStatusHistoryComment(__('3D-secure validation was unsuccessful. This order will be cancelled when the relevant notification has been processed.'))->save();
 
 						// reactivate the quote
 						$session = $this->_getCheckout();

--- a/Model/AdyenThreeDS2Process.php
+++ b/Model/AdyenThreeDS2Process.php
@@ -145,13 +145,6 @@ class AdyenThreeDS2Process implements AdyenThreeDS2ProcessInterface
         if($result['resultCode'] != 'Authorised') {
             $this->checkoutSession->restoreQuote();
 
-            // Always cancel the order if the paymenth has failed
-            if (!$order->canCancel()) {
-                $order->setState(\Magento\Sales\Model\Order::STATE_NEW);
-            }
-
-            $order->cancel()->save();
-
             throw new \Magento\Framework\Exception\LocalizedException(__('The payment is REFUSED.'));
         }
 

--- a/Model/AdyenThreeDS2Process.php
+++ b/Model/AdyenThreeDS2Process.php
@@ -145,6 +145,13 @@ class AdyenThreeDS2Process implements AdyenThreeDS2ProcessInterface
         if($result['resultCode'] != 'Authorised') {
             $this->checkoutSession->restoreQuote();
 
+            // Always cancel the order if the paymenth has failed
+            if (!$order->canCancel()) {
+                $order->setState(\Magento\Sales\Model\Order::STATE_NEW);
+            }
+
+            $order->cancel()->save();
+
             throw new \Magento\Framework\Exception\LocalizedException(__('The payment is REFUSED.'));
         }
 


### PR DESCRIPTION
**Description**
When 3DS payments fail the plugin should cancel the order only on notification processing (Authorization Success False). This fixes issues where orders get conflicting synchronous responses.

**Tested scenarios**
3DS1 failed payments do not cancel the newly created order.
Authorization Success False notifications do cancel the order

**Fixed issue**:  PW-2174
#488