### PR TITLE
Adjusting last name variable for boleto payments

### DIFF
--- a/Gateway/Request/CheckoutDataBuilder.php
+++ b/Gateway/Request/CheckoutDataBuilder.php
@@ -156,8 +156,8 @@ class CheckoutDataBuilder implements BuilderInterface
             $requestBody['shopperName']['firstName'] = $payment->getAdditionalInformation("firstname");
         }
 
-        if ($payment->getAdditionalInformation("lastName")) {
-            $requestBody['shopperName']['lastName'] = $payment->getAdditionalInformation("lastName");
+        if ($payment->getAdditionalInformation("lastname")) {
+            $requestBody['shopperName']['lastName'] = $payment->getAdditionalInformation("lastname");
         }
 
         if ($payment->getMethod() == \Adyen\Payment\Model\Ui\AdyenBoletoConfigProvider::CODE) {


### PR DESCRIPTION
**Description**
The checkout data builder was checking and assigning the billing address `lastName` instead of the boleto `lastname`. This caused boleto payments to send incorrect data.

**Tested scenarios**
Boleto payment sends `lastname` from the payment form instead of using the billing address `lastName`

**Fixed issue**:  Closes #714 