### PR TITLE
use adyen helper to create adyen checkout service

### DIFF
--- a/Gateway/Http/Client/TransactionPayment.php
+++ b/Gateway/Http/Client/TransactionPayment.php
@@ -68,8 +68,7 @@ class TransactionPayment implements ClientInterface
         }
 
         $client = $this->adyenHelper->initializeAdyenClient();
-
-        $service = new \Adyen\Service\Checkout($client);
+        $service = $this->adyenHelper->createAdyenCheckoutService($client);
 
         $requestOptions = [];
 


### PR DESCRIPTION
This is just so we can use a plugin on `createAdyenCheckoutService` method, which we currently cannot do because of `new`.
