### PR TITLE
Updated check to disable storing of CC details when vault is disabled

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/adyen-cc-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-cc-method.js
@@ -119,7 +119,7 @@ define(
              * @returns {*|boolean}
              */
             getEnableStoreDetails: function () {
-                return this.canCreateBillingAgreement() && !this.isVaultEnabled();
+                return this.canCreateBillingAgreement() && this.isVaultEnabled();
             },
             /**
              * Renders the secure fields,


### PR DESCRIPTION
**Description**
When checking if it should be possible to store CC details we currently check if the vault is _**disabled**_. I would however expect that storing of payment details should only be possible if the vault option is _**enabled**_.

**Tested scenarios**
- Checkout flow

**Fixed issue**:  #951 