### PR TITLE
Adding Magento and Plugin versions to the bug report

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -20,6 +20,14 @@ Steps to reproduce the behavior:
 **Expected behavior**
 A clear and concise description of what you expected to happen.
 
+**Magento version**
+
+[e.g. 2.4.1]
+
+**Plugin version**
+
+[e.g. 6.6.8]
+
 **Screenshots**
 If applicable, add screenshots to help explain your problem.
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -24,7 +24,6 @@ A clear and concise description of what you expected to happen.
 [e.g. 2.4.1]
 
 **Plugin version**
-
 [e.g. 6.6.8]
 
 **Screenshots**

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -21,7 +21,6 @@ Steps to reproduce the behavior:
 A clear and concise description of what you expected to happen.
 
 **Magento version**
-
 [e.g. 2.4.1]
 
 **Plugin version**


### PR DESCRIPTION
Most times we're asking for these versions in follow up messages, better to have them in the initial report right away.
