### PR TITLE
[PW-2096] Validate agreements before placing order for Google Pay

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/adyen-google-pay-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-google-pay-method.js
@@ -174,8 +174,8 @@ define(
             context: function () {
                 return this;
             },
-            validate: function () {
-                return this.additionalValidators.validate(true);
+            validate: function (hideErrors) {
+                return this.additionalValidators.validate(hideErrors);
             },
             getControllerName: function () {
                 return window.checkoutConfig.payment.iframe.controllerName[this.getCode()];
@@ -216,9 +216,6 @@ define(
             },
             getCheckoutEnvironment: function () {
                 return window.checkoutConfig.payment.adyen.checkoutEnvironment;
-            },
-            onPaymentMethodContentClick: function (data, event) {
-                $(this.googlePayNode).find('button').prop('disabled', !this.validate());
             }
         });
     }

--- a/view/frontend/web/js/view/payment/method-renderer/adyen-google-pay-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-google-pay-method.js
@@ -84,7 +84,7 @@ define(
                 this.vaultEnabler.setPaymentCode(this.getVaultCode());
                 this.vaultEnabler.isActivePaymentTokenEnabler(false);
                 this._super();
-                },
+            },
 
             renderGooglePay: function () {
                 this.googlePayNode = document.getElementById('googlePay');

--- a/view/frontend/web/js/view/payment/method-renderer/adyen-google-pay-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-google-pay-method.js
@@ -28,6 +28,7 @@ define(
         'jquery',
         'Magento_Checkout/js/view/payment/default',
         'Magento_Checkout/js/action/place-order',
+        'Magento_Checkout/js/model/payment/additional-validators',
         'Magento_Checkout/js/model/quote',
         'Magento_Checkout/js/model/url-builder',
         'Magento_Checkout/js/model/full-screen-loader',
@@ -35,7 +36,7 @@ define(
         'Magento_Vault/js/view/payment/vault-enabler',
         'adyenCheckout'
     ],
-    function (ko, $, Component, placeOrderAction, quote, urlBuilder, fullScreenLoader, url, VaultEnabler, AdyenCheckout) {
+    function (ko, $, Component, placeOrderAction, additionalValidators, quote, urlBuilder, fullScreenLoader, url, VaultEnabler, AdyenCheckout) {
         'use strict';
 
         /**
@@ -78,16 +79,17 @@ define(
                 return this;
             }, initialize: function () {
                 var self = this;
+                this.additionalValidators = additionalValidators;
                 this.vaultEnabler = new VaultEnabler();
                 this.vaultEnabler.setPaymentCode(this.getVaultCode());
                 this.vaultEnabler.isActivePaymentTokenEnabler(false);
                 this._super();
-
-            },
+                },
 
             renderGooglePay: function () {
+                this.googlePayNode = document.getElementById('googlePay');
+
                 var self = this;
-                var googlePayNode = document.getElementById('googlePay');
                 self.checkoutComponent = new AdyenCheckout({
                     locale: self.getLocale(),
                     originKey: self.getOriginKey(),
@@ -137,12 +139,12 @@ define(
                     buttonColor: 'black', // default/black/white
                     buttonType: 'long', // long/short
                     showButton: true // show or hide the Google Pay button
-
                 });
                 var promise = googlepay.isAvailable();
                 promise.then(function (success) {
                     self.googlePayAllowed(true);
-                    googlepay.mount(googlePayNode);
+                    googlepay.mount(self.googlePayNode);
+                    $(self.googlePayNode).find('button').prop('disabled', true);
                 }, function (error) {
                     console.log(error);
                     self.googlePayAllowed(false);
@@ -173,7 +175,7 @@ define(
                 return this;
             },
             validate: function () {
-                return true;
+                return this.additionalValidators.validate(true);
             },
             getControllerName: function () {
                 return window.checkoutConfig.payment.iframe.controllerName[this.getCode()];
@@ -214,6 +216,9 @@ define(
             },
             getCheckoutEnvironment: function () {
                 return window.checkoutConfig.payment.adyen.checkoutEnvironment;
+            },
+            onPaymentMethodContentClick: function (data, event) {
+                $(this.googlePayNode).find('button').prop('disabled', !this.validate());
             }
         });
     }

--- a/view/frontend/web/template/payment/google-pay-form.html
+++ b/view/frontend/web/template/payment/google-pay-form.html
@@ -38,7 +38,7 @@
         </label>
     </div>
 
-    <div class="payment-method-content">
+    <div class="payment-method-content" data-bind="event: { change: onPaymentMethodContentClick }">
         <div class="payment-method-billing-address">
             <!-- ko foreach: $parent.getRegion(getBillingAddressFormName()) -->
             <!-- ko template: getTemplate() --><!-- /ko -->

--- a/view/frontend/web/template/payment/google-pay-form.html
+++ b/view/frontend/web/template/payment/google-pay-form.html
@@ -38,14 +38,14 @@
         </label>
     </div>
 
-    <div class="payment-method-content" data-bind="event: { change: onPaymentMethodContentClick }">
+    <div class="payment-method-content" data-bind="event: { change: onPaymentMethodContentChange }">
         <div class="payment-method-billing-address">
             <!-- ko foreach: $parent.getRegion(getBillingAddressFormName()) -->
             <!-- ko template: getTemplate() --><!-- /ko -->
             <!--/ko-->
         </div>
 
-        <div class="checkout-agreements-block">
+         <div class="checkout-agreements-block" afterRender="bindDomEventListener">
             <!-- ko foreach: $parent.getRegion('before-place-order') -->
             <!-- ko template: getTemplate() --><!-- /ko -->
             <!--/ko-->


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Currently, the Google Pay component does not respect additional validation in Checkout page. This pull request attempts to fix this issue by making the Google Pay button disabled by default and enabling it only when the validation is successful.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
Checked button status in Checkout page while changing the agreement to the store's terms.

**Fixed issue**:  <!-- #-prefixed issue number -->