### PR TITLE
[PW-2070]: payment_authorized_virtual migration script

### DIFF
--- a/Setup/UpgradeData.php
+++ b/Setup/UpgradeData.php
@@ -395,7 +395,6 @@ class UpgradeData implements UpgradeDataInterface
          * The default scope is then checked as well.
          */
         $stores = $this->storeManager->getStores();
-        $scopes = [];
         foreach ($stores as $store) {
 
             $select = $connection->select()


### PR DESCRIPTION
**Description**
Since we're setting a new default value for payment_authorized_virtual in config.xml we want to make sure that instances where this field was not set before do not set it accidentally when saving the admin form.

For this we're checking every store and scope to set the value to null where there is no previous selection.

UpgradeData.php functions also run during the module's installation so we're checking if $context->getVersion() is empty before running the new UI migration scripts.

**Tested scenarios**
Module installation does not run the migration scripts.
Module upgrade sets payment_authorized_virtual to null on scopes where there was no previous selection.
Preselected values are left unchanged.

**Fixed issue**:  PW-2070