### PR TITLE
Implementing new installments config field and removing old validation code

### DIFF
--- a/Gateway/Validator/InstallmentValidator.php
+++ b/Gateway/Validator/InstallmentValidator.php
@@ -40,11 +40,6 @@ class InstallmentValidator extends AbstractValidator
     private $adyenHelper;
 
     /**
-     * @var \Magento\Framework\Serialize\SerializerInterface
-     */
-    private $serializer;
-
-    /**
      * @var \Magento\Quote\Model\QuoteRepository
      */
     private $quoteRepository;
@@ -54,20 +49,17 @@ class InstallmentValidator extends AbstractValidator
      * @param \Magento\Payment\Gateway\Validator\ResultInterfaceFactory $resultFactory
      * @param \Adyen\Payment\Logger\AdyenLogger $adyenLogger
      * @param \Adyen\Payment\Helper\Data $adyenHelper
-     * @param \Magento\Framework\Serialize\SerializerInterface $serializer
      * @param \Magento\Quote\Model\QuoteRepository $quoteRepository
      */
     public function __construct(
         \Magento\Payment\Gateway\Validator\ResultInterfaceFactory $resultFactory,
         \Adyen\Payment\Logger\AdyenLogger $adyenLogger,
         \Adyen\Payment\Helper\Data $adyenHelper,
-        \Magento\Framework\Serialize\SerializerInterface $serializer,
         \Magento\Quote\Model\QuoteRepository $quoteRepository
 
     ) {
         $this->adyenLogger = $adyenLogger;
         $this->adyenHelper = $adyenHelper;
-        $this->serializer = $serializer;
         $this->quoteRepository = $quoteRepository;
         parent::__construct($resultFactory);
     }
@@ -88,27 +80,14 @@ class InstallmentValidator extends AbstractValidator
         $installmentsEnabled = $this->adyenHelper->getAdyenCcConfigData('enable_installments');
         if ($quote && $installmentsEnabled) {
             $grandTotal = $quote->getGrandTotal();
-            $installmentsAvailable = $this->adyenHelper->getAdyenCcConfigData('installments');
+            $installments = $this->adyenHelper->getAdyenCcConfigData('installments');
             $installmentSelected = $payment->getAdditionalInformation('number_of_installments');
             $ccType = $payment->getAdditionalInformation('cc_type');
-            if ($installmentsAvailable) {
-                $installments = $this->serializer->unserialize($installmentsAvailable);
-            }
             if ($installmentSelected && $installmentsAvailable) {
                 $isValid = false;
                 $fails[] = __('Installments not valid.');
                 if ($installments) {
-                    foreach ($installments as $ccTypeInstallment => $installment) {
-                        if ($ccTypeInstallment == $ccType) {
-                            foreach ($installment as $amount => $installmentsData) {
-                                if ($installmentSelected == $installmentsData) {
-                                    if ($grandTotal >= $amount) {
-                                        $isValid = true;
-                                    }
-                                }
-                            }
-                        }
-                    }
+                    //TODO how implement custom validation of generated installments code against selected value?
                 }
             }
         }

