### PR TITLE
[PW-2360]: Removing decode of paywithgoogle.token, expected format is JSON string

### DIFF
--- a/Gateway/Request/GooglePayAuthorizationDataBuilder.php
+++ b/Gateway/Request/GooglePayAuthorizationDataBuilder.php
@@ -63,9 +63,8 @@ class GooglePayAuthorizationDataBuilder implements BuilderInterface
         $requestBody['paymentMethod']['type'] = 'paywithgoogle';
         // get payment data
         if ($token) {
-            $parsedToken = json_decode($token);
             try {
-                $requestBody['paymentMethod']['paywithgoogle.token'] = $parsedToken;
+                $requestBody['paymentMethod']['paywithgoogle.token'] = $token;
             } catch (\Exception $exception) {
                 $this->adyenLogger->addAdyenDebug("exception: " . $exception->getMessage());
             }


### PR DESCRIPTION
**Description**
Logging of sensitive parameters failed when using Google Pay, the paywithgoogle.token variable contained an object that could not be logged as string. Since the service expects this parameter to be a JSON string the previous parsing is being removed.

**Tested scenarios**
Payment with Google Pay on live and test mode

**Fixed issue**: PW-2360