### PR TITLE
Removed duplicate getData() declaration for Google Pay

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/adyen-google-pay-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-google-pay-method.js
@@ -65,12 +65,6 @@ define(
             getCode: function () {
                 return 'adyen_google_pay';
             },
-            getData: function () {
-                return {
-                    'method': this.item.method,
-                    'additional_data': {}
-                };
-            },
             isActive: function () {
                 return true;
             },


### PR DESCRIPTION
**Description**
The getData() function was being declared twice, this PR removes the unused declaration.

**Tested scenarios**
Payment with Google Pay

**Fixed issue**:  Fixes #733 