### PR TITLE
[PW-1972]: Extending AddressAdapter for extra street lines

### DIFF
--- a/Gateway/Data/Order/AddressAdapter.php
+++ b/Gateway/Data/Order/AddressAdapter.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2020 Adyen NV (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\Payment\Gateway\Data\Order;
+
+use Magento\Sales\Api\Data\OrderAddressInterface;
+
+class AddressAdapter extends \Magento\Payment\Gateway\Data\Order\AddressAdapter
+{
+    /**
+     * @var OrderAddressInterface
+     */
+    private $address;
+
+    public function __construct(OrderAddressInterface $address)
+    {
+        $this->address = $address;
+        parent::__construct($address);
+    }
+
+    /**
+     * Get street line 3
+     *
+     * @return string
+     */
+    public function getStreetLine3()
+    {
+        $street = $this->address->getStreet();
+        return isset($street[2]) ? $street[2] : '';
+    }
+
+    /**
+     * Get street line 4
+     *
+     * @return string
+     */
+    public function getStreetLine4()
+    {
+        $street = $this->address->getStreet();
+        return isset($street[3]) ? $street[3] : '';
+    }
+}

--- a/Helper/Requests.php
+++ b/Helper/Requests.php
@@ -487,7 +487,13 @@ class Requests extends AbstractHelper
             // Parse address into street and house number where possible
             $address = $this->adyenHelper->getStreetFromString($address->getStreetFull());
         } else {
-            $address = $this->adyenHelper->getStreetFromString(implode(' ', [$address->getStreetLine1(), $address->getStreetLine2()]));
+            $address = $this->adyenHelper->getStreetFromString(
+                implode(' ', [
+                    $address->getStreetLine1(),
+                    $address->getStreetLine2(),
+                    $address->getStreetLine3(),
+                    $address->getStreetLine4()
+                ]));
         }
 
         return $address;

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -914,6 +914,7 @@
     </virtualType>
 
     <preference for="Magento\Paypal\Model\Billing\Agreement" type="Adyen\Payment\Model\Billing\Agreement" />
+    <preference for="Magento\Payment\Gateway\Data\Order\AddressAdapter" type="Adyen\Payment\Gateway\Data\Order\AddressAdapter"/>
     <type name="Adyen\Payment\Logger\Handler\AdyenDebug">
         <arguments>
             <argument name="filesystem" xsi:type="object">Magento\Framework\Filesystem\Driver\File</argument>


### PR DESCRIPTION
**Description**
Originally, the payments are processed using the street lines 1 and 2 for street and housenumber/addition but Magento allows setting the number of street lines in the range of 1-4.

There's no attributes for street lines 3 and 4 in `Magento\Payment\Gateway\Data\ AddressAdapterInterface` and no corresponding methods in `Magento\Payment\Gateway\Data\Order\AddressAdapter`. Since this isn't an extensible entity extension attributes could not be used to fetch these street lines, so a child for the `AddressAdapter` class is created.

**Tested scenarios**
Payments with `customer/address/street_lines` set to 1, 2, 3 and 4 send the full street data to Adyen.

**Fixed issue**:  PW-1972, fixes #596 