### PR TITLE
3DSecure authorisation fails when additional data is missing from result

### DIFF
--- a/Model/AdyenThreeDS2Process.php
+++ b/Model/AdyenThreeDS2Process.php
@@ -173,7 +173,9 @@ class AdyenThreeDS2Process implements AdyenThreeDS2ProcessInterface
         // Save the payments response because we are going to need it during the place order flow
         $payment->setAdditionalInformation("paymentsResponse", $result);
 
-        $this->vaultHelper->saveRecurringDetails($payment, $result['additionalData']);
+        if (!empty($result['additionalData'])) {
+            $this->vaultHelper->saveRecurringDetails($payment, $result['additionalData']);
+        }
 
         // To actually save the additional info changes into the quote
         $order->save();


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
Check additionalData key in result before using

**Tested scenarios**
card payment 3DS1 and 3DS2

**Fixed issue**:  <!-- #-prefixed issue number -->
#825 [PW-3138] 3DSecure authorisation fails 