### PR TITLE
fix phpDoc for storeId in Helper/Data

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -443,7 +443,7 @@ class Data extends AbstractHelper
      * gives back global configuration values
      *
      * @param $field
-     * @param null $storeId
+     * @param null|int|string $storeId
      * @return mixed
      */
     public function getAdyenAbstractConfigData($field, $storeId = null)
@@ -455,7 +455,7 @@ class Data extends AbstractHelper
      * gives back global configuration values as boolean
      *
      * @param $field
-     * @param null $storeId
+     * @param null|int|string $storeId
      * @return mixed
      */
     public function getAdyenAbstractConfigDataFlag($field, $storeId = null)
@@ -467,7 +467,7 @@ class Data extends AbstractHelper
      * Gives back adyen_cc configuration values
      *
      * @param $field
-     * @param null $storeId
+     * @param null|int|string $storeId
      * @return mixed
      */
     public function getAdyenCcConfigData($field, $storeId = null)
@@ -479,7 +479,7 @@ class Data extends AbstractHelper
      * Gives back adyen_cc configuration values as flag
      *
      * @param $field
-     * @param null $storeId
+     * @param null|int|string $storeId
      * @return mixed
      */
     public function getAdyenCcConfigDataFlag($field, $storeId = null)
@@ -491,7 +491,7 @@ class Data extends AbstractHelper
      * Gives back adyen_cc_vault configuration values as flag
      *
      * @param $field
-     * @param int|null $storeId
+     * @param null|int|string $storeId
      * @return mixed
      */
     public function getAdyenCcVaultConfigDataFlag($field, $storeId = null)
@@ -503,7 +503,7 @@ class Data extends AbstractHelper
      * Gives back adyen_hpp configuration values
      *
      * @param $field
-     * @param null $storeId
+     * @param null|int|string $storeId
      * @return mixed
      */
     public function getAdyenHppConfigData($field, $storeId = null)
@@ -515,7 +515,7 @@ class Data extends AbstractHelper
      * Gives back adyen_hpp configuration values as flag
      *
      * @param $field
-     * @param null $storeId
+     * @param null|int|string $storeId
      * @return mixed
      */
     public function getAdyenHppConfigDataFlag($field, $storeId = null)
@@ -527,7 +527,7 @@ class Data extends AbstractHelper
      * Gives back adyen_oneclick configuration values
      *
      * @param $field
-     * @param null $storeId
+     * @param null|int|string $storeId
      * @return mixed
      */
     public function getAdyenOneclickConfigData($field, $storeId = null)
@@ -539,7 +539,7 @@ class Data extends AbstractHelper
      * Gives back adyen_oneclick configuration values as flag
      *
      * @param $field
-     * @param null $storeId
+     * @param null|int|string $storeId
      * @return mixed
      */
     public function getAdyenOneclickConfigDataFlag($field, $storeId = null)
@@ -549,7 +549,7 @@ class Data extends AbstractHelper
 
     /**
      * @param $field
-     * @param int|null $storeId
+     * @param null|int|string $storeId
      * @return bool|mixed
      */
     public function getAdyenPosCloudConfigData($field, $storeId = null)
@@ -559,7 +559,7 @@ class Data extends AbstractHelper
 
     /**
      * @param $field
-     * @param int|null $storeId
+     * @param null|int|string $storeId
      * @return bool|mixed
      */
     public function getAdyenPosCloudConfigDataFlag($field, $storeId = null)
@@ -571,7 +571,7 @@ class Data extends AbstractHelper
      * Gives back adyen_pay_by_mail configuration values
      *
      * @param $field
-     * @param int|null $storeId
+     * @param null|int|string $storeId
      * @return mixed
      */
     public function getAdyenPayByMailConfigData($field, $storeId = null)
@@ -583,7 +583,7 @@ class Data extends AbstractHelper
      * Gives back adyen_pay_by_mail configuration values as flag
      *
      * @param $field
-     * @param int|null $storeId
+     * @param null|int|string $storeId
      * @return mixed
      */
     public function getAdyenPayByMailConfigDataFlag($field, $storeId = null)
