### PR TITLE
Replacing AdyenCheckout config 'groupTypes' with 'brands'

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/adyen-cc-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-cc-method.js
@@ -126,7 +126,7 @@ define(
 
                 self.cardComponent = self.checkoutComponent.create('card', {
                     enableStoreDetails: self.getEnableStoreDetails(),
-                    groupTypes: self.getAvailableCardTypeAltCodes(),
+                    brands: self.getAvailableCardTypeAltCodes(),
                     onChange: function(state, component) {
                         self.placeOrderAllowed(!!state.isValid);
                     },


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
The version of the web component used does not work with the AdyenCheckout config 'groupTypes', here it is being replaced with 'brands'.

**Tested scenarios**
Cards component allows configured cards.

**Fixed issue**:  NA