### PR TITLE
[PW-2390] Add action component on success page if presentToShopper an…

### DIFF
--- a/view/frontend/layout/checkout_onepage_success.xml
+++ b/view/frontend/layout/checkout_onepage_success.xml
@@ -22,10 +22,15 @@
  * Author: Adyen <magento@adyen.com>
  */
 -->
-<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
-<body>
-    <referenceContainer name="order.success.additional.info">
-        <block class="Adyen\Payment\Block\Checkout\Success" name="onepage.success.adyen_payment" template="checkout/success.phtml" cacheable="false"/>
-    </referenceContainer>
-</body>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <head>
+        <css src="Adyen_Payment::css/styles.css"/>
+    </head>
+    <body>
+        <referenceContainer name="order.success.additional.info">
+            <block class="Adyen\Payment\Block\Checkout\Success" name="onepage.success.adyen_payment"
+                   template="checkout/success.phtml" cacheable="false"/>
+        </referenceContainer>
+    </body>
 </page>

--- a/view/frontend/requirejs-config.js
+++ b/view/frontend/requirejs-config.js
@@ -14,7 +14,8 @@ var config = {
     },
     map: {
         '*': {
-            'adyenCheckout':  'https://checkoutshopper-live.adyen.com/checkoutshopper/sdk/3.4.0/adyen.js'
+            'adyenCheckout':  'https://checkoutshopper-live.adyen.com/checkoutshopper/sdk/3.4.0/adyen.js',
+            'adyenCheckout3101': 'https://checkoutshopper-live.adyen.com/checkoutshopper/sdk/3.10.1/adyen.js'
         }
     }
 };

--- a/view/frontend/templates/checkout/success.phtml
+++ b/view/frontend/templates/checkout/success.phtml
@@ -25,7 +25,32 @@
  * @var \Adyen\Payment\Block\Checkout\Success $block
  */
 ?>
-<?php if ($block->isBoletoPayment()): ?>
+
+
+<?php if ($block->renderAction()): ?>
+    <script type="text/javascript">
+        require([
+            'jquery',
+            'adyenCheckout3101'  // the alias for "mage/accordion"
+        ], function ($, AdyenCheckout) {
+            var action = JSON.parse('<?php echo $block->getAction(); ?>');
+            var checkoutComponent = new AdyenCheckout({
+                locale: '<?php echo $block->getLocale(); ?>',
+                environment: '<?php echo $block->getEnvironment(); ?>',
+                originKey: '<?php echo $block->getOriginKey(); ?>'
+            });
+            var actionNode = document.getElementById('ActionContainer');
+            checkoutComponent.createFromAction(action).mount(actionNode);
+        });
+    </script>
+
+
+    <div id="ActionContainer"></div>
+
+
+<?php else: ?>
+
+    <?php if ($block->isBoletoPayment()): ?>
     <?php
     $boletoData = $block->getBoletoData();
     ?>
@@ -37,21 +62,22 @@
     </p>
 <?php endif; ?>
 
-<?php if (!empty($block->getBankTransferData())): ?>
+    <?php if (!empty($block->getBankTransferData())): ?>
     <?php
     $banktranferData = $block->getBankTransferData();
     $order = $block->getOrder();
     ?>
     <h2><?= $block->escapeHtml(__('Pay using Bank transfer')); ?></h2>
     <p><?= $block->escapeHtml(
-        __('Please transfer the amount using the reference below to the following bank account')
+            __('Please transfer the amount using the reference below to the following bank account')
         ); ?></p>
     <table>
         <tbody>
         <?php if (!empty($order->getGrandTotal())): ?>
             <tr>
                 <th scope="row"><?= $block->escapeHtml(__('Amount')); ?></th>
-                <td><?= /* @noEscape */ $order->formatPrice($order->getGrandTotal()); ?></td>
+                <td><?= /* @noEscape */
+                    $order->formatPrice($order->getGrandTotal()); ?></td>
             </tr>
         <?php endif; ?>
 
@@ -97,10 +123,10 @@
     ?>
     <h2><?= $block->escapeHtml(__('Pay using Multibanco')); ?></h2>
     <p><?= $block->escapeHtml(
-        __(
-            'Please pay with the provided Multibanco reference and entity before payment deadline in order to ' .
-            'complete our payment'
-        )
+            __(
+                'Please pay with the provided Multibanco reference and entity before payment deadline in order to ' .
+                'complete our payment'
+            )
         ); ?></p>
     <table>
         <tbody>
@@ -122,7 +148,8 @@
         <?php if (!empty($multibancoData['totalAmount'])): ?>
             <tr>
                 <th scope="row"><?= $block->escapeHtml(__('Amount')); ?></th>
-                <td><?= /* @noEscape */ $block->priceHelper->currency($multibancoData['totalAmount']['value']);?>
+                <td><?= /* @noEscape */
+                    $block->priceHelper->currency($multibancoData['totalAmount']['value']); ?>
                 </td>
             </tr>
         <?php endif; ?>
