### PR TITLE
Fix boleto URL in customer order and admin

### DIFF
--- a/Block/Info/Boleto.php
+++ b/Block/Info/Boleto.php
@@ -29,4 +29,14 @@ class Boleto extends AbstractInfo
      * @var string
      */
     protected $_template = 'Adyen_Payment::info/adyen_boleto.phtml';
+
+    /**
+     * @param $data string
+     * @return string
+     */
+    public function getPaymentActionData($data)
+    {
+        $paymentAction = $this->getMethod()->getInfoInstance()->getAdditionalInformation('action');
+        return !empty($paymentAction[$data]) ? $paymentAction[$data] : '';
+    }
 }

--- a/view/adminhtml/templates/info/adyen_boleto.phtml
+++ b/view/adminhtml/templates/info/adyen_boleto.phtml
@@ -34,7 +34,6 @@
 <?php
 $_info = $this->getInfo();
 $_isDemoMode = $block->isDemoMode();
-$paymentAction=$block->getMethod()->getInfoInstance()->getAdditionalInformation('action');
 ?>
 
 <?php if ($_pspReference = $_info->getAdditionalInformation('pspReference')):?>
@@ -74,9 +73,9 @@ $paymentAction=$block->getMethod()->getInfoInstance()->getAdditionalInformation(
     </div>
 <?php endif; ?>
 
-<?php if(!empty($paymentAction['expiresAt'])): ?>
+<?php if(!empty($block->getPaymentActionData('expiresAt'))): ?>
     <div>
-        <?php echo __('Expiration Date: %1', $paymentAction['expiresAt']) ?>
+        <?php echo __('Expiration Date: %1', $block->getPaymentActionData('expiresAt')) ?>
     </div>
 <?php endif; ?>
 
@@ -86,9 +85,9 @@ $paymentAction=$block->getMethod()->getInfoInstance()->getAdditionalInformation(
     </div>
 <?php endif; ?>
 
-<?php if(!empty($paymentAction['downloadUrl'])): ?>
+<?php if(!empty($block->getPaymentActionData('downloadUrl'))): ?>
     <div>
-        <a target="_blank" href="<?php echo $paymentAction['downloadUrl']; ?>"><?php echo __('PDF Url'); ?></a>
+        <a target="_blank" href="<?php echo $block->getPaymentActionData('downloadUrl'); ?>"><?php echo __('PDF Url'); ?></a>
     </div>
 <?php endif; ?>
 

--- a/view/adminhtml/templates/info/adyen_boleto.phtml
+++ b/view/adminhtml/templates/info/adyen_boleto.phtml
@@ -34,6 +34,7 @@
 <?php
 $_info = $this->getInfo();
 $_isDemoMode = $block->isDemoMode();
+$paymentAction=$block->getMethod()->getInfoInstance()->getAdditionalInformation('action');
 ?>
 
 <?php if ($_pspReference = $_info->getAdditionalInformation('pspReference')):?>
@@ -73,9 +74,9 @@ $_isDemoMode = $block->isDemoMode();
     </div>
 <?php endif; ?>
 
-<?php if($_info->getAdditionalInformation('expirationDate') != ""): ?>
+<?php if(!empty($paymentAction['expiresAt'])): ?>
     <div>
-        <?php echo __('Expiration Date: %1', $_info->getAdditionalInformation('expirationDate')) ?>
+        <?php echo __('Expiration Date: %1', $paymentAction['expiresAt']) ?>
     </div>
 <?php endif; ?>
 
@@ -85,9 +86,9 @@ $_isDemoMode = $block->isDemoMode();
     </div>
 <?php endif; ?>
 
-<?php if($_info->getAdditionalInformation('url') != ""): ?>
+<?php if(!empty($paymentAction['downloadUrl'])): ?>
     <div>
-        <a target="_blank" href="<?php echo $_info->getAdditionalInformation('url'); ?>"><?php echo __('PDF Url'); ?></a>
+        <a target="_blank" href="<?php echo $paymentAction['downloadUrl']; ?>"><?php echo __('PDF Url'); ?></a>
     </div>
 <?php endif; ?>
 

--- a/view/frontend/templates/info/adyen_boleto.phtml
+++ b/view/frontend/templates/info/adyen_boleto.phtml
@@ -33,5 +33,5 @@ $_info = $this->getInfo();
     <dt class="title"><?php echo $_info->getAdditionalInformation('boleto_type'); ?></dt>
     <dt class="title"><?php echo $_info->getAdditionalInformation('firstname'); ?></dt>
     <dt class="title"><?php echo $_info->getAdditionalInformation('lastname'); ?></dt>
-    <dt class="title"><a target="_blank" href="<?=$this->getPaymentActionData('downloadUrl')?>"><?php echo __("Click here to download Boleto PDF."); ?></a></dt>
+    <dt class="title"><a target="_blank" href="<? echo $this->getPaymentActionData('downloadUrl'); ?>"><?php echo __("Click here to download Boleto PDF."); ?></a></dt>
 </dl>

--- a/view/frontend/templates/info/adyen_boleto.phtml
+++ b/view/frontend/templates/info/adyen_boleto.phtml
@@ -33,5 +33,5 @@ $_info = $this->getInfo();
     <dt class="title"><?php echo $_info->getAdditionalInformation('boleto_type'); ?></dt>
     <dt class="title"><?php echo $_info->getAdditionalInformation('firstname'); ?></dt>
     <dt class="title"><?php echo $_info->getAdditionalInformation('lastname'); ?></dt>
-    <dt class="title"><a target="_blank" href="<? echo $this->getPaymentActionData('downloadUrl'); ?>"><?php echo __("Click here to download Boleto PDF."); ?></a></dt>
+    <dt class="title"><a target="_blank" href="<?php echo $this->getPaymentActionData('downloadUrl'); ?>"><?php echo __("Click here to download Boleto PDF."); ?></a></dt>
 </dl>

--- a/view/frontend/templates/info/adyen_boleto.phtml
+++ b/view/frontend/templates/info/adyen_boleto.phtml
@@ -26,6 +26,7 @@
 ?>
 <?php
 $_info = $this->getInfo();
+$paymentAction=$this->getMethod()->getInfoInstance()->getAdditionalInformation('action');
 ?>
 <dl class="payment-method adyen_cc">
     <dt class="title"><?php echo $block->escapeHtml($block->getMethod()->getTitle()) ?></dt>
@@ -33,5 +34,5 @@ $_info = $this->getInfo();
     <dt class="title"><?php echo $_info->getAdditionalInformation('boleto_type'); ?></dt>
     <dt class="title"><?php echo $_info->getAdditionalInformation('firstname'); ?></dt>
     <dt class="title"><?php echo $_info->getAdditionalInformation('lastname'); ?></dt>
-    <dt class="title"><a target="_blank" href="<?php echo $this->getMethod()->getInfoInstance()->getAdditionalInformation('url'); ?>"><?php echo __("Click here to download Boleto PDF."); ?></a></dt>
+    <dt class="title"><a target="_blank" href="<?=$paymentAction['downloadUrl']?>"><?php echo __("Click here to download Boleto PDF."); ?></a></dt>
 </dl>

--- a/view/frontend/templates/info/adyen_boleto.phtml
+++ b/view/frontend/templates/info/adyen_boleto.phtml
@@ -26,7 +26,6 @@
 ?>
 <?php
 $_info = $this->getInfo();
-$paymentAction=$this->getMethod()->getInfoInstance()->getAdditionalInformation('action');
 ?>
 <dl class="payment-method adyen_cc">
     <dt class="title"><?php echo $block->escapeHtml($block->getMethod()->getTitle()) ?></dt>
@@ -34,5 +33,5 @@ $paymentAction=$this->getMethod()->getInfoInstance()->getAdditionalInformation('
     <dt class="title"><?php echo $_info->getAdditionalInformation('boleto_type'); ?></dt>
     <dt class="title"><?php echo $_info->getAdditionalInformation('firstname'); ?></dt>
     <dt class="title"><?php echo $_info->getAdditionalInformation('lastname'); ?></dt>
-    <dt class="title"><a target="_blank" href="<?=$paymentAction['downloadUrl']?>"><?php echo __("Click here to download Boleto PDF."); ?></a></dt>
+    <dt class="title"><a target="_blank" href="<?=$this->getPaymentActionData('downloadUrl')?>"><?php echo __("Click here to download Boleto PDF."); ?></a></dt>
 </dl>


### PR DESCRIPTION
**Description**
The URL for the Boleto PDF was not being fetched correctly in the customer order and admin views.

**Tested scenarios**
Orders paid with Boleto show the correct PDF URL in customer order and admin view.

**Fixed issue**:  Fixes #727