### PR TITLE
[PW-2984]Add the minify exclude element in config

### DIFF
--- a/etc/config.xml
+++ b/etc/config.xml
@@ -236,6 +236,11 @@
                     <adyen_payment>/3.4.0/adyen</adyen_payment>
                 </minify_exclude>
             </js>
+            <css>
+                <minify_exclude>
+                    <adyen_payment>/3.4.0/adyen</adyen_payment>
+                </minify_exclude>
+            </css>
         </dev>
     </default>
 </config>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -230,5 +230,12 @@
                 <group>adyen</group>
             </adyen_google_pay>
         </payment>
+        <dev>
+            <js>
+                <minify_exclude>
+                    <adyen_payment>/3.4.0/adyen</adyen_payment>
+                </minify_exclude>
+            </js>
+        </dev>
     </default>
 </config>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -233,12 +233,12 @@
         <dev>
             <js>
                 <minify_exclude>
-                    <adyen_payment>/adyen</adyen_payment>
+                    <adyen_payment>adyen.com/checkoutshopper</adyen_payment>
                 </minify_exclude>
             </js>
             <css>
                 <minify_exclude>
-                    <adyen_payment>/adyen</adyen_payment>
+                    <adyen_payment>adyen.com/checkoutshopper</adyen_payment>
                 </minify_exclude>
             </css>
         </dev>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -233,12 +233,12 @@
         <dev>
             <js>
                 <minify_exclude>
-                    <adyen_payment>/3.4.0/adyen</adyen_payment>
+                    <adyen_payment>/adyen</adyen_payment>
                 </minify_exclude>
             </js>
             <css>
                 <minify_exclude>
-                    <adyen_payment>/3.4.0/adyen</adyen_payment>
+                    <adyen_payment>/adyen</adyen_payment>
                 </minify_exclude>
             </css>
         </dev>


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
Added the adyen.js and css files in the minification exclude config in magento. 

**Tested scenarios**
How to test it:
Set magento to developer mode
In the admin find the Minify JavaScript Files flag and set it to yes. (Store->Configuration->Advanced->Developer)
Set magento mode to production
Test the checkout page that loads properly

**Fixed issue**:  <!-- #-prefixed issue number -->