### PR TITLE
Remove X-forwarded-for header and IP whitelisting/ HMAC is in different configuration

### DIFF
--- a/Controller/Process/Json.php
+++ b/Controller/Process/Json.php
@@ -351,12 +351,10 @@ class Json extends \Magento\Framework\App\Action\Action
     protected function isIpValid()
     {
         $ipAddress = [];
-
         //Getting remote and possibly forwarded IP addresses
         if (!empty($_SERVER['REMOTE_ADDR'])) {
-            array_push($ipAddress, $_SERVER['REMOTE_ADDR']);
+            $ipAddress = explode(',', $_SERVER['REMOTE_ADDR']);
         }
-
         return $this->ipAddressHelper->isIpAddressValid($ipAddress);
     }
 

--- a/Controller/Process/Json.php
+++ b/Controller/Process/Json.php
@@ -356,12 +356,6 @@ class Json extends \Magento\Framework\App\Action\Action
         if (!empty($_SERVER['REMOTE_ADDR'])) {
             array_push($ipAddress, $_SERVER['REMOTE_ADDR']);
         }
-        if (!empty($_SERVER['HTTP_X_FORWARDED_FOR'])) {
-            array_push($ipAddress, $_SERVER['HTTP_X_FORWARDED_FOR']);
-        }
-        if (!empty($_SERVER['HTTP_CLIENT_IP'])) {
-            array_push($ipAddress, $_SERVER['HTTP_CLIENT_IP']);
-        }
 
         return $this->ipAddressHelper->isIpAddressValid($ipAddress);
     }

