### PR TITLE
[PW-3462] Remove mapping the bcmc to maestro

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/adyen-cc-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-cc-method.js
@@ -190,13 +190,7 @@ define(
                                     self.installments(0);
                                 }
                             }
-
-                            // for BCMC as this is not a core payment method inside magento use maestro as brand detection
-                            if (creditCardType == "BCMC") {
-                                self.creditCardType("MI");
-                            } else {
-                                self.creditCardType(creditCardType);
-                            }
+                            self.creditCardType(creditCardType);
                         } else {
                             self.creditCardType("")
                             self.installments(0);


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
The mapping is not needed anymore. The bancontact is available in magento and displayed in orders
**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
Test the bancontact in magento2 using Adyen test card and checking if it is authorised as bcmc in the backoffice and in the orders if it is set correct

**Fixed issue**:  #899 