### PR TITLE
[PW-4070] Using TaxAmount for open invoice line items instead of calculating the value 

### DIFF
--- a/Helper/ChargedCurrency.php
+++ b/Helper/ChargedCurrency.php
@@ -104,14 +104,14 @@ class ChargedCurrency
                 $item->getBasePrice(),
                 $item->getQuote()->getBaseCurrencyCode(),
                 $item->getBaseDiscountAmount(),
-                ($item->getTaxPercent() / 100) * $item->getBasePrice()
+                $item->getBaseTaxAmount()
             );
         }
         return new AdyenAmountCurrency(
             $item->getRowTotal() / $item->getQty(),
             $item->getQuote()->getQuoteCurrencyCode(),
             $item->getDiscountAmount(),
-            ($item->getTaxPercent() / 100) * ($item->getRowTotal() / $item->getQty())
+            $item->getTaxAmount()
         );
     }
 


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
The price and tax calculation caused rounding errors, the item's TaxAmount is being used here instead.

**Tested scenarios**
The open invoice line items tax is not calculated, TaxAmount is used instead.

**Fixed issue**:  PW-4070