--- a/Controller/Process/Json.php
+++ b/Controller/Process/Json.php
@@ -205,7 +205,7 @@ class Json extends \Magento\Framework\App\Action\Action
      */
     protected function _processNotification($response, $notificationMode)
     {
-        if ($this->configHelper->getNotificationsIpHmacCheck()) {
+        if ($this->configHelper->getNotificationsIpCheck()) {
             //Validate if the notification comes from a verified IP
             if (!$this->isIpValid()) {
                 $this->_adyenLogger->addAdyenNotification(
@@ -213,17 +213,21 @@ class Json extends \Magento\Framework\App\Action\Action
                 );
                 return false;
             }
-
-            if ($this->hmacSignature->isHmacSupportedEventCode($response)) {
-                //Validate the Hmac calculation
-                if (!$this->hmacSignature->isValidNotificationHMAC($this->configHelper->getNotificationsHmacKey(),
-                    $response)) {
-                    $this->_adyenLogger->addAdyenNotification('HMAC key validation failed ' . print_r($response, 1));
-                    return false;
+            if ($this->configHelper->getNotificationsHmacCheck()) {
+                if ($this->hmacSignature->isHmacSupportedEventCode($response)) {
+                    //Validate the Hmac calculation
+                    if (!$this->hmacSignature->isValidNotificationHMAC(
+                        $this->configHelper->getNotificationsHmacKey(),
+                        $response
+                    )) {
+                        $this->_adyenLogger->addAdyenNotification(
+                            'HMAC key validation failed ' . print_r($response, 1)
+                        );
+                        return false;
+                    }
                 }
             }
         }
-
         // validate the notification
         if ($this->authorised($response)) {
             // log the notification

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -31,7 +31,8 @@ class Config
     const XML_PAYMENT_PREFIX = "payment";
     const XML_ADYEN_ABSTRACT_PREFIX = "adyen_abstract";
     const XML_NOTIFICATIONS_CAN_CANCEL_FIELD = "notifications_can_cancel";
-    const XML_NOTIFICATIONS_IP_HMAC_CHECK = "notifications_ip_hmac_check";
+    const XML_NOTIFICATIONS_HMAC_CHECK = "notifications_hmac_check";
+    const XML_NOTIFICATIONS_IP_CHECK = "notifications_ip_check";
     const XML_NOTIFICATIONS_HMAC_KEY_LIVE = "notification_hmac_key_live";
     const XML_NOTIFICATIONS_HMAC_KEY_TEST = "notification_hmac_key_test";
 
@@ -84,15 +85,31 @@ class Config
     }
 
     /**
-     * Retrieve flag for notifications_ip_hmac_check
+     * Retrieve flag for notifications_hmac_check
      *
      * @param int $storeId
      * @return bool
      */
-    public function getNotificationsIpHmacCheck($storeId = null)
+    public function getNotificationsHmacCheck($storeId = null)
     {
         return (bool)$this->getConfigData(
-            self::XML_NOTIFICATIONS_IP_HMAC_CHECK,
+            self::XML_NOTIFICATIONS_HMAC_CHECK,
+            self::XML_ADYEN_ABSTRACT_PREFIX,
+            $storeId,
+            true
+        );
+    }
+
+    /**
+     * Retrieve flag for notifications_ip_check
+     *
+     * @param int $storeId
+     * @return bool
+     */
+    public function getNotificationsIpCheck($storeId = null)
+    {
+        return (bool)$this->getConfigData(
+            self::XML_NOTIFICATIONS_IP_CHECK,
             self::XML_ADYEN_ABSTRACT_PREFIX,
             $storeId,
             true

--- a/etc/adminhtml/system/adyen_security.xml
+++ b/etc/adminhtml/system/adyen_security.xml
@@ -33,19 +33,30 @@
                 </p>
             ]]>
         </comment>
-        <field id="notifications_ip_hmac_check" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
-            <label>Check notification's IP address and HMAC signature</label>
+        <field id="notifications_hmac_check" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
+            <label>Check notification's HMAC signature</label>
             <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-            <config_path>payment/adyen_abstract/notifications_ip_hmac_check</config_path>
+            <config_path>payment/adyen_abstract/notifications_hmac_check</config_path>
             <comment>
                 <![CDATA[
-                If enabled notifications will be accepted only when the IP address matches Adyen's servers and the HMAC
+                If enabled notifications will be accepted only when the HMAC
                 signature is verified. To learn more about these settings refer to
                 <a target="_blank" href="https://docs.adyen.com/plugins/magento-2/set-up-the-plugin-in-magento">Adyen documentation</a>.
                 ]]>
             </comment>
         </field>
-        <field id="notification_hmac_key_test" translate="label" type="obscure" sortOrder="20" showInDefault="1"
+        <field id="notifications_ip_check" translate="label" type="select" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
+            <label>Check notification's IP address</label>
+            <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+            <config_path>payment/adyen_abstract/notifications_ip_check</config_path>
+            <comment>
+                <![CDATA[
+                If enabled notifications will be accepted only when the IP address matches Adyen's servers. To learn more about these settings refer to
+                <a target="_blank" href="https://docs.adyen.com/plugins/magento-2/set-up-the-plugin-in-magento">Adyen documentation</a>.
+                ]]>
+            </comment>
+        </field>
+        <field id="notification_hmac_key_test" translate="label" type="obscure" sortOrder="30" showInDefault="1"
                showInWebsite="1" showInStore="1">
             <label>HMAC key test</label>
             <backend_model>Magento\Config\Model\Config\Backend\Encrypted</backend_model>
@@ -57,7 +68,7 @@
                 ]]>
             </tooltip>
         </field>
-        <field id="notification_hmac_key_live" translate="label" type="obscure" sortOrder="30" showInDefault="1"
+        <field id="notification_hmac_key_live" translate="label" type="obscure" sortOrder="40" showInDefault="1"
                showInWebsite="1" showInStore="1">
             <label>HMAC key live</label>
             <backend_model>Magento\Config\Model\Config\Backend\Encrypted</backend_model>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1050,7 +1050,8 @@
                 <item name="payment/adyen_abstract/debug" xsi:type="string">1</item>
                 <item name="payment/adyen_apple_pay/full_path_location_pem_file_test" xsi:type="string">1</item>
                 <item name="payment/adyen_apple_pay/full_path_location_pem_file_live" xsi:type="string">1</item>
-                <item name="payment/adyen_abstract/notifications_ip_hmac_check" xsi:type="string">1</item>
+                <item name="payment/adyen_abstract/notifications_ip_check" xsi:type="string">1</item>
+                <item name="payment/adyen_abstract/notifications_hmac_check" xsi:type="string">1</item>
             </argument>
             <argument name="sensitive" xsi:type="array">
                 <item name="payment/adyen_abstract/merchant_account" xsi:type="string">1</item>


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
PW-2750 Currently the ip whitelist is only enabled when the HMAC check is turned on, it would be nice to enable it by default.
The IP whitelist is only enabled by default without depending on HMAC configuration.

[DOCS] A new config field has been introduced to the Security section.

PW-2749 X-forwarded-for header can be controlled by an attacker and used to bypass the whitelist protection
Remove X-forwarded-for header

[DOCS] For the IP verification to check the user's IP the webserver/proxy should be configured to plug the client IP to the REMOTE_ADDR header.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

**Fixed issue**:  #780 