### PR TITLE
Use Oney as Open Invoice payment method in Cron

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -1066,7 +1066,8 @@ class Data extends AbstractHelper
     {
         if (strpos($paymentMethod, 'afterpay') !== false ||
             strpos($paymentMethod, 'klarna') !== false ||
-            strpos($paymentMethod, 'ratepay') !== false
+            strpos($paymentMethod, 'ratepay') !== false ||
+            strpos($paymentMethod, 'facilypay_') !== false
         ) {
             return true;
         }


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Oney payment methods are not being processed as an open invoice payment method, not allowing for manual capture. Since Oney is an open invoice, I suggest we add it to the list in `Adyen\Payment\Helper\Data`.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
None.

**Fixed issue**:  <!-- #-prefixed issue number -->