### PR TITLE
[PW-3220] Revert the config to exclude adyen js from minification

### DIFF
--- a/etc/config.xml
+++ b/etc/config.xml
@@ -230,17 +230,5 @@
                 <group>adyen</group>
             </adyen_google_pay>
         </payment>
-        <dev>
-            <js>
-                <minify_exclude>
-                    <adyen_payment>adyen.com/checkoutshopper</adyen_payment>
-                </minify_exclude>
-            </js>
-            <css>
-                <minify_exclude>
-                    <adyen_payment>adyen.com/checkoutshopper</adyen_payment>
-                </minify_exclude>
-            </css>
-        </dev>
     </default>
 </config>


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
We had to remove the fix from the config.xml to exclude the adyen checkout component js file from minification. The reason is that the ```<minify_exclude>``` is supported by magento version 2.3 and above and not from the older versions. We are planning to make a generic fix for this which will covers all the versions.
For now merchants who are using 2.3 and above can use the adyen-magento2 [version release 6.6.0](https://github.com/Adyen/adyen-magento2/pull/817)


**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

**Fixed issue**:  <!-- #-prefixed issue number -->