### PR TITLE
PWA redirect support

### DIFF
--- a/Api/AdyenOrderPaymentDetailsInterface.php
+++ b/Api/AdyenOrderPaymentDetailsInterface.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2019 Adyen BV (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\Payment\Api;
+
+interface AdyenOrderPaymentDetailsInterface
+{
+    /**
+     * @param string $orderId Order id to return payment details for
+     * @param string $payload JSON encoded values to provide to the `/payment/details` Adyen API
+     *                        see https://docs.adyen.com/api-explorer/#/CheckoutService/payments/details
+     * @return string JSON encoded details
+     * @throws \Magento\Framework\Exception\LocalizedException
+     */
+    public function getDetails($orderId, $payload);
+}

--- a/Api/AdyenThreeDSProcessInterface.php
+++ b/Api/AdyenThreeDSProcessInterface.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Payment Module
+ *
+ * Copyright (c) 2019 Adyen B.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\Payment\Api;
+
+use Magento\Sales\Model\Order;
+
+interface AdyenThreeDSProcessInterface
+{
+    const AUTHORIZED = "AUTHORIZED";
+    const UNSUCCESSFUL = "UNSUCCESSFUL";
+    const ALREADY_SUCCESSFUL = "ALREADY_SUCCESSFUL";
+    const NEEDS_REDIRECT = "NEEDS_REDIRECT";
+
+    /**
+     * Shared authorization logic across all frontend (native or PWA)
+     * for handling a redirect after 3DS auth
+     *
+     * @param \Magento\Sales\Model\Order $order
+     * @param string $requestMD
+     * @param string $requestPaRes
+     * @return string
+     * @api
+     */
+    public function authorize(Order $order, $requestMD, $requestPaRes): string;
+
+}

--- a/Api/AdyenThreeDSProcessInterface.php
+++ b/Api/AdyenThreeDSProcessInterface.php
@@ -34,6 +34,17 @@ interface AdyenThreeDSProcessInterface
     const NEEDS_REDIRECT = "NEEDS_REDIRECT";
 
     /**
+     * Allow remote PWA to run an authorization process when Customers
+     * are redirected on the shop
+     *
+     * @param string $orderId
+     * @param string $payload
+     * @return string
+     * @api
+     */
+    public function headlessAuthorize($orderId, $payload);
+
+    /**
      * Shared authorization logic across all frontend (native or PWA)
      * for handling a redirect after 3DS auth
      *

--- a/Gateway/Request/CheckoutDataBuilder.php
+++ b/Gateway/Request/CheckoutDataBuilder.php
@@ -93,9 +93,7 @@ class CheckoutDataBuilder implements BuilderInterface
             );
         }
 
-        $requestBody['returnUrl'] = $this->storeManager->getStore()->getBaseUrl(
-                \Magento\Framework\UrlInterface::URL_TYPE_LINK
-            ) . 'adyen/process/result';
+        $requestBody['returnUrl'] = $this->adyenHelper->getOrigin($storeId) . '/adyen/process/result';
 
         // Additional data for ACH
         if ($payment->getAdditionalInformation("bankAccountNumber")) {

--- a/Model/AdyenOrderPaymentDetails.php
+++ b/Model/AdyenOrderPaymentDetails.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2019 Adyen BV (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\Payment\Model;
+
+use Adyen\Payment\Api\AdyenOrderPaymentDetailsInterface;
+
+class AdyenOrderPaymentDetails implements AdyenOrderPaymentDetailsInterface
+{
+
+    /**
+     * @var \Adyen\Payment\Helper\Data
+     */
+    private $adyenHelper;
+
+    /**
+     * @var \Magento\Sales\Model\OrderFactory
+     */
+    private $orderFactory;
+
+    /**
+     * @var \Adyen\Payment\Logger\AdyenLogger
+     */
+    private $adyenLogger;
+
+    /**
+     * AdyenThreeDS2Process constructor.
+     *
+     * @param \Adyen\Payment\Helper\Data $adyenHelper
+     * @param \Magento\Sales\Model\OrderFactory $orderFactory
+     * @param \Adyen\Payment\Logger\AdyenLogger $adyenLogger
+     */
+    public function __construct(
+        \Adyen\Payment\Helper\Data $adyenHelper,
+        \Magento\Sales\Model\OrderFactory $orderFactory,
+        \Adyen\Payment\Logger\AdyenLogger $adyenLogger
+    ) {
+        $this->adyenHelper = $adyenHelper;
+        $this->orderFactory = $orderFactory;
+        $this->adyenLogger = $adyenLogger;
+    }
+
+    public function getDetails($orderId, $payload)
+    {
+        // Decode payload from frontend
+        $payload = json_decode($payload, true);
+
+        // Validate JSON that has just been parsed if it was in a valid format
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            throw new \Magento\Framework\Exception\LocalizedException(
+                __('Payment details failed because the request was not a valid JSON')
+            );
+        }
+
+        // Create order by order id
+        $order = $this->orderFactory->create()->load($orderId);
+        $payment = $order->getPayment();
+        if (empty($payment) || !$this->isAdyen($payment->getMethod())) {
+            throw new \Magento\Framework\Exception\LocalizedException(
+                __('Payment details are not available for this order')
+            );
+        }
+
+        $additionalInformation = $payment->getAdditionalInformation();
+        if (!empty($additionalInformation['paymentData']) && empty($payload['paymentData'])) {
+            $payload['paymentData'] = $additionalInformation['paymentData'];
+        }
+        // ToDo check that Order belongs to the customer or can be queried
+
+        try {
+            $client = $this->adyenHelper->initializeAdyenClient($order->getStoreId());
+            $service = $this->adyenHelper->createAdyenCheckoutService($client);
+            $result = $service->paymentsDetails($payload);
+            return json_encode($result);
+        } catch (\Adyen\AdyenException $e) {
+            $this->adyenLogger->error("Payment details failed" . $e->getMessage());
+            throw new \Magento\Framework\Exception\LocalizedException(__('Payment details failed'));
+        }
+    }
+
+    private function isAdyen($method)
+    {
+        return strpos($method, 'adyen') !== false;
+    }
+}

