### PR TITLE
[PW-3705] Implement importOrderPayment method in Adyen billing agreement

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -1689,7 +1689,11 @@ class Data extends AbstractHelper
                     // create new BA
                     $billingAgreement = $this->billingAgreementFactory->create();
                     $billingAgreement->setStoreId($order->getStoreId());
-                    $billingAgreement->importOrderPaymentWithRecurringDetailReference($order->getPayment(), $additionalData['recurring.recurringDetailReference']);                    if ($billingAgreement->getCustomerId() === null) {
+                    $billingAgreement->importOrderPaymentWithRecurringDetailReference(
+                        $order->getPayment(),
+                        $additionalData['recurring.recurringDetailReference']
+                    );
+                    if ($billingAgreement->getCustomerId() === null) {
                         $billingAgreement->setCustomerId($this->getCustomerId($order));
                     }
                     $message = __(

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -1689,8 +1689,7 @@ class Data extends AbstractHelper
                     // create new BA
                     $billingAgreement = $this->billingAgreementFactory->create();
                     $billingAgreement->setStoreId($order->getStoreId());
-                    $billingAgreement->importOrderPayment($order->getPayment());
-                    if ($billingAgreement->getCustomerId() === null) {
+                    $billingAgreement->importOrderPaymentWithRecurringDetailReference($order->getPayment(), $additionalData['recurring.recurringDetailReference']);                    if ($billingAgreement->getCustomerId() === null) {
                         $billingAgreement->setCustomerId($this->getCustomerId($order));
                     }
                     $message = __(

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -1693,9 +1693,7 @@ class Data extends AbstractHelper
                         $order->getPayment(),
                         $additionalData['recurring.recurringDetailReference']
                     );
-                    if ($billingAgreement->getCustomerId() === null) {
-                        $billingAgreement->setCustomerId($this->getCustomerId($order));
-                    }
+
                     $message = __(
                         'Created billing agreement #%1.',
                         $additionalData['recurring.recurringDetailReference']

--- a/Model/Billing/Agreement.php
+++ b/Model/Billing/Agreement.php
@@ -274,6 +274,7 @@ class Agreement extends \Magento\Paypal\Model\Billing\Agreement
      * @param $recurringDetailReference
      * @return $this
      * @throws \Magento\Framework\Exception\LocalizedException
+     * todo: refactor or remove this method as those fields are set later
      */
     public function importOrderPaymentWithRecurringDetailReference(Payment $payment, $recurringDetailReference)
     {

--- a/Model/Billing/Agreement.php
+++ b/Model/Billing/Agreement.php
@@ -23,6 +23,8 @@
 
 namespace Adyen\Payment\Model\Billing;
 
+use Magento\Sales\Model\Order\Payment;
+
 class Agreement extends \Magento\Paypal\Model\Billing\Agreement
 {
     /**
@@ -190,8 +192,8 @@ class Agreement extends \Magento\Paypal\Model\Billing\Agreement
             !isset($contractDetail['paymentMethod'])
         ) {
             $this->_errors[] = __(
-                '"In the Additional data in API response section, select: Card bin, 
-                Card summary, Expiry Date, Cardholder name, Recurring details and Variant 
+                '"In the Additional data in API response section, select: Card bin,
+                Card summary, Expiry Date, Cardholder name, Recurring details and Variant
                 to create billing agreements immediately after the payment is authorized."'
             );
             return $this;
@@ -263,6 +265,32 @@ class Agreement extends \Magento\Paypal\Model\Billing\Agreement
         }
 
         $this->setAgreementData($agreementData);
+
+        return $this;
+    }
+
+    /**
+     * @param Payment $payment
+     * @param $recurringDetailReference
+     * @return $this
+     * @throws \Magento\Framework\Exception\LocalizedException
+     */
+    public function importOrderPaymentWithRecurringDetailReference(Payment $payment, $recurringDetailReference)
+    {
+        $baData = $payment->getBillingAgreementData();
+        $this->_paymentMethodInstance = (isset($baData['method_code']))
+            ? $this->_paymentData->getMethodInstance($baData['method_code'])
+            : $payment->getMethodInstance();
+        if(empty($baData['billing_agreement_id'])){
+            $baData['billing_agreement_id'] = $recurringDetailReference;
+        }
+
+        $this->_paymentMethodInstance->setStore($payment->getMethodInstance()->getStore());
+        $this->setCustomerId($payment->getOrder()->getCustomerId())
+            ->setMethodCode($this->_paymentMethodInstance->getCode())
+            ->setReferenceId($baData['billing_agreement_id'])
+            ->setStatus(self::STATUS_ACTIVE)
+            ->setAgreementLabel($this->_paymentMethodInstance->getTitle());
 
         return $this;
     }

--- a/Model/Cron.php
+++ b/Model/Cron.php
@@ -1289,7 +1289,7 @@ class Cron
 
                             $billingAgreement = $this->_billingAgreementFactory->create();
                             $billingAgreement->setStoreId($this->_order->getStoreId());
-                            $billingAgreement->importOrderPayment($this->_order->getPayment());
+                            $billingAgreement->importOrderPaymentWithRecurringDetailReference($this->_order->getPayment(), $recurringDetailReference);
                             $message = __('Created billing agreement #%1.', $recurringDetailReference);
                         } else {
                             $this->_adyenLogger->addAdyenNotificationCronjob


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Implement importOrderPayment method in Adyen billing agreement because so far we were using the one from Paypal. 
The issue is that the magento 2.4 is using php 7.4 as in this version if an array is not null but the index does not exist then throws exception. 
Adding the new implementation of `importOrderPayment` the `$baData = $payment->getBillingAgreementData()` is checked and if the billing_agreement_id is not exist then the recurringDetailReference is assigned to `baData['billing_agreement_id']`. 
The importOrderPayment method is used and replaced in Data.php and Cron.php

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

**Fixed issue**:  <!-- #-prefixed issue number -->
Magento 2.3 
 Create a BA 
Cron create BA 
Magento 2.4 
Create a BA 
 Cron create BA