### PR TITLE
[PW-2332] Delay OFFER_CLOSED notifications processing by 10 minutes

### DIFF
--- a/Model/Cron.php
+++ b/Model/Cron.php
@@ -352,9 +352,9 @@ class Cron
             // Remove OFFER_CLOSED notifications arrived in the last 10 minutes from the list to process to ensure it
             // won't close any order which has an AUTHORISED notification arrived a bit later than the OFFER_CLOSED one.
             $createdAt = \DateTime::createFromFormat('Y-m-d H:i:s', $notification['created_at']);
-            // Difference between $offerClosedMinDate and $createdAt in minutes is the time until processing the
-            // notification in minutes
-            $minutesUntilProcessing = $offerClosedMinDate->diff($createdAt)->i;
+            // To get the difference between $offerClosedMinDate and $createdAt, $offerClosedMinDate time in seconds is
+            // deducted from $createdAt time in seconds, divided by 60 and rounded down to integer
+            $minutesUntilProcessing = floor(($createdAt->getTimestamp() - $offerClosedMinDate->getTimestamp()) / 60);
             if ($notification['event_code'] == Notification::OFFER_CLOSED && $minutesUntilProcessing > 0) {
                 $this->_adyenLogger->addAdyenNotificationCronjob(
                     sprintf('OFFER_CLOSED notification %s skipped! Wait %s minute(s) before processing.',

--- a/Model/Cron.php
+++ b/Model/Cron.php
@@ -364,7 +364,7 @@ class Cron
 
         foreach ($notifications as $notification) {
             // Remove OFFER_CLOSED notifications arrived in the last 10 minutes from the list to process to ensure it
-            // won't close any order which has an AUTHOIRSED notification arrived a bit later than the OFFER_CLOSED one.
+            // won't close any order which has an AUTHORISED notification arrived a bit later than the OFFER_CLOSED one.
             $createdAt = \DateTime::createFromFormat('Y-m-d H:i:s', $notification['created_at']);
             $minutesUntilProcessing = $offerClosedMinDate->diff($createdAt)->i;
             if ($notification['event_code'] == Notification::OFFER_CLOSED && $minutesUntilProcessing > 0) {

--- a/Model/Cron.php
+++ b/Model/Cron.php
@@ -341,22 +341,8 @@ class Cron
 
         $this->_order = null;
 
-        // execute notifications from 2 minute or earlier because order could not yet been created by magento
-        $dateStart = new \DateTime();
-        $dateStart->modify('-5 day');
-        $dateEnd = new \DateTime();
-        $dateEnd->modify('-1 minute');
-        $dateRange = ['from' => $dateStart, 'to' => $dateEnd, 'datetime' => true];
-
-        // create collection
         $notifications = $this->_notificationFactory->create();
-        $notifications->addFieldToFilter('done', 0);
-        $notifications->addFieldToFilter('processing', 0);
-        $notifications->addFieldToFilter('created_at', $dateRange);
-        $notifications->addFieldToFilter('error_count', ['lt' => Notification::MAX_ERROR_COUNT]);
-
-        // Process the notifications in ascending order by creation date and event_code
-        $notifications->getSelect()->order('created_at ASC')->order('event_code ASC');
+        $notifications->notificationsToProcessFilter();
 
         // OFFER_CLOSED notifications needs to be at least 10 minutes old to be processed
         $offerClosedMinDate = new \DateTime();

--- a/Model/Cron.php
+++ b/Model/Cron.php
@@ -366,6 +366,8 @@ class Cron
             // Remove OFFER_CLOSED notifications arrived in the last 10 minutes from the list to process to ensure it
             // won't close any order which has an AUTHORISED notification arrived a bit later than the OFFER_CLOSED one.
             $createdAt = \DateTime::createFromFormat('Y-m-d H:i:s', $notification['created_at']);
+            // Difference between $offerClosedMinDate and $createdAt in minutes is the time until processing the
+            // notification in minutes
             $minutesUntilProcessing = $offerClosedMinDate->diff($createdAt)->i;
             if ($notification['event_code'] == Notification::OFFER_CLOSED && $minutesUntilProcessing > 0) {
                 $this->_adyenLogger->addAdyenNotificationCronjob(

--- a/Model/ResourceModel/Notification/Collection.php
+++ b/Model/ResourceModel/Notification/Collection.php
@@ -46,4 +46,30 @@ class Collection extends \Magento\Framework\Model\ResourceModel\Db\Collection\Ab
         $this->addFieldToFilter('created_at', $dateRange);
         return $this;
     }
+
+    /**
+     * Filter the notifications table to get non processed or done notifications without 5 or more errors older than 
+     * 2 minutes but not older than 5 days, ordered by created_at and event_code columns
+     *
+     * @return $this
+     */
+    public function notificationsToProcessFilter()
+    {
+        // execute notifications from 2 minute or earlier because order could not yet been created by magento
+        $dateStart = new \DateTime();
+        $dateStart->modify('-5 day');
+        $dateEnd = new \DateTime();
+        $dateEnd->modify('-1 minute');
+        $dateRange = ['from' => $dateStart, 'to' => $dateEnd, 'datetime' => true];
+
+        $this->addFieldToFilter('done', 0);
+        $this->addFieldToFilter('processing', 0);
+        $this->addFieldToFilter('created_at', $dateRange);
+        $this->addFieldToFilter('error_count', ['lt' => \Adyen\Payment\Model\Notification::MAX_ERROR_COUNT]);
+
+        // Process the notifications in ascending order by creation date and event_code
+        $this->getSelect()->order('created_at ASC')->order('event_code ASC');
+
+        return $this;
+    }
 }


### PR DESCRIPTION
**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Some payment methods - using mobile application to finish the payment - can create extra OFFER_CLOSED notifications when the user closes the app and then reopens it in the same session. To avoid closing an order when processing an OFFER_CLOSED notification delay processing these notifications by 10 minutes.

**Fixed issue**:  <!-- #-prefixed issue number -->