--- a/Model/AdyenOrderPaymentStatus.php
+++ b/Model/AdyenOrderPaymentStatus.php
@@ -100,6 +100,17 @@ class AdyenOrderPaymentStatus implements \Adyen\Payment\Api\AdyenOrderPaymentSta
                 $additionalInformation['resultCode'] == 'Pending'
             ) {
                 return json_encode(['action' => $additionalInformation['action']]);
+            } else if ($additionalInformation['resultCode'] == 'RedirectShopper') {
+                return json_encode([
+                    'action' => [
+                        'type' => 'redirect',
+                        'method' => $additionalInformation['redirectMethod'],
+                        'url' => $additionalInformation['redirectUrl'],
+                        'paymentData' => $additionalInformation['paymentData'],
+                        'paymentMethodType' => $additionalInformation['brand_code']
+                    ],
+                    'details' => $additionalInformation['details']
+                ]);
             }
         }
 

--- a/Model/AdyenThreeDSProcess.php
+++ b/Model/AdyenThreeDSProcess.php
@@ -1,0 +1,294 @@
+<?php
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2019 Adyen BV (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\Payment\Model;
+
+use Adyen\Payment\Api\AdyenThreeDSProcessInterface;
+use Magento\Payment\Model\InfoInterface;
+use Magento\Sales\Model\Order;
+use Magento\Sales\Model\ResourceModel\Order\Payment as OrderPaymentResource;
+use Magento\Vault\Api\Data\PaymentTokenFactoryInterface;
+use Magento\Vault\Api\Data\PaymentTokenInterface;
+use Magento\Sales\Api\Data\OrderPaymentExtensionInterfaceFactory;
+
+class AdyenThreeDSProcess implements AdyenThreeDSProcessInterface
+{
+    /**
+     * @var \Adyen\Payment\Helper\Data
+     */
+    private $_adyenHelper;
+
+    /**
+     * @var \Magento\Sales\Model\OrderFactory
+     */
+    private $orderFactory;
+
+    /**
+     * @var \Adyen\Payment\Logger\AdyenLogger
+     */
+    private $_adyenLogger;
+    /**
+     * @var \Magento\Sales\Api\OrderRepositoryInterface
+     */
+    private $_orderRepository;
+    /**
+     * @var OrderPaymentExtensionInterfaceFactory
+     */
+    private $paymentExtensionFactory;
+    /**
+     * @var \Magento\Framework\Serialize\SerializerInterface
+     */
+    private $serializer;
+    /**
+     * @var OrderPaymentResource
+     */
+    private $orderPaymentResource;
+    /**
+     * @var PaymentTokenFactoryInterface
+     */
+    private $paymentTokenFactory;
+    /**
+     * @var Api\PaymentRequest
+     */
+    private $_paymentRequest;
+
+    /**
+     * AdyenThreeDS2Process constructor.
+     *
+     * @param \Adyen\Payment\Helper\Data $adyenHelper
+     * @param \Magento\Sales\Api\OrderRepositoryInterface $orderRepository ,
+     * @param \Adyen\Payment\Logger\AdyenLogger $adyenLogger
+     * @param Api\PaymentRequest $paymentRequest
+     * @param \Magento\Sales\Model\OrderFactory $orderFactory
+     * @param OrderPaymentExtensionInterfaceFactory $paymentExtensionFactory
+     * @param \Magento\Framework\Serialize\SerializerInterface $serializer
+     * @param OrderPaymentResource $orderPaymentResource
+     * @param PaymentTokenFactoryInterface $paymentTokenFactory
+     */
+    public function __construct(
+        \Adyen\Payment\Helper\Data $adyenHelper,
+        \Magento\Sales\Api\OrderRepositoryInterface $orderRepository,
+        \Adyen\Payment\Logger\AdyenLogger $adyenLogger,
+        \Adyen\Payment\Model\Api\PaymentRequest $paymentRequest,
+        \Magento\Sales\Model\OrderFactory $orderFactory,
+        OrderPaymentExtensionInterfaceFactory $paymentExtensionFactory,
+        \Magento\Framework\Serialize\SerializerInterface $serializer,
+        OrderPaymentResource $orderPaymentResource,
+        PaymentTokenFactoryInterface $paymentTokenFactory
+    ) {
+        $this->_adyenHelper = $adyenHelper;
+        $this->_orderRepository = $orderRepository;
+        $this->_adyenLogger = $adyenLogger;
+        $this->_paymentRequest = $paymentRequest;
+
+        $this->orderFactory = $orderFactory;
+        $this->paymentExtensionFactory = $paymentExtensionFactory;
+        $this->serializer = $serializer;
+        $this->orderPaymentResource = $orderPaymentResource;
+        $this->paymentTokenFactory = $paymentTokenFactory;
+    }
+
+    /**
+     * {@inheridoc}
+     */
+    public function authorize(Order $order, $requestMD, $requestPaRes): string
+    {
+        $active = null;
+        $success = null;
+        if ($order->getPayment()) {
+            $active = $order->getPayment()->getAdditionalInformation('3dActive');
+            $success = $order->getPayment()->getAdditionalInformation('3dSuccess');
+            $checkoutAPM = $order->getPayment()->getAdditionalInformation('checkoutAPM');
+        }
+
+        // check if 3D secure is active. If not just go to success page
+        if ($active && $success != true) {
+            $this->_adyenLogger->addAdyenResult("3D secure is active");
+
+            // check if the GET request contains the required 3DS params
+            if ($requestPaRes && $requestMD) {
+                $this->_adyenLogger->addAdyenResult("Process 3D secure payment");
+
+                //Reset the payment's additional info to the new MD and PaRes
+                $order->getPayment()->setAdditionalInformation('md', $requestMD);
+                $order->getPayment()->setAdditionalInformation('paRequest', $requestPaRes);
+                $order->getPayment()->setAdditionalInformation('paResponse', $requestPaRes);
+
+                try {
+                    $result = $this->_authorise3d($order->getPayment());
+                    $responseCode = $result['resultCode'];
+                } catch (\Exception $e) {
+                    $this->_adyenLogger->addAdyenResult("Process 3D secure payment was refused");
+                    $responseCode = 'Refused';
+                }
+
+                $this->_adyenLogger->addAdyenResult("Process 3D secure payment result is: " . $responseCode);
+
+                // check if authorise3d was successful
+                if ($responseCode == 'Authorised') {
+                    $this->markOrderAsAuthorized($order, $result);
+                    return self::AUTHORIZED;
+                } else {
+                    /*
+                     * Since responseCode!='Authorised' the order could be cancelled immediately,
+                     * but redirect payments can have multiple conflicting responses.
+                     * The order will be cancelled if an Authorization
+                     * Success=False notification is processed instead
+                    */
+                    $order->addStatusHistoryComment(
+                        __(
+                            '3D-secure validation was unsuccessful. This order will be cancelled when the related
+                                notification has been processed.'
+                        )
+                    )->save();
+                    return self::UNSUCCESSFUL;
+                }
+            } else {
+                $this->_adyenLogger->addAdyenResult("Customer was redirected to bank for 3D-secure validation.");
+                $order->addStatusHistoryComment(
+                    __(
+                        'Customer was redirected to bank for 3D-secure validation. Once the shopper authenticated,
+                        the order status will be updated accordingly.
+                        <br />Make sure that your notifications are being processed!
+                        <br />If the order is stuck on this status, the shopper abandoned the session.
+                        The payment can be seen as unsuccessful.
+                        <br />The order can be automatically cancelled based on the OFFER_CLOSED notification.
+                        Please contact Adyen Support to enable this.'
+                    )
+                )->save();
+                return self::NEEDS_REDIRECT;
+            }
+        } elseif (!empty($checkoutAPM)) {
+            return self::NEEDS_REDIRECT;
+        } else {
+            return self::ALREADY_SUCCESSFUL;
+        }
+    }
+
+    /**
+     * Called by redirect controller when cc payment has 3D secure
+     *
+     * @param $payment
+     * @return mixed
+     * @throws \Exception
+     */
+    private function _authorise3d($payment)
+    {
+        try {
+            $response = $this->_paymentRequest->authorise3d($payment);
+        } catch (\Exception $e) {
+            throw $e;
+        }
+        return $response;
+    }
+
+    /**
+     * @param \Magento\Sales\Model\Order $order
+     * @param $authorizeResult
+     */
+    private function markOrderAsAuthorized(\Magento\Sales\Model\Order $order, $authorizeResult): void
+    {
+        $order->addStatusHistoryComment(__('3D-secure validation was successful'))->save();
+        // set back to false so when pressed back button on the success page
+        // it will reactivate 3D secure
+        $order->getPayment()->setAdditionalInformation('3dActive', '');
+        $order->getPayment()->setAdditionalInformation('3dSuccess', true);
+
+        if (!$this->_adyenHelper->isCreditCardVaultEnabled() &&
+            !empty($authorizeResult['additionalData']['recurring.recurringDetailReference'])) {
+            $this->_adyenHelper->createAdyenBillingAgreement($order, $authorizeResult['additionalData']);
+        } elseif (!empty($authorizeResult['additionalData']['recurring.recurringDetailReference'])
+        ) {
+            try {
+                $additionalData = $authorizeResult['additionalData'];
+                $token = $additionalData['recurring.recurringDetailReference'];
+                $expirationDate = $additionalData['expiryDate'];
+                $cardType = $additionalData['paymentMethod'];
+                $cardSummary = $additionalData['cardSummary'];
+                /** @var PaymentTokenInterface $paymentToken */
+                $paymentToken = $this->paymentTokenFactory->create(
+                    PaymentTokenFactoryInterface::TOKEN_TYPE_CREDIT_CARD
+                );
+                $paymentToken->setGatewayToken($token);
+                $paymentToken->setExpiresAt($this->getExpirationDate($expirationDate));
+                $details = [
+                    'type' => $cardType,
+                    'maskedCC' => $cardSummary,
+                    'expirationDate' => $expirationDate
+                ];
+                $paymentToken->setTokenDetails(json_encode($details));
+                $extensionAttributes = $this->getExtensionAttributes($order->getPayment());
+                $extensionAttributes->setVaultPaymentToken($paymentToken);
+                $orderPayment = $order->getPayment()->setExtensionAttributes($extensionAttributes);
+                $add = $this->serializer->unserialize($orderPayment->getAdditionalData());
+                $add['force_save'] = true;
+                $orderPayment->setAdditionalData($this->serializer->serialize($add));
+                $this->orderPaymentResource->save($orderPayment);
+            } catch (\Exception $e) {
+                $this->_adyenLogger->error((string)$e->getMessage());
+            }
+        }
+
+        $this->_orderRepository->save($order);
+    }
+
+    /**
+     * @param $expirationDate
+     * @return string
+     */
+    private function getExpirationDate($expirationDate)
+    {
+        $expirationDate = explode('/', $expirationDate);
+        //add leading zero to month
+        $month = sprintf("%02d", $expirationDate[0]);
+        $expDate = new \DateTime(
+            $expirationDate[1]
+            . '-'
+            . $month
+            . '-'
+            . '01'
+            . ' '
+            . '00:00:00',
+            new \DateTimeZone('UTC')
+        );
+        // add one month
+        $expDate->add(new \DateInterval('P1M'));
+        return $expDate->format('Y-m-d 00:00:00');
+    }
+
+    /**
+     * Get payment extension attributes
+     *
+     * @param InfoInterface $payment
+     * @return OrderPaymentExtensionInterface
+     */
+    private function getExtensionAttributes(InfoInterface $payment)
+    {
+        $extensionAttributes = $payment->getExtensionAttributes();
+        if (null === $extensionAttributes) {
+            $extensionAttributes = $this->paymentExtensionFactory->create();
+            $payment->setExtensionAttributes($extensionAttributes);
+        }
+        return $extensionAttributes;
+    }
+}

--- a/Model/AdyenThreeDSProcess.php
+++ b/Model/AdyenThreeDSProcess.php
@@ -111,6 +111,29 @@ class AdyenThreeDSProcess implements AdyenThreeDSProcessInterface
     /**
      * {@inheridoc}
      */
+    public function headlessAuthorize($orderId, $payload)
+    {
+        // Decode payload from frontend
+        $payload = json_decode($payload, true);
+
+        // Validate JSON that has just been parsed if it was in a valid format
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            throw new \Magento\Framework\Exception\LocalizedException(
+                __('3D secure failed because the request was not a valid JSON')
+            );
+        }
+
+        $order = $this->orderFactory->create()->load($orderId);
+        return $this->authorize(
+            $order,
+            $payload['MD'],
+            $payload['PaRes']
+        );
+    }
+
+    /**
+     * {@inheridoc}
+     */
     public function authorize(Order $order, $requestMD, $requestPaRes): string
     {
         $active = null;

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1099,6 +1099,8 @@
                 type="Adyen\Payment\Model\AdyenInitiateTerminalApi"/>
     <preference for="Adyen\Payment\Api\AdyenThreeDS2ProcessInterface"
                 type="Adyen\Payment\Model\AdyenThreeDS2Process"/>
+    <preference for="Adyen\Payment\Api\AdyenThreeDSProcessInterface"
+                type="Adyen\Payment\Model\AdyenThreeDSProcess"/>
     <preference for="Adyen\Payment\Api\AdyenOriginKeyInterface"
                 type="Adyen\Payment\Model\AdyenOriginKey"/>
     <preference for="Adyen\Payment\Api\AdyenOrderPaymentStatusInterface"

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1091,6 +1091,8 @@
 
     <preference for="Adyen\Payment\Api\GuestAdyenPaymentMethodManagementInterface"
                 type="Adyen\Payment\Model\GuestAdyenPaymentMethodManagement"/>
+    <preference for="Adyen\Payment\Api\AdyenOrderPaymentDetailsInterface"
+                type="Adyen\Payment\Model\AdyenOrderPaymentDetails"/>
     <preference for="Adyen\Payment\Api\AdyenPaymentMethodManagementInterface"
                 type="Adyen\Payment\Model\AdyenPaymentMethodManagement"/>
     <preference for="Adyen\Payment\Api\AdyenRequestMerchantSessionInterface"

--- a/etc/webapi.xml
+++ b/etc/webapi.xml
@@ -65,6 +65,13 @@
         </resources>
     </route>
 
+    <route url="/V1/adyen/threeDSProcess" method="POST">
+        <service class="Adyen\Payment\Api\AdyenThreeDSProcessInterface" method="headlessAuthorize"/>
+        <resources>
+            <resource ref="anonymous"/>
+        </resources>
+    </route>
+
     <route url="/V1/adyen/originKey" method="GET">
         <service class="Adyen\Payment\Api\AdyenOriginKeyInterface" method="getOriginKey"/>
         <resources>

--- a/etc/webapi.xml
+++ b/etc/webapi.xml
@@ -85,4 +85,11 @@
             <resource ref="anonymous"/>
         </resources>
     </route>
+
+    <route url="/V1/adyen/orders/:orderId/payment-details" method="POST">
+        <service class="Adyen\Payment\Api\AdyenOrderPaymentDetailsInterface" method="getDetails"/>
+        <resources>
+            <resource ref="anonymous"/>
+        </resources>
+    </route>
 </routes>


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
This PR brings several new features that enable a wider range of payment flows in a PWA context.
It was successfully tested (Q/A is still in progress for more in-depth testing) with the following methods: directEbanking, ideal, ebanking_FI, bcmc, dotpay, facilipay (Oney), klarna, giropay, trustly, 3DS and 3DS2.

**Tested scenarios**
- customer can be redirected to the payment provider: Magento now return correct `action` details for `RedirectShopper` values in the `/payment-status` endpoint
- customers can be redirected back to the PWA from the payment provider in redirect actions
- 3DS1 flows can now be fully achieved thanks to the new `/adyen/threeDSProcess` API endpoint (it would fix #787, however #821 introduced a "regression" preventing the user to be redirected back properly… to be discussed)
- PWA can get instant details about a payment so they can present an accurate information to the shopper ([according to the `resultCode`](https://docs.adyen.com/checkout/payment-result-codes)) no matter the platform it is redirected back from. A new `/adyen/orders/:orderId/payment-details` API endpoint was created to support this, because notifications are not processed fast enough (Magento receives them ~10-20 seconds after the customer is redirect back, and then it needs to be processed with the next CRON run)

**Fixed issue**:  #787 

## ToDo

- [ ] 3DS1 redirection seems to now be failing since #821 reverted the feature added in #806 and #786. I think that we need to find the correct canonical way to use correct urls (and this PR will have to be updated to use it) 
- [ ] improve the `/adyen/orders/:orderId/payment-details` new API endpoint:
  - [ ] I'd appreciate your feedback on the signature and ways to receive params, so it feels natural and consistent with other endpoints
  - [ ] it seems to me that it might need further security to prevent leaking sensitive information. The most important I can think of is ensuring that the customers are allowed to get details about the order. Your feedback is welcome, and if possible I'd appreciate to be shown other locations in the code where it is implemented (I couldn't fine what security strategies were in place for the `/payment-status` API)
- [ ] implement a way to restore quote in a PWA context so customers are not frustrated if they cancel their payment (it could be another PR/issue by itself). The Adyen module calls `$session->restoreQuote()` at controller level because it is session based. The code could be duplicated to do it from an order id. However I'd appreciate your opinion about how / when it should be done… in the `payment-details` endpoint? A new separate endpoint?
See https://github.com/magento/magento2/blob/390505a93555198c93331ed9159664fbccb70cd9/app/code/Magento/Checkout/Model/Session.php#L558-L567


Please let me know if you need further information.