### PR TITLE
[PW-3006 ]3DS redirect to wrong storefront

### DIFF
--- a/Helper/Requests.php
+++ b/Helper/Requests.php
@@ -35,19 +35,21 @@ use Magento\Quote\Api\Data\PaymentInterface;
 class Requests extends AbstractHelper
 {
     /**
-     * @var \Adyen\Payment\Helper\Data
+     * @var Data
      */
     private $adyenHelper;
+
     /**
-     * Requests constructor.
-     *
-     * @param Data $adyenHelper
+     * @var \Magento\Framework\UrlInterface
      */
+    private $urlBuilder;
 
     public function __construct(
-        \Adyen\Payment\Helper\Data $adyenHelper
+        \Adyen\Payment\Helper\Data $adyenHelper,
+        \Magento\Framework\UrlInterface $urlBuilder
     ) {
         $this->adyenHelper = $adyenHelper;
+        $this->urlBuilder = $urlBuilder;
     }
 
     /**
@@ -349,7 +351,9 @@ class Requests extends AbstractHelper
     {
         $request['redirectFromIssuerMethod'] = 'GET';
         $request['redirectToIssuerMethod'] = 'POST';
-        $request['returnUrl'] = $this->adyenHelper->getOrigin($storeId) . '/adyen/process/redirect';
+        $request['returnUrl'] = $this->urlBuilder->getUrl(
+            'adyen/process/redirect'
+        );
 
         return $request;
     }


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
Magento with multiple stores redirects the shopper to wrong storefront after 3DS. After the fix the return url includes the correct storefront. 

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

**Fixed issue**:  <!-- #-prefixed issue number -->