@@ -135,4 +162,5 @@
         <?php endif; ?>
         </tbody>
     </table>
+    <?php endif; ?>
 <?php endif; ?>

--- a/view/frontend/templates/checkout/success.phtml
+++ b/view/frontend/templates/checkout/success.phtml
@@ -35,9 +35,9 @@
         ], function ($, AdyenCheckout) {
             var action = JSON.parse('<?= $block->escapeHtml($block->getAction()); ?>');
             var checkoutComponent = new AdyenCheckout({
-                locale: '<?php echo $block->getLocale(); ?>',
-                environment: '<?php echo $block->getEnvironment(); ?>',
-                originKey: '<?php echo $block->getOriginKey(); ?>'
+                locale: '<?= $block->escapeHtml($block->getLocale()); ?>',
+                environment: '<?= $block->escapeHtml($block->getEnvironment()); ?>',
+                originKey: '<?= $block->escapeHtml($block->getOriginKey()); ?>'
             });
             try {
                 checkoutComponent.createFromAction(action).mount('#ActionContainer');

--- a/view/frontend/templates/checkout/success.phtml
+++ b/view/frontend/templates/checkout/success.phtml
@@ -39,8 +39,11 @@
                 environment: '<?php echo $block->getEnvironment(); ?>',
                 originKey: '<?php echo $block->getOriginKey(); ?>'
             });
-            var actionNode = document.getElementById('ActionContainer');
-            checkoutComponent.createFromAction(action).mount(actionNode);
+            try {
+                checkoutComponent.createFromAction(action).mount('#ActionContainer');
+            } catch(err) {
+                // Action component cannot be created
+            }
         });
     </script>
 

--- a/view/frontend/templates/checkout/success.phtml
+++ b/view/frontend/templates/checkout/success.phtml
@@ -33,7 +33,7 @@
             'jquery',
             'adyenCheckout3101'  // the alias for "mage/accordion"
         ], function ($, AdyenCheckout) {
-            var action = JSON.parse('<?php echo $block->getAction(); ?>');
+            var action = JSON.parse('<?= $block->escapeHtml($block->getAction()); ?>');
             var checkoutComponent = new AdyenCheckout({
                 locale: '<?php echo $block->getLocale(); ?>',
                 environment: '<?php echo $block->getEnvironment(); ?>',

--- a/view/frontend/templates/checkout/success.phtml
+++ b/view/frontend/templates/checkout/success.phtml
@@ -25,8 +25,6 @@
  * @var \Adyen\Payment\Block\Checkout\Success $block
  */
 ?>
-
-
 <?php if ($block->renderAction()): ?>
     <script type="text/javascript">
         require([
@@ -46,13 +44,8 @@
             }
         });
     </script>
-
-
     <div id="ActionContainer"></div>
-
-
 <?php else: ?>
-
     <?php if ($block->isBoletoPayment()): ?>
     <?php
     $boletoData = $block->getBoletoData();

--- a/view/frontend/templates/checkout/success.phtml
+++ b/view/frontend/templates/checkout/success.phtml
@@ -31,7 +31,7 @@
             'jquery',
             'adyenCheckout3101'
         ], function ($, AdyenCheckout) {
-            var action = JSON.parse('<?= $block->getAction(); ?>');
+            var action = JSON.parse('<?= /* @noEscape */ $block->getAction(); ?>');
             var checkoutComponent = new AdyenCheckout({
                 locale: '<?= $block->escapeHtml($block->getLocale()); ?>',
                 environment: '<?= $block->escapeHtml($block->getEnvironment()); ?>',

--- a/view/frontend/templates/checkout/success.phtml
+++ b/view/frontend/templates/checkout/success.phtml
@@ -29,7 +29,7 @@
     <script type="text/javascript">
         require([
             'jquery',
-            'adyenCheckout3101'  // the alias for "mage/accordion"
+            'adyenCheckout3101'
         ], function ($, AdyenCheckout) {
             var action = JSON.parse('<?= $block->getAction(); ?>');
             var checkoutComponent = new AdyenCheckout({

--- a/view/frontend/templates/checkout/success.phtml
+++ b/view/frontend/templates/checkout/success.phtml
@@ -31,7 +31,7 @@
             'jquery',
             'adyenCheckout3101'  // the alias for "mage/accordion"
         ], function ($, AdyenCheckout) {
-            var action = JSON.parse('<?= $block->escapeHtml($block->getAction()); ?>');
+            var action = JSON.parse('<?= $block->getAction(); ?>');
             var checkoutComponent = new AdyenCheckout({
                 locale: '<?= $block->escapeHtml($block->getLocale()); ?>',
                 environment: '<?= $block->escapeHtml($block->getEnvironment()); ?>',


### PR DESCRIPTION
…d Action result is provided.

* Added a adyenCheckout3101 requireJS variable to use latest component version. This we can use for all new payment method integrations or upgrades.
* Success block loads all values needed for the component
* Success page renders the component
* Layout renders the styles.css file for showing the component with the right styling

<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

**Fixed issue**:  <!-- #-prefixed issue number -->