### PR TITLE
[PW-4070] Using TaxAmount for open invoice line items instead of calculating the value

### DIFF
--- a/Gateway/Request/CheckoutDataBuilder.php
+++ b/Gateway/Request/CheckoutDataBuilder.php
@@ -245,7 +245,7 @@ class CheckoutDataBuilder implements BuilderInterface
 
             $formattedPriceExcludingTax = $this->adyenHelper->formatAmount($item->getPrice(), $currency);
 
-            $taxAmount = $item->getPrice() * ($item->getTaxPercent() / 100);
+            $taxAmount = $item->getTaxAmount();
             $formattedTaxAmount = $this->adyenHelper->formatAmount($taxAmount, $currency);
             $formattedTaxPercentage = $item->getTaxPercent() * 100;
 


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
The price and tax calculation caused rounding errors, the item's TaxAmount is being used here instead.

**Tested scenarios**
The open invoice line items tax is not calculated, TaxAmount is used instead.

**Fixed issue**:  PW-4070