### PR TITLE
Fix for getCheckoutOriginKeys() output

### DIFF
--- a/view/adminhtml/templates/form/cc.phtml
+++ b/view/adminhtml/templates/form/cc.phtml
@@ -111,7 +111,7 @@ $ccExpYear = $block->getInfoData('cc_exp_year');
                  */
                 var secureFieldsInitialize = function () {
 
-                    if (!"<?php $block->getCheckoutOriginKeys(); ?>") {
+                    if (!"<?= $block->getCheckoutOriginKeys(); ?>") {
                         document.getElementById('noApiKey').style = "visibility: visible; display:inline-block";
                         return;
                     }


### PR DESCRIPTION
MOTO orders can't be placed because the getCheckoutOriginKeys() has no output