### PR TITLE
[PW-2257] Check availability of userAgent and acceptHeader before assigning

### DIFF
--- a/Helper/Requests.php
+++ b/Helper/Requests.php
@@ -288,10 +288,13 @@ class Requests extends AbstractHelper
      */
     public function buildBrowserData($request = [])
     {
-        $request['browserInfo'] = [
-            'userAgent' => $_SERVER['HTTP_USER_AGENT'],
-            'acceptHeader' => $_SERVER['HTTP_ACCEPT']
-        ];
+        if (!empty($_SERVER['HTTP_USER_AGENT'])) {
+            $request['browserInfo']['userAgent'] = $_SERVER['HTTP_USER_AGENT'];
+        }
+
+        if (!empty($_SERVER['HTTP_ACCEPT'])) {
+            $request['browserInfo']['acceptHeader'] = $_SERVER['HTTP_ACCEPT'];
+        }
 
         return $request;
     }
@@ -324,7 +327,7 @@ class Requests extends AbstractHelper
             $request['origin'] = $this->adyenHelper->getOrigin();
             $request['channel'] = 'web';
         }
-        
+
         return $request;
     }
 


### PR DESCRIPTION
**Description**
The required browserInfo details are missing if the process is started by a cron job, therefore we need to check if the userAgent and acceptHeader value is not empty and only send it then. Otherwise leave these fields out of the request.

**Fixed issue**:  <!-- #-prefixed issue number -->
#673