### PR TITLE
[PW-4027] Shopper reference is too short for api v66

### DIFF
--- a/Helper/PaymentMethods.php
+++ b/Helper/PaymentMethods.php
@@ -178,7 +178,7 @@ class PaymentMethods extends AbstractHelper
                     $currencyCode
                 ),
             ],
-            "shopperReference" => $this->getCurrentShopperReference(),
+            "shopperReference" => str_pad($this->getCurrentShopperReference(), 3, '0', STR_PAD_LEFT),
             "shopperLocale" => $this->adyenHelper->getCurrentLocaleCode($store->getId())
         ];
 

--- a/Helper/Requests.php
+++ b/Helper/Requests.php
@@ -101,7 +101,7 @@ class Requests extends AbstractHelper
         $request = []
     ) {
         if ($customerId > 0) {
-            $request['shopperReference'] = $customerId;
+            $request['shopperReference'] = str_pad($customerId, 3, '0', STR_PAD_LEFT);
         }
         else {
             $uuid = Uuid::generateV4();

--- a/Model/AdyenInitiateTerminalApi.php
+++ b/Model/AdyenInitiateTerminalApi.php
@@ -260,7 +260,7 @@ class AdyenInitiateTerminalApi implements AdyenInitiateTerminalApiInterface
 
             if (!empty($recurringContract) && !empty($shopperEmail)) {
                 $saleToAcquirerData['shopperEmail'] = $shopperEmail;
-                $saleToAcquirerData['shopperReference'] = (string)$customerId;
+                $saleToAcquirerData['shopperReference'] = str_pad((string)$customerId, 3, '0', STR_PAD_LEFT);
                 $saleToAcquirerData['recurringContract'] = $recurringContract;
             }
         }


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
Shopper reference was too short, less than 3 digits and therefore the tokens cannot be retrieved on the /paymentMethods call. It is updated so it is always 3 digits at least.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

**Fixed issue**:  <!-- #-prefixed issue number -->