--- a/Model/Ui/AdyenCcConfigProvider.php
+++ b/Model/Ui/AdyenCcConfigProvider.php
@@ -70,11 +70,6 @@ class AdyenCcConfigProvider implements ConfigProviderInterface
     private $storeManager;
 
     /**
-     * @var \Magento\Framework\Serialize\SerializerInterface
-     */
-    private $serializer;
-
-    /**
      * AdyenCcConfigProvider constructor.
      *
      * @param \Magento\Payment\Helper\Data $paymentHelper
@@ -84,7 +79,6 @@ class AdyenCcConfigProvider implements ConfigProviderInterface
      * @param \Magento\Framework\View\Asset\Source $assetSource
      * @param \Magento\Store\Model\StoreManagerInterface $storeManager
      * @param \Magento\Payment\Model\CcConfig $ccConfig
-     * @param \Magento\Framework\Serialize\SerializerInterface $serializer
      */
     public function __construct(
         \Magento\Payment\Helper\Data $paymentHelper,
@@ -93,8 +87,7 @@ class AdyenCcConfigProvider implements ConfigProviderInterface
         \Magento\Framework\UrlInterface $urlBuilder,
         \Magento\Framework\View\Asset\Source $assetSource,
         \Magento\Store\Model\StoreManagerInterface $storeManager,
-        \Magento\Payment\Model\CcConfig $ccConfig,
-        \Magento\Framework\Serialize\SerializerInterface $serializer
+        \Magento\Payment\Model\CcConfig $ccConfig
     ) {
         $this->_paymentHelper = $paymentHelper;
         $this->_adyenHelper = $adyenHelper;
@@ -103,7 +96,6 @@ class AdyenCcConfigProvider implements ConfigProviderInterface
         $this->_assetSource = $assetSource;
         $this->ccConfig = $ccConfig;
         $this->storeManager = $storeManager;
-        $this->serializer = $serializer;
     }
 
     /**
@@ -163,7 +155,7 @@ class AdyenCcConfigProvider implements ConfigProviderInterface
         $installments = $this->_adyenHelper->getAdyenCcConfigData('installments');
 
         if ($installmentsEnabled && $installments) {
-            $config['payment']['adyenCc']['installments'] = $this->serializer->unserialize($installments);
+            $config['payment']['adyenCc']['installments'] = $installments;
             $config['payment']['adyenCc']['hasInstallments'] = true;
         } else {
             $config['payment']['adyenCc']['installments'] = [];

--- a/etc/adminhtml/system/adyen_cc.xml
+++ b/etc/adminhtml/system/adyen_cc.xml
@@ -77,20 +77,17 @@
                 <tooltip>Enable installments for each credit card type.</tooltip>
                 <config_path>payment/adyen_cc/enable_installments</config_path>
             </field>
-            <field id="installments" translate="label" sortOrder="220" showInDefault="1" showInWebsite="1"
-                   showInStore="1">
+            <field id="installments" type="textarea" translate="label" sortOrder="220" showInDefault="1"
+                   showInWebsite="1" showInStore="1">
                 <label>Installments</label>
                 <depends>
                     <field id="enable_installments">1</field>
                 </depends>
-                <tooltip>Configure your installment for each credit card type: Insert the minimum amount required to
-                    make the configured installment available in the amount range column.
-                    Example: if the amount range is configured to 100 and the number of installments to 4x, the shopper
-                    will see the 4x option only if the payment total is higher or equal than 100.
-                </tooltip>
-                <frontend_model>Adyen\Payment\Block\Adminhtml\System\Config\Field\Installments</frontend_model>
-                <backend_model>Adyen\Payment\Model\Config\Backend\Installments</backend_model>
-                <config_path>payment/adyen_cc/installments</config_path>
+                <validate>required-entry</validate>
+                <comment><![CDATA[
+                    Generate the desired installments configuration <a href="">here</a> and paste it on this field.
+                ]]></comment>
+                <config_path>payment/adyen_cc/installments_code</config_path>
             </field>
         </group>
 

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -989,11 +989,6 @@
             <argument name="serializer" xsi:type="object">Magento\Framework\Serialize\Serializer\Serialize</argument>
         </arguments>
     </type>
-    <type name="Adyen\Payment\Gateway\Validator\InstallmentValidator">
-        <arguments>
-            <argument name="serializer" xsi:type="object">Magento\Framework\Serialize\Serializer\Serialize</argument>
-        </arguments>
-    </type>
     <type name="Adyen\Payment\Model\Ui\AdyenPosCloudConfigProvider">
         <arguments>
             <argument name="serializer" xsi:type="object">Magento\Framework\Serialize\Serializer\Serialize</argument>


### PR DESCRIPTION
**Description**
We're implementing a new config field that will hold the generated code for installments instead of the serialize value created by the old row UI. The serializer DI has been removed from some places as it doesn't have application now. The installments validation needs to be implemented when this new logic has been figured out.

Backwards compatibility is breaking: Installments needs to be reconfigured and saved!