### PR TITLE
[PW-3006] 3DS redirect to wrong storefront

### DIFF
--- a/Helper/Requests.php
+++ b/Helper/Requests.php
@@ -44,18 +44,26 @@ class Requests extends AbstractHelper
     private $adyenConfig;
 
     /**
+     * @var \Magento\Framework\UrlInterface
+     */
+    private $urlBuilder;
+
+    /**
      * Requests constructor.
      *
      * @param Data $adyenHelper
-     * @param Config $adyenConfig ;
+     * @param Config $adyenConfig
+     * @param \Magento\Framework\UrlInterface $urlBuilder
      */
 
     public function __construct(
         \Adyen\Payment\Helper\Data $adyenHelper,
-        \Adyen\Payment\Helper\Config $adyenConfig
+        \Adyen\Payment\Helper\Config $adyenConfig,
+        \Magento\Framework\UrlInterface $urlBuilder
     ) {
         $this->adyenHelper = $adyenHelper;
         $this->adyenConfig = $adyenConfig;
+        $this->urlBuilder = $urlBuilder;
     }
 
     /**
@@ -357,8 +365,8 @@ class Requests extends AbstractHelper
     {
         $request['redirectFromIssuerMethod'] = 'GET';
         $request['redirectToIssuerMethod'] = 'POST';
-        $request['returnUrl'] = $this->adyenHelper->getOrigin($storeId) . '/adyen/process/redirect';
-
+        $request['returnUrl'] = $this->urlBuilder->getUrl(
+            'adyen/process/redirect');
         return $request;
     }
 

--- a/view/frontend/web/js/view/payment/method-renderer/adyen-cc-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-cc-method.js
@@ -389,7 +389,7 @@ define(
                     // render component
                     self.renderThreeDS2Component(response.type, response.token, orderId);
                 } else {
-                    if (response.type === 'RedirectShopper') {
+                    if (response.type === 'RedirectShopper' && response.action) {
                         self.threedsfallback(response.action);
                     } else {
                         window.location.replace(url.build(


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
Magento with multiple stores redirects the shopper to wrong storefront after 3DS. After the fix the return url includes the correct storefront.


**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

**Fixed issue**:  <!-- #-prefixed issue number -->