### PR TITLE
Remove unknown function call allowRecurring

### DIFF
--- a/view/adminhtml/templates/form/cc.phtml
+++ b/view/adminhtml/templates/form/cc.phtml
@@ -131,7 +131,7 @@ $ccExpYear = $block->getInfoData('cc_exp_year');
                         type: 'card',
                         groupTypes: ccTypes,
                         hideCVC: hideCVC,
-                        enableStoreDetails: "<?= /* @noEscape */ $block->allowRecurring() && !$block->isVaultEnabled();?>",
+                        enableStoreDetails: "<?= /* @noEscape */ !$block->isVaultEnabled();?>",
 
                         onChange: function (state) {
                             // When the state is valid update the input fields


### PR DESCRIPTION
This method was removed in version 6.7 (https://github.com/Adyen/adyen-magento2/commit/0d9fa3cc2a806b584a14a28aeb6774b3b8af8c8f). Currently crashing order placement though admin if grand total is grater than 0.


https://github.com/Adyen/adyen-magento2/blob/6.7.0/Block/Form/Cc.php