### PR TITLE
Fix swish payment methods when running it with the swish app

### DIFF
--- a/Controller/Process/Result.php
+++ b/Controller/Process/Result.php
@@ -392,7 +392,6 @@ class Result extends \Magento\Framework\App\Action\Action
         if (!empty($this->_session->getLastRealOrder()) &&
             !empty($this->_session->getLastRealOrder()->getPayment())
         ) {
-
             if (!empty($this->_session->getLastRealOrder()->getPayment()->getAdditionalInformation('paymentData'))) {
                 $request['paymentData'] = $this->_session->getLastRealOrder()->getPayment()->
                 getAdditionalInformation('paymentData');

--- a/Controller/Process/Result.php
+++ b/Controller/Process/Result.php
@@ -402,7 +402,7 @@ class Result extends \Magento\Framework\App\Action\Action
             }
 
             // for pending payment that redirect we store this under adyenPaymentData
-            // we need to refactor the code in the plugin that all paymentData is stored in paymentData and not in adyenPaymentData
+            // TODO: refactor the code in the plugin that all paymentData is stored in paymentData and not in adyenPaymentData
             if (!empty($this->_session->getLastRealOrder()->getPayment()->getAdditionalInformation('adyenPaymentData'))) {
                 $request['paymentData'] = $this->_session->getLastRealOrder()->getPayment()->
                 getAdditionalInformation("adyenPaymentData");

--- a/Controller/Process/Result.php
+++ b/Controller/Process/Result.php
@@ -397,7 +397,6 @@ class Result extends \Magento\Framework\App\Action\Action
                 $request['paymentData'] = $this->_session->getLastRealOrder()->getPayment()->
                 getAdditionalInformation('paymentData');
 
-
                 // remove paymentData from db
                 $this->_session->getLastRealOrder()->getPayment()->unsAdditionalInformation('paymentData');
                 $this->_session->getLastRealOrder()->getPayment()->save();

--- a/Controller/Process/Result.php
+++ b/Controller/Process/Result.php
@@ -390,11 +390,31 @@ class Result extends \Magento\Framework\App\Action\Action
         $request = [];
 
         if (!empty($this->_session->getLastRealOrder()) &&
-            !empty($this->_session->getLastRealOrder()->getPayment()) &&
-            !empty($this->_session->getLastRealOrder()->getPayment()->getAdditionalInformation("paymentData"))
+            !empty($this->_session->getLastRealOrder()->getPayment())
         ) {
-            $request['paymentData'] = $this->_session->getLastRealOrder()->getPayment()->
-            getAdditionalInformation("paymentData");
+
+            if (!empty($this->_session->getLastRealOrder()->getPayment()->getAdditionalInformation('paymentData'))) {
+                $request['paymentData'] = $this->_session->getLastRealOrder()->getPayment()->
+                getAdditionalInformation('paymentData');
+
+
+                // remove paymentData from db
+                $this->_session->getLastRealOrder()->getPayment()->unsAdditionalInformation('paymentData');
+                $this->_session->getLastRealOrder()->getPayment()->save();
+            }
+
+            // for pending payment that redirect we store this under adyenPaymentData
+            // we need to refactor the code in the plugin that all paymentData is stored in paymentData and not in adyenPaymentData
+            if (!empty($this->_session->getLastRealOrder()->getPayment()->getAdditionalInformation('adyenPaymentData'))) {
+                $request['paymentData'] = $this->_session->getLastRealOrder()->getPayment()->
+                getAdditionalInformation("adyenPaymentData");
+
+                // remove paymentData from db
+                $this->_session->getLastRealOrder()->getPayment()->unsAdditionalInformation('adyenPaymentData');
+                $this->_session->getLastRealOrder()->getPayment()->save();
+            }
+        } else {
+            $this->_adyenLogger->addError("Can't load the order id from the session");
         }
 
         $request["details"] = $response;


### PR DESCRIPTION
For some payment methods like swish with resultCode pending we store this into the property adyenPaymentData instead of paymentData. Check if adyenPaymentData exists if so add this as paymentData in request. This will solve issues for Swish payment method. We need to refactor a lot of code to make everywhere to use consistency in the naming this will be a separate story to be picked up.

<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

**Fixed issue**:  <!-- #-prefixed issue number -->