### PR TITLE
[PW-2264]: New data builder for LPMs to include storePaymentMethod flag based on configuration

### DIFF
--- a/Gateway/Request/RecurringAlternativePaymentMethodsDataBuilder.php
+++ b/Gateway/Request/RecurringAlternativePaymentMethodsDataBuilder.php
@@ -65,8 +65,10 @@ class RecurringAlternativePaymentMethodsDataBuilder implements BuilderInterface
         $storeId = $payment->getOrder()->getStoreId();
         $areaCode = $this->appState->getAreaCode();
         $additionalInformation = $payment->getAdditionalInformation();
-        $request['body'] = $this->adyenRequestsHelper->buildRecurringAlternativePaymentMethodsData([], $areaCode,
-            $storeId, $additionalInformation);
+        $request['body'] = $this->adyenRequestsHelper->buildRecurringAlternativePaymentMethodsData(
+            [],
+            $areaCode,
+            $storeId);
         return $request;
     }
 }

--- a/Gateway/Request/RecurringAlternativePaymentMethodsDataBuilder.php
+++ b/Gateway/Request/RecurringAlternativePaymentMethodsDataBuilder.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2015 Adyen BV (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\Payment\Gateway\Request;
+
+use Magento\Payment\Gateway\Request\BuilderInterface;
+
+class RecurringAlternativePaymentMethodsDataBuilder implements BuilderInterface
+{
+    /**
+     * @var \Magento\Framework\App\State
+     */
+    private $appState;
+
+    /**
+     * @var \Adyen\Payment\Helper\Requests
+     */
+    private $adyenRequestsHelper;
+
+    /**
+     * RecurringDataBuilder constructor.
+     *
+     * @param \Magento\Framework\Model\Context $context
+     * @param \Adyen\Payment\Helper\Requests $adyenRequestsHelper
+     */
+    public function __construct(
+        \Magento\Framework\Model\Context $context,
+        \Adyen\Payment\Helper\Requests $adyenRequestsHelper
+    ) {
+        $this->appState = $context->getAppState();
+        $this->adyenRequestsHelper = $adyenRequestsHelper;
+    }
+
+
+    /**
+     * @param array $buildSubject
+     * @return array
+     * @throws \Magento\Framework\Exception\LocalizedException
+     */
+    public function build(array $buildSubject)
+    {
+        /** @var \Magento\Payment\Gateway\Data\PaymentDataObject $paymentDataObject */
+        $paymentDataObject = \Magento\Payment\Gateway\Helper\SubjectReader::readPayment($buildSubject);
+        $payment = $paymentDataObject->getPayment();
+        $storeId = $payment->getOrder()->getStoreId();
+        $areaCode = $this->appState->getAreaCode();
+        $additionalInformation = $payment->getAdditionalInformation();
+        $request['body'] = $this->adyenRequestsHelper->buildRecurringAlternativePaymentMethodsData([], $areaCode,
+            $storeId, $additionalInformation);
+        return $request;
+    }
+}

--- a/Helper/Requests.php
+++ b/Helper/Requests.php
@@ -373,7 +373,7 @@ class Requests extends AbstractHelper
      * @param $storeId
      * @param $payment
      */
-    public function buildRecurringAlternativePaymentMethodsData($request = [], $areaCode, int $storeId, $additionalData)
+    public function buildRecurringAlternativePaymentMethodsData($request = [], $areaCode, int $storeId)
     {
 
         if ($areaCode !== \Magento\Backend\App\Area\FrontNameResolver::AREA_CODE) {

--- a/Helper/Requests.php
+++ b/Helper/Requests.php
@@ -324,7 +324,7 @@ class Requests extends AbstractHelper
             $request['origin'] = $this->adyenHelper->getOrigin();
             $request['channel'] = 'web';
         }
-        
+
         return $request;
     }
 
@@ -362,6 +362,30 @@ class Requests extends AbstractHelper
             if (!empty($additionalData[AdyenCcDataAssignObserver::STORE_CC])) {
                 $request['paymentMethod']['storeDetails'] = true;
             }
+        }
+
+        return $request;
+    }
+
+    /**
+     * @param $request
+     * @param $areaCode
+     * @param $storeId
+     * @param $payment
+     */
+    public function buildRecurringAlternativePaymentMethodsData($request = [], $areaCode, int $storeId, $additionalData)
+    {
+
+        if ($areaCode !== \Magento\Backend\App\Area\FrontNameResolver::AREA_CODE) {
+            $storeId = null;
+        }
+
+        $enableStorePaymentMethod = $this->adyenHelper->getAdyenAbstractConfigData('stored_local_payments_active', $storeId);
+
+        if ($enableStorePaymentMethod) {
+            $request['storePaymentMethod'] = true;
+        } else {
+            $request['storePaymentMethod'] = false;
         }
 
         return $request;

--- a/etc/adminhtml/system/payment_methods/local_payment_methods/stored_payment_method_details.xml
+++ b/etc/adminhtml/system/payment_methods/local_payment_methods/stored_payment_method_details.xml
@@ -24,7 +24,7 @@
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_file.xsd">
     <label>Stored payment method details options</label>
-    <comment><![CDATA[Adyen can securely store shoppers' local payment method details to enable recurring payments. See which local payment methods support recurring on <a href="https://docs.adyen.com/payment-methods#cash-and-atm-payment-methods" target="_blank">Adyen documentation</a>.]]]></comment>
+    <comment><![CDATA[Adyen can securely store shoppers' local payment method details to enable recurring payments. See which local payment methods support recurring on <a href="https://docs.adyen.com/payment-methods#cash-and-atm-payment-methods" target="_blank">Adyen documentation</a>.]]></comment>
 
     <field id="active" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
         <label>Enabled</label>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -620,7 +620,7 @@
                 <item name="address" xsi:type="string">Adyen\Payment\Gateway\Request\AddressDataBuilder</item>
                 <item name="payment" xsi:type="string">Adyen\Payment\Gateway\Request\PaymentDataBuilder</item>
                 <item name="browserinfo" xsi:type="string">Adyen\Payment\Gateway\Request\BrowserInfoDataBuilder</item>
-                <item name="recurring" xsi:type="string">Adyen\Payment\Gateway\Request\RecurringDataBuilder</item>
+                <item name="recurring" xsi:type="string">Adyen\Payment\Gateway\Request\RecurringAlternativePaymentMethodsDataBuilder</item>
                 <item name="transaction" xsi:type="string">Adyen\Payment\Gateway\Request\CheckoutDataBuilder</item>
             </argument>
         </arguments>


### PR DESCRIPTION
**Description**
For the new stored_local_payments_active we're implementing a new data builder that includes the storePaymentMethod in the /payments request based on the value of that config field.

**Tested scenarios**
Payment using alternative payment methods with the stored_local_payments_active enabled/disabled sends a payment request with storePaymentMethod true/false

**Fixed issue**:  PW-2264