### PR TITLE
[PW-2913] Adding redirect data builder to CC authorize requests

### DIFF
--- a/Block/Redirect/Redirect.php
+++ b/Block/Redirect/Redirect.php
@@ -470,14 +470,16 @@ class Redirect extends \Magento\Payment\Block\Form
     }
 
     /**
-     * @return string
+     * @return mixed
      */
     public function getTermUrl()
     {
-        return $this->getUrl(
-            'adyen/process/redirect',
-            ['_secure' => $this->_getRequest()->isSecure()]
-        );
+        $payment=$this->getPayment();
+        if ($termUrl = $payment->getAdditionalInformation('termUrl')) {
+            return $termUrl;
+        }
+
+        throw new AdyenException("No termUrl is provided.");
     }
 
     /**

--- a/Block/Redirect/Redirect.php
+++ b/Block/Redirect/Redirect.php
@@ -474,8 +474,7 @@ class Redirect extends \Magento\Payment\Block\Form
      */
     public function getTermUrl()
     {
-        $payment=$this->getPayment();
-        if ($termUrl = $payment->getAdditionalInformation('termUrl')) {
+        if ($termUrl = $this->getPayment()->getAdditionalInformation('termUrl')) {
             return $termUrl;
         }
 

--- a/Gateway/Request/RedirectDataBuilder.php
+++ b/Gateway/Request/RedirectDataBuilder.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2020 Adyen BV (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\Payment\Gateway\Request;
+
+use Magento\Payment\Gateway\Request\BuilderInterface;
+
+class RedirectDataBuilder implements BuilderInterface
+{
+    /**
+     * @var \Magento\Framework\App\State
+     */
+    private $appState;
+
+    /**
+     * @var \Adyen\Payment\Helper\Requests
+     */
+    private $adyenRequestsHelper;
+
+    /**
+     * RedirectDataBuilder constructor.
+     *
+     * @param \Magento\Framework\Model\Context $context
+     * @param \Adyen\Payment\Helper\Requests $adyenRequestsHelper
+     */
+    public function __construct(
+        \Magento\Framework\Model\Context $context,
+        \Adyen\Payment\Helper\Requests $adyenRequestsHelper
+    ) {
+        $this->appState = $context->getAppState();
+        $this->adyenRequestsHelper = $adyenRequestsHelper;
+    }
+
+    /**
+     * @param array $buildSubject
+     * @return array
+     * @throws \Magento\Framework\Exception\LocalizedException
+     */
+    public function build(array $buildSubject)
+    {
+        $request['body'] = $this->adyenRequestsHelper->buildRedirectData([]);
+
+        return $request;
+    }
+}

--- a/Gateway/Validator/CheckoutResponseValidator.php
+++ b/Gateway/Validator/CheckoutResponseValidator.php
@@ -148,9 +148,14 @@ class CheckoutResponseValidator extends AbstractValidator
                     }
 
                     // If the redirect data is there then the payment is a card payment with 3d secure
-                    if (isset($response['redirect']['data']['PaReq']) && isset($response['redirect']['data']['MD'])) {
+                    if (
+                        isset($response['redirect']['data']['PaReq']) &&
+                        isset($response['redirect']['data']['MD']) &&
+                        isset($response['redirect']['data']['TermUrl'])
+                    ) {
                         $paReq = null;
                         $md = null;
+                        $termUrl = null;
 
                         $payment->setAdditionalInformation('3dActive', true);
 
@@ -162,11 +167,16 @@ class CheckoutResponseValidator extends AbstractValidator
                             $md = $response['redirect']['data']['MD'];
                         }
 
+                        if (!empty($response['redirect']['data']['TermUrl'])) {
+                            $termUrl = $response['redirect']['data']['TermUrl'];
+                        }
+
                         if ($paReq && $md && $redirectUrl && $paymentData && $redirectMethod) {
                             $payment->setAdditionalInformation('redirectUrl', $redirectUrl);
                             $payment->setAdditionalInformation('redirectMethod', $redirectMethod);
                             $payment->setAdditionalInformation('paRequest', $paReq);
                             $payment->setAdditionalInformation('md', $md);
+                            $payment->setAdditionalInformation('termUrl', $termUrl);
                             $payment->setAdditionalInformation('paymentData', $paymentData);
                         } else {
                             $isValid = false;

--- a/Helper/Requests.php
+++ b/Helper/Requests.php
@@ -342,6 +342,19 @@ class Requests extends AbstractHelper
     }
 
     /**
+     * @param array $request
+     * @return array
+     */
+    public function buildRedirectData($request = [])
+    {
+        $request['redirectFromIssuerMethod'] = 'GET';
+        $request['redirectToIssuerMethod'] = 'POST';
+        $request['returnUrl'] = $this->adyenHelper->getOrigin() . '/adyen/process/redirect';
+
+        return $request;
+    }
+
+    /**
      * @param $request
      * @param $areaCode
      * @param $storeId

--- a/Helper/Requests.php
+++ b/Helper/Requests.php
@@ -349,7 +349,7 @@ class Requests extends AbstractHelper
     {
         $request['redirectFromIssuerMethod'] = 'GET';
         $request['redirectToIssuerMethod'] = 'POST';
-        $request['returnUrl'] = $this->adyenHelper->getOrigin() . '/adyen/process/redirect';
+        $request['returnUrl'] = $this->adyenHelper->getOrigin() . '/adyen/process/result';
 
         return $request;
     }

--- a/Helper/Requests.php
+++ b/Helper/Requests.php
@@ -349,7 +349,7 @@ class Requests extends AbstractHelper
     {
         $request['redirectFromIssuerMethod'] = 'GET';
         $request['redirectToIssuerMethod'] = 'POST';
-        $request['returnUrl'] = $this->adyenHelper->getOrigin() . '/adyen/process/result';
+        $request['returnUrl'] = $this->adyenHelper->getOrigin() . '/adyen/process/redirect';
 
         return $request;
     }

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -578,6 +578,7 @@
                 <item name="payment" xsi:type="string">Adyen\Payment\Gateway\Request\PaymentDataBuilder</item>
                 <item name="browserinfo" xsi:type="string">Adyen\Payment\Gateway\Request\BrowserInfoDataBuilder</item>
                 <item name="recurring" xsi:type="string">Adyen\Payment\Gateway\Request\RecurringVaultDataBuilder</item>
+                <item name="redirect" xsi:type="string">Adyen\Payment\Gateway\Request\RedirectDataBuilder</item>
             </argument>
         </arguments>
     </virtualType>
@@ -608,6 +609,7 @@
                 <item name="recurring" xsi:type="string">Adyen\Payment\Gateway\Request\RecurringDataBuilder</item>
                 <item name="oneclick" xsi:type="string">Adyen\Payment\Gateway\Request\OneclickAuthorizationDataBuilder</item>
                 <item name="threeds2" xsi:type="string">Adyen\Payment\Gateway\Request\ThreeDS2DataBuilder</item>
+                <item name="redirect" xsi:type="string">Adyen\Payment\Gateway\Request\RedirectDataBuilder</item>
             </argument>
         </arguments>
     </virtualType>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -560,6 +560,7 @@
                 <item name="transaction" xsi:type="string">Adyen\Payment\Gateway\Request\CcAuthorizationDataBuilder</item>
                 <item name="vault" xsi:type="string">Adyen\Payment\Gateway\Request\VaultDataBuilder</item>
                 <item name="threeds2" xsi:type="string">Adyen\Payment\Gateway\Request\ThreeDS2DataBuilder</item>
+                <item name="redirect" xsi:type="string">Adyen\Payment\Gateway\Request\RedirectDataBuilder</item>
             </argument>
         </arguments>
     </virtualType>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -578,7 +578,6 @@
                 <item name="payment" xsi:type="string">Adyen\Payment\Gateway\Request\PaymentDataBuilder</item>
                 <item name="browserinfo" xsi:type="string">Adyen\Payment\Gateway\Request\BrowserInfoDataBuilder</item>
                 <item name="recurring" xsi:type="string">Adyen\Payment\Gateway\Request\RecurringVaultDataBuilder</item>
-                <item name="redirect" xsi:type="string">Adyen\Payment\Gateway\Request\RedirectDataBuilder</item>
             </argument>
         </arguments>
     </virtualType>


### PR DESCRIPTION
**Description**
This new redirect data builder adds `redirectFromIssuerMethod`, `redirectToIssuerMethod` and `returnUrl` to the `/payments` request.

The `TermUrl` is now fetched from the `/payments` response and added to the additional information so it can be used in the redirect submission form.

**Tested scenarios**
`/payments` request contains new redirect data

**Fixed issue**:  PW-2913