### PR TITLE
[PW-2385] - Use mandatory HMAC validation for notifications

### DIFF
--- a/Controller/Process/Json.php
+++ b/Controller/Process/Json.php
@@ -214,11 +214,11 @@ class Json extends \Magento\Framework\App\Action\Action
                 return false;
             }
 
-            if ($this->_isHmacSupportedEventCode($response)) {
+            if ($this->hmacSignature->isHmacSupportedEventCode($response)) {
                 //Validate the Hmac calculation
                 if (!$this->hmacSignature->isValidNotificationHMAC($this->configHelper->getNotificationsHmacKey(),
                     $response)) {
-                    $this->_adyenLogger->addAdyenNotification('HMAC key validation failed '. print_r($response, 1));
+                    $this->_adyenLogger->addAdyenNotification('HMAC key validation failed ' . print_r($response, 1));
                     return false;
                 }
             }
@@ -449,27 +449,5 @@ class Json extends \Magento\Framework\App\Action\Action
             ->setHeader('Content-Type', 'text/html')
             ->setBody($message);
         return;
-    }
-
-    /**
-     * Returns true when the event code support HMAC validation
-     *
-     * @param $response
-     */
-    protected function _isHmacSupportedEventCode($response)
-    {
-        $eventCodes = array("ADVICE_OF_DEBIT","AUTHORISATION","AUTHORISATION_PENDING","AUTHORISE_REFERRAL","CANCELLATION",
-            "CANCEL_OR_REFUND", "CAPTURE","CAPTURE_FAILED","CAPTURE_WITH_EXTERNAL_AUTH","CHARGEBACK","CHARGEBACK_REVERSED",
-            "DEACTIVATE_RECURRING","FRAUD_ONLY","FUND_TRANSFER","HANDLED_EXTERNALLY","MANUAL_REVIEW_ACCEPT","NOTIFICATION_OF_CHARGEBACK",
-            "NOTIFICATION_OF_FRAUD", "OFFER_CLOSED","ORDER_OPENED","PAIDOUT_REVERSED","PAYOUT_DECLINE","PAYOUT_EXPIRE","PAYOUT_THIRDPARTY",
-             "PREARBITRATION_LOST","PREARBITRATION_WON","PROCESS_RETRY","RECURRING_CONTRACT","REFUND","REFUNDED_REVERSED","REFUND_FAILED",
-            "REFUND_WITH_DATA", "REQUEST_FOR_INFORMATION","SECOND_CHARGEBACK","SUBMIT_RECURRING","VOID_PENDING_REFUND",
-            "POSTPONED_REFUND","TECHNICAL_CANCEL","AUTHORISATION_ADJUSTMENT","CANCEL_AUTORESCUE","AUTORESCUE");
-        if (array_key_exists('eventCode', $response)) {
-            if (in_array($response['eventCode'], $eventCodes)) {
-                return true;
-            }
-        }
-        return false;
     }
 }

--- a/Controller/Process/Json.php
+++ b/Controller/Process/Json.php
@@ -218,12 +218,9 @@ class Json extends \Magento\Framework\App\Action\Action
                 //Validate the Hmac calculation
                 if (!$this->hmacSignature->isValidNotificationHMAC($this->configHelper->getNotificationsHmacKey(),
                     $response)) {
-                    $this->_adyenLogger->addAdyenNotification('HMAC key validation failed');
+                    $this->_adyenLogger->addAdyenNotification('HMAC key validation failed '. print_r($response, 1));
                     return false;
                 }
-                $this->_adyenLogger->addAdyenNotification('In the list');
-            }else{
-                $this->_adyenLogger->addAdyenNotification('Event code not in my array');
             }
         }
 

--- a/Controller/Process/Json.php
+++ b/Controller/Process/Json.php
@@ -214,10 +214,16 @@ class Json extends \Magento\Framework\App\Action\Action
                 return false;
             }
 
-            //Validate the Hmac calculation
-            if (!$this->hmacSignature->isValidNotificationHMAC($this->configHelper->getNotificationsHmacKey(), $response)) {
-                $this->_adyenLogger->addAdyenNotification('HMAC key validation failed');
-                return false;
+            if ($this->_isHmacSupportedEventCode($response)) {
+                //Validate the Hmac calculation
+                if (!$this->hmacSignature->isValidNotificationHMAC($this->configHelper->getNotificationsHmacKey(),
+                    $response)) {
+                    $this->_adyenLogger->addAdyenNotification('HMAC key validation failed');
+                    return false;
+                }
+                $this->_adyenLogger->addAdyenNotification('In the list');
+            }else{
+                $this->_adyenLogger->addAdyenNotification('Event code not in my array');
             }
         }
 
