### PR TITLE
Remove Apple Pay extra check if valid active cards are present

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/adyen-apple-pay-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-apple-pay-method.js
@@ -146,14 +146,8 @@ define(
                 var self = this;
 
                 if (!!window.ApplePaySession) {
-                    // validate if applepay is allowed, it will be picked up by the isApplePayVisible method
-                    var promise = window.ApplePaySession.canMakePaymentsWithActiveCard(self.getMerchantIdentifier());
-                    promise.then(function (canMakePayments) {
-                        if (canMakePayments)
-                            canMakeApplePayPayments(true);
-                    });
-
                     if (window.ApplePaySession && window.ApplePaySession.supportsVersion(applePayVersion)) {
+                        canMakeApplePayPayments(true);
                         return true;
                     }
                 }

--- a/view/frontend/web/js/view/payment/method-renderer/adyen-apple-pay-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-apple-pay-method.js
@@ -143,15 +143,12 @@ define(
                 return window.checkoutConfig.payment.adyen.showLogo;
             },
             isApplePayAllowed: function () {
-                var self = this;
-
                 if (!!window.ApplePaySession) {
                     if (window.ApplePaySession && window.ApplePaySession.supportsVersion(applePayVersion)) {
                         canMakeApplePayPayments(true);
                         return true;
                     }
                 }
-
                 return false;
             },
             performValidation: function (validationURL) {


### PR DESCRIPTION
**Description**
This check always returned false even if active cards were present in the wallet. [A similar fix was applied for the Magento 1 plugin](https://github.com/Adyen/adyen-magento/pull/781/commits/ea832c4458edc13af8f07276c0f81b0664b4315e).

**Tested scenarios**
Safari in regular and private mode shows Apple Pay button.