### PR TITLE
Fix issue with capture on shipment

### DIFF
--- a/Observer/Adminhtml/BeforeShipmentObserver.php
+++ b/Observer/Adminhtml/BeforeShipmentObserver.php
@@ -30,6 +30,7 @@ use Adyen\Payment\Observer\AdyenHppDataAssignObserver;
 use Exception;
 use Magento\Framework\Event\Observer;
 use Magento\Payment\Observer\AbstractDataAssignObserver;
+use Magento\Sales\Model\Order\Invoice;
 use Magento\Sales\Model\Order\InvoiceRepository;
 use Magento\Sales\Model\Order\Shipment;
 use Psr\Log\LoggerInterface;
@@ -123,6 +124,7 @@ class BeforeShipmentObserver extends AbstractDataAssignObserver
             // set transaction id so you can do a online refund from credit memo
             $pspReference = $order->getPayment()->getAdyenPspReference();
             $invoice->setTransactionId($pspReference);
+            $invoice->setRequestedCaptureCase(Invoice::CAPTURE_ONLINE);
             $invoice->register()->pay();
             $this->invoiceRepository->save($invoice);
         } catch (Throwable $e) {


### PR DESCRIPTION
**Description**
When setting the plugin to capture on shipment, the capture is not actually happening. This is because the invoice is not configured on how to manage the capture process (online or offline). This commit provides the invoice object with information about the capture mode.

**Tested scenarios**
1. Set capture to manual and capture on shipment on for OpenInvoice payment methods in the plugin.
1. Set capture to manual in Customer Area.
1. Make a purchase and pay with Klarna pay later.
1. In Magento 2 admin, submit a shipment for this order.
