### PR TITLE
[PW-3950] All the klarna variants skips the no required fields

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/adyen-hpp-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-hpp-method.js
@@ -257,7 +257,7 @@ define(
                      * @returns {boolean}
                      */
                     result.isPaymentMethodKlarna = function () {
-                        if (result.getBrandCode() === "klarna") {
+                        if (result.getBrandCode().indexOf("klarna") >= 0) {
                             return true;
                         }
 


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
Magento 2 6.6.5 and above are requiring klarna pay now (tx klarna_paynow) and klarna pay over time (tx klarna_account) extra fields when checking out. ie. Gender, DOB and telephone number.

If the payment method brand code includes any klarma variant the extra fields are skipped and not shown.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

**Fixed issue**:  <!-- #-prefixed issue number -->