@@ -595,7 +595,7 @@ class Data extends AbstractHelper
      * Gives back adyen_boleto configuration values
      *
      * @param $field
-     * @param null $storeId
+     * @param null|int|string $storeId
      * @return mixed
      */
     public function getAdyenBoletoConfigData($field, $storeId = null)
@@ -607,7 +607,7 @@ class Data extends AbstractHelper
      * Gives back adyen_boleto configuration values as flag
      *
      * @param $field
-     * @param null $storeId
+     * @param null|int|string $storeId
      * @return mixed
      */
     public function getAdyenBoletoConfigDataFlag($field, $storeId = null)
@@ -619,7 +619,7 @@ class Data extends AbstractHelper
      * Gives back adyen_apple_pay configuration values
      *
      * @param $field
-     * @param null $storeId
+     * @param null|int|string $storeId
      * @return mixed
      */
     public function getAdyenApplePayConfigData($field, $storeId = null)
@@ -628,7 +628,7 @@ class Data extends AbstractHelper
     }
 
     /**
-     * @param null $storeId
+     * @param null|int|string $storeId
      * @return mixed
      */
     public function getAdyenApplePayMerchantIdentifier($storeId = null)
@@ -642,7 +642,7 @@ class Data extends AbstractHelper
     }
 
     /**
-     * @param null $storeId
+     * @param null|int|string $storeId
      * @return mixed
      */
     public function getAdyenApplePayPemFileLocation($storeId = null)
@@ -659,7 +659,7 @@ class Data extends AbstractHelper
      * Gives back adyen_google_pay configuration values
      *
      * @param $field
-     * @param null $storeId
+     * @param null|int|string $storeId
      * @return mixed
      */
     public function getAdyenGooglePayConfigData($field, $storeId = null)
@@ -671,7 +671,7 @@ class Data extends AbstractHelper
      * Gives back adyen_google_pay configuration values
      *
      * @param $field
-     * @param null $storeId
+     * @param null|int|string $storeId
      * @return mixed
      */
     public function isAdyenGooglePayEnabled($storeId = null)
@@ -680,7 +680,7 @@ class Data extends AbstractHelper
     }
 
     /**
-     * @param null $storeId
+     * @param null|int|string $storeId
      * @return mixed
      */
     public function getAdyenGooglePayMerchantIdentifier($storeId = null)
@@ -722,7 +722,7 @@ class Data extends AbstractHelper
     /**
      * Check if configuration is set to demo mode
      *
-     * @param int|null $storeId
+     * @param null|int|string $storeId
      * @return mixed
      */
     public function isDemoMode($storeId = null)
@@ -743,7 +743,7 @@ class Data extends AbstractHelper
     /**
      * Retrieve the API key
      *
-     * @param int|null $storeId
+     * @param null|int|string $storeId
      * @return string
      */
     public function getAPIKey($storeId = null)
@@ -773,7 +773,7 @@ class Data extends AbstractHelper
     /**
      * Retrieve the webserver username
      *
-     * @param int|null $storeId
+     * @param null|int|string $storeId
      * @return string
      */
     public function getWsUsername($storeId = null)
@@ -789,7 +789,7 @@ class Data extends AbstractHelper
     /**
      * Retrieve the Live endpoint prefix key
      *
-     * @param int|null $storeId
+     * @param null|int|string $storeId
      * @return string
      */
     public function getLiveEndpointPrefix($storeId = null)
@@ -867,11 +867,11 @@ class Data extends AbstractHelper
      *
      * @param $field
      * @param $paymentMethodCode
-     * @param $storeId
+     * @param null|int|string $storeId
      * @param bool|false $flag
      * @return bool|mixed
      */
-    public function getConfigData($field, $paymentMethodCode, $storeId, $flag = false)
+    public function getConfigData($field, $paymentMethodCode, $storeId = null, $flag = false)
     {
         $path = 'payment/' . $paymentMethodCode . '/' . $field;
 
@@ -1391,7 +1391,7 @@ class Data extends AbstractHelper
     }
 
     /**
-     * @param int|null $storeId
+     * @param null|int|string $storeId
      * @return string the X API Key for the specified or current store
      */
     public function getPosApiKey($storeId = null)
