### PR TITLE
[PW-2236] Remove idempotency from alternative payment methods

### DIFF
--- a/Gateway/Http/Client/TransactionAuthorization.php
+++ b/Gateway/Http/Client/TransactionAuthorization.php
@@ -64,10 +64,8 @@ class TransactionAuthorization implements ClientInterface
     public function placeRequest(\Magento\Payment\Gateway\Http\TransferInterface $transferObject)
     {
         $request = $transferObject->getBody();
-        $headers = $transferObject->getHeaders();
-
         $requestOptions = [];
-        
+
         // call lib
         $service = new \Adyen\Service\Payment($this->client);
 

--- a/Gateway/Http/Client/TransactionAuthorization.php
+++ b/Gateway/Http/Client/TransactionAuthorization.php
@@ -67,11 +67,7 @@ class TransactionAuthorization implements ClientInterface
         $headers = $transferObject->getHeaders();
 
         $requestOptions = [];
-
-        if (!empty($headers['idempotencyKey'])) {
-            $requestOptions['idempotencyKey'] = $headers['idempotencyKey'];
-        }
-
+        
         // call lib
         $service = new \Adyen\Service\Payment($this->client);
 

--- a/Gateway/Http/Client/TransactionPayment.php
+++ b/Gateway/Http/Client/TransactionPayment.php
@@ -63,7 +63,6 @@ class TransactionPayment implements ClientInterface
     public function placeRequest(\Magento\Payment\Gateway\Http\TransferInterface $transferObject)
     {
         $request = $transferObject->getBody();
-        $headers = $transferObject->getHeaders();
 
         // If the payments call is already done return the request
         if (!empty($request['resultCode'])) {
@@ -76,7 +75,7 @@ class TransactionPayment implements ClientInterface
         $service = new \Adyen\Service\Checkout($client);
 
         $requestOptions = [];
-        
+
         $request = $this->applicationInfo->addMerchantApplicationIntoRequest($request);
 
         try {

--- a/Gateway/Http/Client/TransactionPayment.php
+++ b/Gateway/Http/Client/TransactionPayment.php
@@ -76,11 +76,7 @@ class TransactionPayment implements ClientInterface
         $service = new \Adyen\Service\Checkout($client);
 
         $requestOptions = [];
-
-        if (!empty($headers['idempotencyKey'])) {
-            $requestOptions['idempotencyKey'] = $headers['idempotencyKey'];
-        }
-
+        
         $request = $this->applicationInfo->addMerchantApplicationIntoRequest($request);
 
         try {

--- a/Gateway/Request/PaymentDataBuilder.php
+++ b/Gateway/Request/PaymentDataBuilder.php
@@ -63,9 +63,7 @@ class PaymentDataBuilder implements BuilderInterface
         $paymentMethod = $payment->getMethod();
 
         $request['body'] = $this->adyenRequestsHelper->buildPaymentData([], $amount, $currencyCode, $reference, $paymentMethod);
-
-        $request['headers'] = $this->adyenRequestsHelper->addIdempotencyKey([], $paymentMethod, $reference);
-
+        
         return $request;
     }
 }

--- a/Helper/Requests.php
+++ b/Helper/Requests.php
@@ -492,21 +492,4 @@ class Requests extends AbstractHelper
 
         return $address;
     }
-
-    /**
-     * Only adds idempotency key if payment method is adyen_hpp for now
-     *
-     * @param array $request
-     * @param $paymentMethod
-     * @param $idempotencyKey
-     * @return array
-     */
-    public function addIdempotencyKey($request = [], $paymentMethod, $idempotencyKey)
-    {
-        if (!empty($paymentMethod) && $paymentMethod == 'adyen_hpp') {
-            $request['idempotencyKey'] = $idempotencyKey;
-        }
-
-        return $request;
-    }
 }


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
We don't need the idempotency key in the plugin since it's not working everywhere in the world and it doesn't have any added value anymore.

**Tested scenarios**
Test that there is no idempotency key in the API requests for alternative payment methods 
