### PR TITLE
[FIX]: Rewriting CC types objects in expected format

### DIFF
--- a/Helper/CardAvailableTypes.php
+++ b/Helper/CardAvailableTypes.php
@@ -62,7 +62,11 @@ class CardAvailableTypes extends AbstractHelper
         $availableTypes = explode(',', $availableTypes);
         foreach (array_keys($cardTypes) as $code) {
             if (in_array($code, $availableTypes)) {
-                $types[$code] = $cardTypes[$code][$index];
+                if (strcmp($index, 'name') === 0) {
+                    $types[$code] = $cardTypes[$code][$index];
+                } elseif (strcmp($index, 'code_alt') === 0) {
+                    $types[$cardTypes[$code][$index]] = $code;
+                }
             }
         }
 

--- a/Test/Unit/Helper/CardAvailableTypesTest.php
+++ b/Test/Unit/Helper/CardAvailableTypesTest.php
@@ -106,9 +106,9 @@ class CardAvailableTypesTest extends \PHPUnit\Framework\TestCase
             array(
                 'code_alt',
                 [
-                    'AE' => 'amex',
-                    'VI' => 'visa',
-                    'DI' => 'discover',
+                    'amex' => 'AE',
+                    'visa' => 'VI',
+                    'discover' => 'DI',
                 ]
 
             )

--- a/etc/adminhtml/system/payment_methods/cards/advanced_options.xml
+++ b/etc/adminhtml/system/payment_methods/cards/advanced_options.xml
@@ -29,7 +29,7 @@
         <source_model>Adyen\Payment\Model\Config\Source\AcceptedCardTypes</source_model>
         <config_path>payment/adyen_cc/enablecctypes</config_path>
     </field>
-    <field id="cctypes" translate="label" type="multiselect" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="0">
+    <field id="cctypes" translate="label" type="multiselect" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
         <depends>
             <field id="enable_card_types">1</field>
         </depends>


### PR DESCRIPTION
**Description**
The new CardAvailableTypes helper was not outputting the card type objects in the correct format when requested with Alt codes, I've rewritten the function to fix this. Additionally, the cctypes config field has been made available for storeview scopes.

**Tested scenarios**
Call of the getCardAvailableTypes() function for alt codes and names returns the object in the format outputted by the deprecated functions getCcAvailableTypesByAlt() and getCcAvailableTypes()

**Fixed issue**:  None