### PR TITLE
Fix order payment status on non-3DS orders

### DIFF
--- a/Model/AdyenOrderPaymentStatus.php
+++ b/Model/AdyenOrderPaymentStatus.php
@@ -75,8 +75,8 @@ class AdyenOrderPaymentStatus implements \Adyen\Payment\Api\AdyenOrderPaymentSta
         ) {
             $additionalInformation = $payment->getAdditionalInformation();
             return $this->adyenHelper->buildThreeDS2ProcessResponseJson(
-                $additionalInformation['threeDSType'],
-                $additionalInformation['threeDS2Token']
+                isset($additionalInformation['threeDSType']) ? $additionalInformation['threeDSType'] : null,
+                isset($additionalInformation['threeDS2Token']) ? $additionalInformation['threeDS2Token'] : null
             );
         }
         return true;


### PR DESCRIPTION
If an order is made with Credit Card but without 3DS information required, the indexes `threeDSType` and `threeDS2Token` might not exist. To prevent PHP throwing a notice, we need to check if these values exist before trying to read them.
