### PR TITLE
Fetch country id from order address instead of country

### DIFF
--- a/Gateway/Command/PayByMailCommand.php
+++ b/Gateway/Command/PayByMailCommand.php
@@ -157,8 +157,8 @@ class PayByMailCommand implements CommandInterface
 
         // if directory lookup is enabled use the billingadress as countrycode
         if ($countryCode == false) {
-            if (is_object($order->getBillingAddress()) && $order->getBillingAddress()->getCountry() != "") {
-                $countryCode = $order->getBillingAddress()->getCountry();
+            if (is_object($order->getBillingAddress()) && $order->getBillingAddress()->getCountryId() != "") {
+                $countryCode = $order->getBillingAddress()->getCountryId();
             } else {
                 $countryCode = "";
             }


### PR DESCRIPTION
**Description**
`\Magento\Sales\Api\Data\OrderAddressInterface` does not contain `getCountry()` method.

**Tested scenarios**
- Create order using pay by mail payment method.
- Open url and check if `countryCode` is added to url.
