### PR TITLE
Release 6.6.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "adyen/module-payment",
   "description": "Official Magento2 Plugin to connect to Payment Service Provider Adyen.",
   "type": "magento2-module",
-  "version": "6.6.6",
+  "version": "6.6.8",
   "license": [
     "OSL-3.0",
     "AFL-3.0"


### PR DESCRIPTION
**Fixes**
#831 Move BeforeShipmentObserver to global area
#899 Remove js code which map the bcmc to maestro
#910 [PW-3157] [iDeal] First notification is unsuccessful but a second notification 2 minutes later send a success response => order canceled but payment is in success
#911 CSP Whitelist config

**Fixed issues**
#875 [PW-3462] Bancontact is stored as Maestro in Magento
#717 [PW-3157] [iDeal] First notification is unsuccessful but a second notification 2 minutes later send a success response => order canceled but payment is in success