### PR TITLE
[PW-2379]: Declaring configuration values as sensitive or system-specific

### DIFF
--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1047,4 +1047,34 @@
             <argument name="resourceModel" xsi:type="string">Adyen\Payment\Model\ResourceModel\Notification</argument>
         </arguments>
     </virtualType>
+
+    <!--Sensitive and system-specific configuration-->
+    <type name="Magento\Config\Model\Config\TypePool">
+        <arguments>
+            <argument name="environment" xsi:type="array">
+                <item name="payment/adyen_abstract/demo_mode" xsi:type="string">1</item>
+                <item name="payment/adyen_abstract/debug" xsi:type="string">1</item>
+                <item name="payment/adyen_apple_pay/full_path_location_pem_file_test" xsi:type="string">1</item>
+                <item name="payment/adyen_apple_pay/full_path_location_pem_file_live" xsi:type="string">1</item>
+            </argument>
+            <argument name="sensitive" xsi:type="array">
+                <item name="payment/adyen_abstract/merchant_account" xsi:type="string">1</item>
+                <item name="payment/adyen_abstract/api_key_test" xsi:type="string">1</item>
+                <item name="payment/adyen_abstract/api_key_live" xsi:type="string">1</item>
+                <item name="payment/adyen_abstract/notification_username" xsi:type="string">1</item>
+                <item name="payment/adyen_abstract/notification_password" xsi:type="string">1</item>
+                <item name="payment/adyen_abstract/live_endpoint_url_prefix" xsi:type="string">1</item>
+                <item name="payment/adyen_pos_cloud/pos_merchant_account" xsi:type="string">1</item>
+                <item name="payment/adyen_pos_cloud/api_key_test" xsi:type="string">1</item>
+                <item name="payment/adyen_pos_cloud/api_key_live" xsi:type="string">1</item>
+                <item name="payment/adyen_pos_cloud/pos_store_id" xsi:type="string">1</item>
+                <item name="payment/adyen_pay_by_mail/skin_code" xsi:type="string">1</item>
+                <item name="payment/adyen_pay_by_mail/hmac_test" xsi:type="string">1</item>
+                <item name="payment/adyen_pay_by_mail/hmac_live" xsi:type="string">1</item>
+                <item name="payment/adyen_apple_pay/merchant_identifier_test" xsi:type="string">1</item>
+                <item name="payment/adyen_apple_pay/merchant_identifier_live" xsi:type="string">1</item>
+                <item name="payment/adyen_google_pay/merchant_identifier" xsi:type="string">1</item>
+            </argument>
+        </arguments>
+    </type>
 </config>


### PR DESCRIPTION
**Description**
On multi-environment setups the app:config:dump feature can be used to sync configuration between instances. The configuration values are being declared as sensitive or system-specific so the correct data is persisted on config.php and env.php.

**Tested scenarios**
app:config:dump persists sensitive data to env.php and system-specific to config.php

**Fixed issue**:  PW-2379 Solves #703 