### PR TITLE
Adding the RedirectDataBuilder to OneClick payments

### DIFF
--- a/etc/di.xml
+++ b/etc/di.xml
@@ -607,6 +607,7 @@
                 <item name="recurring" xsi:type="string">Adyen\Payment\Gateway\Request\RecurringDataBuilder</item>
                 <item name="oneclick" xsi:type="string">Adyen\Payment\Gateway\Request\OneclickAuthorizationDataBuilder</item>
                 <item name="threeds2" xsi:type="string">Adyen\Payment\Gateway\Request\ThreeDS2DataBuilder</item>
+                <item name="redirect" xsi:type="string">Adyen\Payment\Gateway\Request\RedirectDataBuilder</item>
             </argument>
         </arguments>
     </virtualType>


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
OneClick payments will need the RedirectDataBuilder for 3DS1 cards.

**Tested scenarios**
OneClick 3DS1 payments use the Auto and Manual behavior.

**Fixed issue**:  NA