### PR TITLE
Fixing Magento2 Commerce edition error with 3DS when having website r…

### DIFF
--- a/etc/webrestrictions.xml
+++ b/etc/webrestrictions.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_WebsiteRestriction:etc/webrestrictions.xsd">
     <action path="adyen_process_json" type="generic" />
+    <action path="adyen_transparent_redirect" type="generic" />
 </config>


### PR DESCRIPTION
**Description**
This happens when you have website restrictions enable to force login in Magento 2 Commerce or Cloud Edition

**Tested scenarios**

1. Enable the website restrictions with forced login
2. Try to make a purchase with 3DS
3. When it redirects back it should work as expected (send you to order confirmation page)
