### PR TITLE
[PW-2382]: Checking if the _order object is set before attempting to add comment

### DIFF
--- a/Model/Cron.php
+++ b/Model/Cron.php
@@ -1965,7 +1965,9 @@ class Cron
     private function addNotificationErrorComment($errorMessage)
     {
         $comment = __('The order failed to update: %1', $errorMessage);
-        $this->_order->addStatusHistoryComment($comment);
-        $this->_order->save();
+        if ($this->_order) {
+            $this->_order->addStatusHistoryComment($comment);
+            $this->_order->save();
+        }
     }
 }


### PR DESCRIPTION
**Description**
In some cases the notification processing fails before the _order object is set, this causes the cron process to quit before it is completed.

**Tested scenarios**
Throwing exception before the _order is set does not interrupt the cron process.

**Fixed issue**:  PW-2382