@@ -446,5 +452,27 @@ class Json extends \Magento\Framework\App\Action\Action
             ->setHeader('Content-Type', 'text/html')
             ->setBody($message);
         return;
+    }
+
+    /**
+     * Returns true when the event code support HMAC validation
+     *
+     * @param $response
+     */
+    protected function _isHmacSupportedEventCode($response)
+    {
+        $eventCodes = array("ADVICE_OF_DEBIT","AUTHORISATION","AUTHORISATION_PENDING","AUTHORISE_REFERRAL","CANCELLATION",
+            "CANCEL_OR_REFUND", "CAPTURE","CAPTURE_FAILED","CAPTURE_WITH_EXTERNAL_AUTH","CHARGEBACK","CHARGEBACK_REVERSED",
+            "DEACTIVATE_RECURRING","FRAUD_ONLY","FUND_TRANSFER","HANDLED_EXTERNALLY","MANUAL_REVIEW_ACCEPT","NOTIFICATION_OF_CHARGEBACK",
+            "NOTIFICATION_OF_FRAUD", "OFFER_CLOSED","ORDER_OPENED","PAIDOUT_REVERSED","PAYOUT_DECLINE","PAYOUT_EXPIRE","PAYOUT_THIRDPARTY",
+             "PREARBITRATION_LOST","PREARBITRATION_WON","PROCESS_RETRY","RECURRING_CONTRACT","REFUND","REFUNDED_REVERSED","REFUND_FAILED",
+            "REFUND_WITH_DATA", "REQUEST_FOR_INFORMATION","SECOND_CHARGEBACK","SUBMIT_RECURRING","VOID_PENDING_REFUND",
+            "POSTPONED_REFUND","TECHNICAL_CANCEL","AUTHORISATION_ADJUSTMENT","CANCEL_AUTORESCUE","AUTORESCUE");
+        if (array_key_exists('eventCode', $response)) {
+            if (in_array($response['eventCode'], $eventCodes)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -109,14 +109,14 @@ class Config
     {
         $key = "";
         if ($this->adyenHelper->isDemoMode($storeId)) {
-            $key = (string)$this->getConfigData(
+            $key = $this->getConfigData(
                 self::XML_NOTIFICATIONS_HMAC_KEY_TEST,
                 self::XML_ADYEN_ABSTRACT_PREFIX,
                 $storeId,
                 false
             );
         } else {
-            $key = (string)$this->getConfigData(
+            $key = $this->getConfigData(
                 self::XML_NOTIFICATIONS_HMAC_KEY_LIVE,
                 self::XML_ADYEN_ABSTRACT_PREFIX,
                 $storeId,

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -24,6 +24,7 @@
 namespace Adyen\Payment\Helper;
 
 use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\Encryption\EncryptorInterface;
 
 class Config
 {
@@ -32,6 +33,7 @@ class Config
     const XML_ADYEN_ABSTRACT_PREFIX = "adyen_abstract";
     const XML_NOTIFICATIONS_CAN_CANCEL_FIELD = "notifications_can_cancel";
     const XML_NOTIFICATIONS_IP_HMAC_CHECK = "notifications_ip_hmac_check";
+    const XML_NOTIFICATIONS_HMAC_KEY = "notification_hmac_key";
 
     /**
      * @var Magento\Framework\App\Config\ScopeConfigInterface
@@ -39,13 +41,20 @@ class Config
     protected $scopeConfig;
 
     /**
+     * @var EncryptorInterface
+     */
+    private $encryptor;
+
+    /**
      * Config constructor.
      * @param Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
      */
     public function __construct(
-        ScopeConfigInterface $scopeConfig
+        ScopeConfigInterface $scopeConfig,
+        EncryptorInterface $encryptor
     ) {
         $this->scopeConfig = $scopeConfig;
+        $this->encryptor = $encryptor;
     }
 
     /**
@@ -80,6 +89,22 @@ class Config
         );
     }
 
+    /**
+     * Retrieve key for notifications_hmac_key
+     *
+     * @param int $storeId
+     * @return string
+     */
+    public function getNotificationsHmacKey($storeId = null)
+    {
+        $key = (string)$this->getConfigData(
+            self::XML_NOTIFICATIONS_HMAC_KEY,
+            self::XML_ADYEN_ABSTRACT_PREFIX,
+            $storeId,
+            false
+        );
+        return $this->encryptor->decrypt(trim($key));
+    }
     /**
      * Retrieve information from payment configuration
      *

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -99,7 +99,6 @@ class Config
      */
     public function getNotificationsHmacKey($storeId = null)
     {
-        $key = "";
         if ($this->isDemoMode($storeId)) {
             $key = $this->getConfigData(
                 self::XML_NOTIFICATIONS_HMAC_KEY_TEST,
@@ -125,7 +124,7 @@ class Config
      */
     public function isDemoMode($storeId = null)
     {
-        return $this->getConfigData('demo_mode', 'adyen_abstract', $storeId, true);
+        return $this->getConfigData('demo_mode', self::XML_ADYEN_ABSTRACT_PREFIX, $storeId, true);
     }
 
     /**

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -47,24 +47,16 @@ class Config
     private $encryptor;
 
     /**
-     * @var \Adyen\Payment\Helper\Data
-     */
-    private $adyenHelper;
-
-    /**
      * Config constructor.
      * @param Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
      * @param EncryptorInterface $encryptor
-     * @param \Adyen\Payment\Helper\Data $adyenHelper
      */
     public function __construct(
         ScopeConfigInterface $scopeConfig,
-        EncryptorInterface $encryptor,
-        \Adyen\Payment\Helper\Data $adyenHelper
+        EncryptorInterface $encryptor
     ) {
         $this->scopeConfig = $scopeConfig;
         $this->encryptor = $encryptor;
-        $this->adyenHelper = $adyenHelper;
     }
 
     /**
@@ -108,7 +100,7 @@ class Config
     public function getNotificationsHmacKey($storeId = null)
     {
         $key = "";
-        if ($this->adyenHelper->isDemoMode($storeId)) {
+        if ($this->isDemoMode($storeId)) {
             $key = $this->getConfigData(
                 self::XML_NOTIFICATIONS_HMAC_KEY_TEST,
                 self::XML_ADYEN_ABSTRACT_PREFIX,
@@ -125,6 +117,17 @@ class Config
         }
         return $this->encryptor->decrypt(trim($key));
     }
+    /**
+     * Returns true if the enviroment is set to test, false for live
+     *
+     * @param int $storeId
+     * @return bool
+     */
+    public function isDemoMode($storeId = null)
+    {
+        return $this->getConfigData('demo_mode', 'adyen_abstract', $storeId, true);
+    }
+
     /**
      * Retrieve information from payment configuration
      *

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -35,7 +35,6 @@ class Config
     const XML_NOTIFICATIONS_IP_HMAC_CHECK = "notifications_ip_hmac_check";
     const XML_NOTIFICATIONS_HMAC_KEY_LIVE = "notification_hmac_key_live";
     const XML_NOTIFICATIONS_HMAC_KEY_TEST = "notification_hmac_key_test";
-    const XML_DEMO_MODE = 'demo_mode';
 
     /**
      * @var Magento\Framework\App\Config\ScopeConfigInterface
@@ -48,16 +47,24 @@ class Config
     private $encryptor;
 
     /**
+     * @var \Adyen\Payment\Helper\Data
+     */
+    private $adyenHelper;
+
+    /**
      * Config constructor.
      * @param Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
      * @param EncryptorInterface $encryptor
+     * @param \Adyen\Payment\Helper\Data $adyenHelper
      */
     public function __construct(
         ScopeConfigInterface $scopeConfig,
-        EncryptorInterface $encryptor
+        EncryptorInterface $encryptor,
+        \Adyen\Payment\Helper\Data $adyenHelper
     ) {
         $this->scopeConfig = $scopeConfig;
         $this->encryptor = $encryptor;
+        $this->adyenHelper = $adyenHelper;
     }
 
     /**
@@ -100,7 +107,7 @@ class Config
      */
     public function getNotificationsHmacKey($storeId = null)
     {
-        if ($this->isDemoMode($storeId)) {
+        if ($this->adyenHelper->isDemoMode($storeId)) {
             $key = $this->getConfigData(
                 self::XML_NOTIFICATIONS_HMAC_KEY_TEST,
                 self::XML_ADYEN_ABSTRACT_PREFIX,
@@ -117,17 +124,7 @@ class Config
         }
         return $this->encryptor->decrypt(trim($key));
     }
-    /**
-     * Returns true if the enviroment is set to test, false for live
-     *
-     * @param int $storeId
-     * @return bool
-     */
-    public function isDemoMode($storeId = null)
-    {
-        return $this->getConfigData(self::XML_DEMO_MODE, self::XML_ADYEN_ABSTRACT_PREFIX, $storeId, true);
-    }
-
+   
     /**
      * Retrieve information from payment configuration
      *

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -35,6 +35,7 @@ class Config
     const XML_NOTIFICATIONS_IP_HMAC_CHECK = "notifications_ip_hmac_check";
     const XML_NOTIFICATIONS_HMAC_KEY_LIVE = "notification_hmac_key_live";
     const XML_NOTIFICATIONS_HMAC_KEY_TEST = "notification_hmac_key_test";
+    const XML_DEMO_MODE = 'demo_mode';
 
     /**
      * @var Magento\Framework\App\Config\ScopeConfigInterface
@@ -124,7 +125,7 @@ class Config
      */
     public function isDemoMode($storeId = null)
     {
-        return $this->getConfigData('demo_mode', self::XML_ADYEN_ABSTRACT_PREFIX, $storeId, true);
+        return $this->getConfigData(self::XML_DEMO_MODE, self::XML_ADYEN_ABSTRACT_PREFIX, $storeId, true);
     }
 
     /**

--- a/etc/adminhtml/system/adyen_security.xml
+++ b/etc/adminhtml/system/adyen_security.xml
@@ -46,7 +46,7 @@
             <tooltip>
                 <![CDATA[
                 Set HMAC key at first on Adyen so new notifications are sent with the key. To learn more about these settings refer to
-                <a target="_blank" href="https://docs.adyen.com/classic-integration/hosted-payment-pages/hmac-signature-calculation#page-introduction">Adyen documentation</a>.
+                <a target="_blank" href="https://docs.adyen.com/development-resources/webhooks/verify-hmac-signatures">Adyen documentation</a>.
                 ]]>
             </tooltip>
         </field>
@@ -58,9 +58,9 @@
             <tooltip>
                 <![CDATA[
                 Set HMAC key at first on Adyen so new notifications are sent with the key. To learn more about these settings refer to
-                <a target="_blank" href="https://docs.adyen.com/classic-integration/hosted-payment-pages/hmac-signature-calculation#page-introduction">Adyen documentation</a>.
+                <a target="_blank" href="https://docs.adyen.com/development-resources/webhooks/verify-hmac-signatures">Adyen documentation</a>.
                 ]]>
             </tooltip>
         </field>
-    </group>
+    </group>v
 </include>

--- a/etc/adminhtml/system/adyen_security.xml
+++ b/etc/adminhtml/system/adyen_security.xml
@@ -62,5 +62,5 @@
                 ]]>
             </tooltip>
         </field>
-    </group>v
+    </group>
 </include>

--- a/etc/adminhtml/system/adyen_security.xml
+++ b/etc/adminhtml/system/adyen_security.xml
@@ -38,5 +38,17 @@
                 ]]>
             </comment>
         </field>
+        <field id="notification_hmac_key" translate="label" type="text" sortOrder="20" showInDefault="1"
+               showInWebsite="1" showInStore="1">
+            <label>Hmac key</label>
+            <backend_model>Magento\Config\Model\Config\Backend\Encrypted</backend_model>
+            <config_path>payment/adyen_abstract/notification_hmac_key</config_path>
+            <comment>
+                <![CDATA[
+                Set HMAC key at first on Adyen so new notifications are sent with the key. To learn more about these settings refer to
+                <a target="_blank" href="https://docs.adyen.com/classic-integration/hosted-payment-pages/hmac-signature-calculation#page-introduction">Adyen documentation</a>.
+                ]]>
+            </comment>
+        </field>
     </group>
 </include>

--- a/etc/adminhtml/system/adyen_security.xml
+++ b/etc/adminhtml/system/adyen_security.xml
@@ -38,17 +38,29 @@
                 ]]>
             </comment>
         </field>
-        <field id="notification_hmac_key" translate="label" type="text" sortOrder="20" showInDefault="1"
+        <field id="notification_hmac_key_test" translate="label" type="text" sortOrder="20" showInDefault="1"
                showInWebsite="1" showInStore="1">
-            <label>Hmac key</label>
+            <label>Hmac key test</label>
             <backend_model>Magento\Config\Model\Config\Backend\Encrypted</backend_model>
-            <config_path>payment/adyen_abstract/notification_hmac_key</config_path>
-            <comment>
+            <config_path>payment/adyen_abstract/notification_hmac_key_test</config_path>
+            <tooltip>
                 <![CDATA[
                 Set HMAC key at first on Adyen so new notifications are sent with the key. To learn more about these settings refer to
                 <a target="_blank" href="https://docs.adyen.com/classic-integration/hosted-payment-pages/hmac-signature-calculation#page-introduction">Adyen documentation</a>.
                 ]]>
-            </comment>
+            </tooltip>
+        </field>
+        <field id="notification_hmac_key_live" translate="label" type="text" sortOrder="30" showInDefault="1"
+               showInWebsite="1" showInStore="1">
+            <label>Hmac key live</label>
+            <backend_model>Magento\Config\Model\Config\Backend\Encrypted</backend_model>
+            <config_path>payment/adyen_abstract/notification_hmac_key_live</config_path>
+            <tooltip>
+                <![CDATA[
+                Set HMAC key at first on Adyen so new notifications are sent with the key. To learn more about these settings refer to
+                <a target="_blank" href="https://docs.adyen.com/classic-integration/hosted-payment-pages/hmac-signature-calculation#page-introduction">Adyen documentation</a>.
+                ]]>
+            </tooltip>
         </field>
     </group>
 </include>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1057,7 +1057,6 @@
                 <item name="payment/adyen_apple_pay/full_path_location_pem_file_test" xsi:type="string">1</item>
                 <item name="payment/adyen_apple_pay/full_path_location_pem_file_live" xsi:type="string">1</item>
                 <item name="payment/adyen_abstract/notifications_ip_hmac_check" xsi:type="string">1</item>
-                <item name="payment/adyen_abstract/notification_hmac_key" xsi:type="string">1</item>
             </argument>
             <argument name="sensitive" xsi:type="array">
                 <item name="payment/adyen_abstract/merchant_account" xsi:type="string">1</item>
@@ -1076,6 +1075,8 @@
                 <item name="payment/adyen_apple_pay/merchant_identifier_test" xsi:type="string">1</item>
                 <item name="payment/adyen_apple_pay/merchant_identifier_live" xsi:type="string">1</item>
                 <item name="payment/adyen_google_pay/merchant_identifier" xsi:type="string">1</item>
+                <item name="payment/adyen_abstract/notification_hmac_key_test" xsi:type="string">1</item>
+                <item name="payment/adyen_abstract/notification_hmac_key_live" xsi:type="string">1</item>
             </argument>
         </arguments>
     </type>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1057,6 +1057,7 @@
                 <item name="payment/adyen_apple_pay/full_path_location_pem_file_test" xsi:type="string">1</item>
                 <item name="payment/adyen_apple_pay/full_path_location_pem_file_live" xsi:type="string">1</item>
                 <item name="payment/adyen_abstract/notifications_ip_hmac_check" xsi:type="string">1</item>
+                <item name="payment/adyen_abstract/notification_hmac_key" xsi:type="string">1</item>
             </argument>
             <argument name="sensitive" xsi:type="array">
                 <item name="payment/adyen_abstract/merchant_account" xsi:type="string">1</item>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1075,8 +1075,8 @@
                 <item name="payment/adyen_apple_pay/merchant_identifier_test" xsi:type="string">1</item>
                 <item name="payment/adyen_apple_pay/merchant_identifier_live" xsi:type="string">1</item>
                 <item name="payment/adyen_google_pay/merchant_identifier" xsi:type="string">1</item>
-                <item name="payment/adyen_abstract/notification_hmac_key_test" xsi:type="string">1</item>
-                <item name="payment/adyen_abstract/notification_hmac_key_live" xsi:type="string">1</item>
+                <item name="payment/adyen_abstract/notification_hmac_key_test" xsi:type="string">0</item>
+                <item name="payment/adyen_abstract/notification_hmac_key_live" xsi:type="string">0</item>
             </argument>
         </arguments>
     </type>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1075,8 +1075,8 @@
                 <item name="payment/adyen_apple_pay/merchant_identifier_test" xsi:type="string">1</item>
                 <item name="payment/adyen_apple_pay/merchant_identifier_live" xsi:type="string">1</item>
                 <item name="payment/adyen_google_pay/merchant_identifier" xsi:type="string">1</item>
-                <item name="payment/adyen_abstract/notification_hmac_key_test" xsi:type="string">0</item>
-                <item name="payment/adyen_abstract/notification_hmac_key_live" xsi:type="string">0</item>
+                <item name="payment/adyen_abstract/notification_hmac_key_test" xsi:type="string">1</item>
+                <item name="payment/adyen_abstract/notification_hmac_key_live" xsi:type="string">1</item>
             </argument>
         </arguments>
     </type>


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
Currently we just check the username password but validating the notification agains the HMAC key would be more secure.

**Tested scenarios**
If configuration field is enabled:
If HMAC key is not correct or not sent, do not accept notification and write error log
If HMAC key is correct accept notification and no error log
