### PR TITLE
Added missing 'items' data required for checkout agreements

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/adyen-hpp-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-hpp-method.js
@@ -166,6 +166,10 @@ define(
                     result.value = result.getBrandCode();
                     result.name = value;
                     result.method = self.item.method;
+                    result.item = {
+                        "title": value.title,
+                        "method": value.type
+                    };
                     /**
                      * Observable to enable and disable place order buttons for payment methods
                      * Default value is true to be able to send the real hpp requiests that doesn't require any input


### PR DESCRIPTION
**Description**
When checkout agreements are enabled, and the target Terms and conditions are set to be applied manually the checkbox to agree with the terms and conditions cannot be checked for alternative payment methods, with the exception of the first alternative payment method.

This is happening because Magento generates the ID of the input field based on data that is set for the specified payment method. In the case of alternative payment methods (HPP) this data is missing.

Because the method cannot be found an empty string is used, and the resulting id becomes `agreement__1`. Since the checkbox is updated based on this ID, when it is clicked the incorrect selector is targeted. Resulting in the checkbox not being checked.

The logic of the ID generation can be found in the magento core under: `vendor/magento/module-checkout-agreements/view/frontend/web/js/view/checkout-agreements.js:62`

As you can see on this line, the example given is:

```
// item looks like this: {title: "Check / Money order", method: "checkmo"}
```

To stay in line with the expected values I have also added the `title` to the data.

**Tested scenarios**
- Checkout flow

**Fixed issue**:   #948 