### PR TITLE
Replacing order amount for build subject amount on refund request builder

### DIFF
--- a/Gateway/Request/RefundDataBuilder.php
+++ b/Gateway/Request/RefundDataBuilder.php
@@ -84,7 +84,7 @@ class RefundDataBuilder implements BuilderInterface
         $pspReference = $payment->getCcTransId();
         $orderAmountCurrency = $this->chargedCurrency->getOrderAmountCurrency($payment->getOrder(), false);
         $currency = $orderAmountCurrency->getCurrencyCode();
-        $amount = $orderAmountCurrency->getAmount();
+        $amount = $buildSubjectAmount;
         $storeId = $order->getStoreId();
         $method = $payment->getMethod();
         $merchantAccount = $this->adyenHelper->getAdyenMerchantAccount($method, $storeId);

--- a/Gateway/Request/RefundDataBuilder.php
+++ b/Gateway/Request/RefundDataBuilder.php
@@ -110,7 +110,7 @@ class RefundDataBuilder implements BuilderInterface
                 $orderPaymentCollection->addPaymentFilterDescending($payment->getId());
             } elseif ($refundStrategy == "3") {
                 // refund based on ratio
-                $ratio = $buildSubjectAmount / $amount;
+                $ratio = $buildSubjectAmount / $orderAmountCurrency->getAmount();
                 $orderPaymentCollection->addPaymentFilterAscending($payment->getId());
             }
 


### PR DESCRIPTION
**Description**
The amount set for refunds was being fetched from the order total and not from the refund request.

**Tested scenarios**
Partial refunds use the request amount with the order currency (system or Adyen's depending on the charged currency config).

**Fixed issue**: fixes  #976 