### PR TITLE
avoid setting order state to NULL

### DIFF
--- a/Model/Cron.php
+++ b/Model/Cron.php
@@ -1945,7 +1945,6 @@ class Cron
     {
         $statusObject = $this->_orderStatusCollection->create()
             ->addFieldToFilter('main_table.status', $status)
-            ->addFieldToFilter('state_table.is_default', true)
             ->joinStates()
             ->getFirstItem();
 


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
Avoid setting order state to NULL. This may happen when setting a status that is not default for a state.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

**Fixed issue**:  Adyen/adyen-magento2#384