@@ -1407,7 +1407,7 @@ class Data extends AbstractHelper
     /**
      * Return the Store ID for the current store/mode
      *
-     * @param int|null $storeId
+     * @param null|int|string $storeId
      * @return mixed
      */
     public function getPosStoreId($storeId = null)
@@ -1421,7 +1421,7 @@ class Data extends AbstractHelper
      * return the merchant account name defined in required settings.
      *
      * @param $paymentMethod
-     * @param int|null $storeId
+     * @param null|int|string $storeId
      * @return string
      */
     public function getAdyenMerchantAccount($paymentMethod, $storeId = null)
@@ -1476,7 +1476,7 @@ class Data extends AbstractHelper
     /**
      * Initializes and returns Adyen Client and sets the required parameters of it
      *
-     * @param int|null $storeId
+     * @param null|int|string $storeId
      * @param string|null $apiKey
      * @return \Adyen\Client
      * @throws \Adyen\AdyenException
@@ -1573,7 +1573,7 @@ class Data extends AbstractHelper
      * Get origin key for a specific origin using the adyen api library client
      *
      * @param $origin
-     * @param int|null $storeId
+     * @param null|int|string $storeId
      * @return string
      * @throws \Adyen\AdyenException
      */
@@ -1604,7 +1604,7 @@ class Data extends AbstractHelper
     }
 
     /**
-     * @param int|null $storeId
+     * @param null|int|string $storeId
      * @return string
      */
     public function getCheckoutEnvironment($storeId = null)
@@ -1627,7 +1627,7 @@ class Data extends AbstractHelper
     }
 
     /**
-     * @param int|null $storeId
+     * @param null|int|string $storeId
      * @return string
      */
     public function getCheckoutCardComponentJs($storeId = null)
@@ -1722,7 +1722,7 @@ class Data extends AbstractHelper
     /**
      * For backwards compatibility get the recurringType used for HPP + current billing agreements
      *
-     * @param null $storeId
+     * @param null|int|string $storeId
      * @return null|string
      */
     public function getRecurringTypeFromOneclickRecurringSetting($storeId = null)
@@ -1762,7 +1762,7 @@ class Data extends AbstractHelper
     /**
      * Check if CreditCard vault is enabled
      *
-     * @param int|null $storeId
+     * @param null|int|string $storeId
      * @return mixed
      */
     public function isCreditCardVaultEnabled($storeId = null)
@@ -1786,7 +1786,7 @@ class Data extends AbstractHelper
     /**
      * Check if 3DS2.0 is enabled for credit cards
      *
-     * @param int|null $storeId
+     * @param null|int|string $storeId
      * @return mixed
      */
     public function isCreditCardThreeDS2Enabled($storeId = null)
@@ -1849,7 +1849,7 @@ class Data extends AbstractHelper
     }
 
     /**
-     * @param int $storeId
+     * @param null|int|string $storeId
      * @return mixed|string
      */
     public function getCurrentLocaleCode($storeId)


### PR DESCRIPTION
**Description**
in my code i start to use our helper to retrieve some configuration info.
after complete my job i have automatic tools what analyze code, this tools generate errors like:
```
> vendor/bin/phpstan analyze --no-progress
Note: Using configuration file /srv/phpstan.neon.
 ------ ----------------------------------------------------------------------- 
  Line   My/Feature/Adyen.php                    
 ------ ----------------------------------------------------------------------- 
  65     Parameter #2 $storeId of method                                        
         Adyen\Payment\Helper\Data::getAdyenAbstractConfigData() expects null,  
         int given.                                                             
  115    Parameter #2 $storeId of method                                        
         Adyen\Payment\Helper\Data::getAdyenHppConfigData() expects null, int   
         given.                                                                 
 ------ ----------------------------------------------------------------------- 

 [ERROR] Found 2 errors 
```

my code:
```
$store = MagentoStoreClass;
$countryCode = $this->adyenHelper->getAdyenHppConfigData('country_code', $store->getId());
```

please take care about our phpDoc it's important for programmers!

