### PR TITLE
clone_quote configuration flag

### DIFF
--- a/Controller/Process/Result.php
+++ b/Controller/Process/Result.php
@@ -143,15 +143,24 @@ class Result extends \Magento\Framework\App\Action\Action
      */
     protected function replaceCart($response)
     {
-        try {
-            $newQuote = $this->quoteHelper->cloneQuote($this->_session->getQuote(), $this->_order);
-            $this->_session->replaceQuote($newQuote);
-        } catch (\Magento\Framework\Exception\LocalizedException $e) {
+        if ($this->_adyenHelper->getConfigData(
+            "clone_quote",
+            "adyen_abstract",
+            $this->_order->getStoreId(),
+            true
+        )) {
+            try {
+                $newQuote = $this->quoteHelper->cloneQuote($this->_session->getQuote(), $this->_order);
+                $this->_session->replaceQuote($newQuote);
+            } catch (\Magento\Framework\Exception\LocalizedException $e) {
+                $this->_session->restoreQuote();
+                $this->_adyenLogger->addAdyenResult(
+                    'Error when trying to create a new quote, ' .
+                    'the previous quote has been restored instead: ' . $e->getMessage()
+                );
+            }
+        } else {
             $this->_session->restoreQuote();
-            $this->_adyenLogger->addAdyenResult(
-                'Error when trying to create a new quote, ' .
-                'the previous quote has been restored instead: ' . $e->getMessage()
-            );
         }
 
         if (isset($response['authResult']) && $response['authResult'] == \Adyen\Payment\Model\Notification::CANCELLED) {

--- a/etc/adminhtml/system/adyen_checkout_experience.xml
+++ b/etc/adminhtml/system/adyen_checkout_experience.xml
@@ -42,5 +42,11 @@
             <config_path>payment/adyen_abstract/return_path</config_path>
             <tooltip><![CDATA[The path the customer will be redirected to when payment was <b>not</b> successful. Default is <i>checkout/cart</i>.]]></tooltip>
         </field>
+        <field id="clone_quote" translate="label" type="select" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
+            <label>Clone quote on failed payment</label>
+            <config_path>payment/adyen_abstract/clone_quote</config_path>
+            <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+            <tooltip><![CDATA[3DS1, 3DS2 and redirect failed payments can restore the previous quote or clone it for a retry.]]></tooltip>
+        </field>
     </group>
 </include>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -39,6 +39,7 @@
                 <enable_recurring>0</enable_recurring>
                 <group>adyen</group>
                 <notifications_can_cancel>1</notifications_can_cancel>
+                <clone_quote>0</clone_quote>
             </adyen_abstract>
             <adyen_cc>
                 <active>1</active>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1063,6 +1063,7 @@
                 <item name="payment/adyen_apple_pay/full_path_location_pem_file_live" xsi:type="string">1</item>
                 <item name="payment/adyen_abstract/notifications_ip_check" xsi:type="string">1</item>
                 <item name="payment/adyen_abstract/notifications_hmac_check" xsi:type="string">1</item>
+                <item name="payment/adyen_abstract/clone_quote" xsi:type="string">1</item>
             </argument>
             <argument name="sensitive" xsi:type="array">
                 <item name="payment/adyen_abstract/merchant_account" xsi:type="string">1</item>


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
Adding a new config flag `clone_quote` to check before cloning or restoring the quote on failed payment.

**Tested scenarios**
 * `clone_quote` -> true
    * Guest
        * Redirect failed payment: Quote cloned.
        * 3DS1 failed payment: Quote cloned.
        * 3DS2 failed payment: Quote restored (Guest 3DS2 will always restore as there's no active cart ID to check).
    * Logged In
        * Redirect failed payment: Quote cloned.
        * 3DS1 failed payment: Quote cloned.
        * 3DS2 failed payment: Quote cloned.
  * `clone_quote` -> false
    * Guest
        * Redirect failed payment: Quote restored.
        * 3DS1 failed payment: Quote restored.
        * 3DS2 failed payment: Quote restored (Guest 3DS2 will always restore as there's no active cart ID to check).
    * Logged In
        * Redirect failed payment: Quote restored.
        * 3DS1 failed payment: Quote restored.
        * 3DS2 failed payment: Quote restored.

**Fixed issue**:  PW-4113