### PR TITLE
[PW-3157] [iDeal] First notification is unsuccessful but a second notification 2 minutes later send a success response => order canceled but payment is in success

### DIFF
--- a/Model/Cron.php
+++ b/Model/Cron.php
@@ -382,26 +382,68 @@ class Cron
      */
     private function shouldSkipProcessingNotification($notification)
     {
-        // OFFER_CLOSED notifications needs to be at least 10 minutes old to be processed
-        $offerClosedMinDate = new \DateTime();
-        $offerClosedMinDate->modify('-10 minutes');
+        switch ($notification['event_code']) {
+            // Remove OFFER_CLOSED and AUTHORISATION success=false notifications for some time from the processing list
+            // to ensure they won't close any order which has an AUTHORISED notification arrived a bit later than the
+            // OFFER_CLOSED or the AUTHORISATION success=false one.
+            case Notification::OFFER_CLOSED:
+                // OFFER_CLOSED notifications needs to be at least 10 minutes old to be processed
+                $offerClosedMinDate = new \DateTime();
+                $offerClosedMinDate->modify('-10 minutes');
+                $createdAt = \DateTime::createFromFormat('Y-m-d H:i:s', $notification['created_at']);
+                // To get the difference between $offerClosedMinDate and $createdAt, $offerClosedMinDate time in seconds
+                // is deducted from $createdAt time in seconds, divided by 60 and rounded down to integer
+                $minutesUntilProcessing = floor(
+                    ($createdAt->getTimestamp() - $offerClosedMinDate->getTimestamp()) / 60
+                );
 
-        // Remove OFFER_CLOSED notifications arrived in the last 10 minutes from the list to process to ensure it
-        // won't close any order which has an AUTHORISED notification arrived a bit later than the OFFER_CLOSED one.
-        $createdAt = \DateTime::createFromFormat('Y-m-d H:i:s', $notification['created_at']);
-        // To get the difference between $offerClosedMinDate and $createdAt, $offerClosedMinDate time in seconds is
-        // deducted from $createdAt time in seconds, divided by 60 and rounded down to integer
-        $minutesUntilProcessing = floor(($createdAt->getTimestamp() - $offerClosedMinDate->getTimestamp()) / 60);
-        if ($notification['event_code'] == Notification::OFFER_CLOSED && $minutesUntilProcessing > 0) {
-            $this->_adyenLogger->addAdyenNotificationCronjob(
-                sprintf(
-                    'OFFER_CLOSED notification %s skipped! Wait %s minute(s) before processing.',
-                    $notification->getEntityId(),
-                    $minutesUntilProcessing
-                )
-            );
+                if ($minutesUntilProcessing > 0) {
+                    $this->_adyenLogger->addAdyenNotificationCronjob(
+                        sprintf(
+                            'OFFER_CLOSED notification (entity_id: %s) for merchant_reference: %s is skipped! Wait %s minute(s) before processing.',
+                            $notification->getEntityId(),
+                            $notification->getMerchantReference(),
+                            $minutesUntilProcessing
+                        )
+                    );
 
-            return true;
+                    return true;
+                }
+
+                break;
+            case Notification::AUTHORISATION:
+                // Only delay success=false notifications processing
+                if (
+                    strcmp($notification['success'], 'true') == 0 ||
+                    strcmp($notification['success'], '1') == 0
+                ) {
+                    // do not skip this notification but process it now
+                    return false;
+                }
+
+                // AUTHORISATION success=false notifications needs to be at least 10 minutes old to be processed
+                $authorisationSuccessFalseMinDate = new \DateTime();
+                $authorisationSuccessFalseMinDate->modify('-10 minutes');
+                $createdAt = \DateTime::createFromFormat('Y-m-d H:i:s', $notification['created_at']);
+
+                $minutesUntilProcessing = floor(
+                    ($createdAt->getTimestamp() - $authorisationSuccessFalseMinDate->getTimestamp()) / 60
+                );
+
+                if ($minutesUntilProcessing > 0) {
+                    $this->_adyenLogger->addAdyenNotificationCronjob(
+                        sprintf(
+                            'AUTHORISATION success=false notification (entity_id: %s) for merchant_reference: %s is skipped! Wait %s minute(s) before processing.',
+                            $notification->getEntityId(),
+                            $notification->getMerchantReference(),
+                            $minutesUntilProcessing
+                        )
+                    );
+
+                    return true;
+                }
+
+                break;
         }
 
         return false;
@@ -753,7 +795,8 @@ class Cron
 
         // if payment method is klarna, ratepay or openinvoice/afterpay show the reservartion number
         if ($this->_adyenHelper->isPaymentMethodOpenInvoiceMethod(
-            $this->_paymentMethod) && !empty($this->_klarnaReservationNumber)) {
+                $this->_paymentMethod
+            ) && !empty($this->_klarnaReservationNumber)) {
             $klarnaReservationNumberText = "<br /> reservationNumber: " . $this->_klarnaReservationNumber;
         } else {
             $klarnaReservationNumberText = "";

--- a/Model/Cron.php
+++ b/Model/Cron.php
@@ -388,14 +388,10 @@ class Cron
             // OFFER_CLOSED or the AUTHORISATION success=false one.
             case Notification::OFFER_CLOSED:
                 // OFFER_CLOSED notifications needs to be at least 10 minutes old to be processed
-                $offerClosedMinDate = new \DateTime();
-                $offerClosedMinDate->modify('-10 minutes');
+                $offerClosedMinDate = new \DateTime('-10 minutes');
                 $createdAt = \DateTime::createFromFormat('Y-m-d H:i:s', $notification['created_at']);
-                // To get the difference between $offerClosedMinDate and $createdAt, $offerClosedMinDate time in seconds
-                // is deducted from $createdAt time in seconds, divided by 60 and rounded down to integer
-                $minutesUntilProcessing = floor(
-                    ($createdAt->getTimestamp() - $offerClosedMinDate->getTimestamp()) / 60
-                );
+
+                $minutesUntilProcessing = $createdAt->diff($offerClosedMinDate)->i;
 
                 if ($minutesUntilProcessing > 0) {
                     $this->_adyenLogger->addAdyenNotificationCronjob(
@@ -422,13 +418,10 @@ class Cron
                 }
 
                 // AUTHORISATION success=false notifications needs to be at least 10 minutes old to be processed
-                $authorisationSuccessFalseMinDate = new \DateTime();
-                $authorisationSuccessFalseMinDate->modify('-10 minutes');
+                $authorisationSuccessFalseMinDate = new \DateTime('-10 minutes');
                 $createdAt = \DateTime::createFromFormat('Y-m-d H:i:s', $notification['created_at']);
 
-                $minutesUntilProcessing = floor(
-                    ($createdAt->getTimestamp() - $authorisationSuccessFalseMinDate->getTimestamp()) / 60
-                );
+                $minutesUntilProcessing = $createdAt->diff($authorisationSuccessFalseMinDate)->i;
 
                 if ($minutesUntilProcessing > 0) {
                     $this->_adyenLogger->addAdyenNotificationCronjob(


### PR DESCRIPTION
**Description**
Delay processing of AUTHORISATION success=false notifications by 10 min
In some edge cases (for example 3DS1 authentication) an authorisation
success=false notification can be sent earlier than the success=true one
The reason can be a closed and reopened mobile application where the
customer performs the 3DS1 authentication
To avoid closing false unsuccessful orders, processing authorisation
success=false and offer_closed notifications are delayed

**Tested scenarios**
OFFER_CLOSED and AUTHORISATION success=false notification processing

**Fixed issue**:  <!-- #-prefixed issue number -->