### PR TITLE
extract isAutoCapture logic to separate class

### DIFF
--- a/Model/Config/Source/ManualCaptureMethods.php
+++ b/Model/Config/Source/ManualCaptureMethods.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2015 Adyen BV (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+declare(strict_types=1);
+
+namespace Adyen\Payment\Model\Config\Source;
+
+use Magento\Framework\Data\OptionSourceInterface;
+
+class ManualCaptureMethods implements OptionSourceInterface
+{
+    public function toOptionArray(): array
+    {
+        return [
+            ['value' => 'cup',               'label' => 'China Union Pay'],
+            ['value' => 'cartebancaire',     'label' => 'Carte Bancaire'],
+            ['value' => 'visa',              'label' => 'VISA'],
+            ['value' => 'visadankort',       'label' => 'VISA Dankort'],
+            ['value' => 'mc',                'label' => 'Mastercard'],
+            ['value' => 'uatp',              'label' => 'Universal Air Travel Plan'],
+            ['value' => 'amex',              'label' => 'American Express'],
+            ['value' => 'maestro',           'label' => 'Maestro'],
+            ['value' => 'maestrouk',         'label' => 'Maestro UK'],
+            ['value' => 'diners',            'label' => 'Diners Club'],
+            ['value' => 'discover',          'label' => 'Discover'],
+            ['value' => 'jcb',               'label' => 'JCB'],
+            ['value' => 'laser',             'label' => 'Laser'],
+            ['value' => 'paypal',            'label' => 'PayPal'],
+            ['value' => 'sepadirectdebit',   'label' => 'SEPA Direct Debit'],
+            ['value' => 'dankort',           'label' => 'Dankort'],
+            ['value' => 'elo',               'label' => 'Elo'],
+            ['value' => 'hipercard',         'label' => 'Hipercard'],
+            ['value' => 'mc_applepay',       'label' => 'Mastercard Apple Pay'],
+            ['value' => 'visa_applepay',     'label' => 'VISA Apple Pay'],
+            ['value' => 'amex_applepay',     'label' => 'American Express Apple Pay'],
+            ['value' => 'discover_applepay', 'label' => 'Discover Apple Pay'],
+            ['value' => 'maestro_applepay',  'label' => 'Maestro Apple Pay'],
+            ['value' => 'paywithgoogle',     'label' => 'Google Pay'],
+        ];
+    }
+}

--- a/Model/Config/Source/ManualCaptureMethods.php
+++ b/Model/Config/Source/ManualCaptureMethods.php
@@ -15,7 +15,7 @@
  *
  * Adyen Payment module (https://www.adyen.com/)
  *
- * Copyright (c) 2015 Adyen BV (https://www.adyen.com/)
+ * Copyright (c) 2021 Adyen BV (https://www.adyen.com/)
  * See LICENSE.txt for license details.
  *
  * Author: Adyen <magento@adyen.com>

--- a/Model/Cron/IsAutoCapture.php
+++ b/Model/Cron/IsAutoCapture.php
@@ -15,7 +15,7 @@
  *
  * Adyen Payment module (https://www.adyen.com/)
  *
- * Copyright (c) 2015 Adyen BV (https://www.adyen.com/)
+ * Copyright (c) 2021 Adyen BV (https://www.adyen.com/)
  * See LICENSE.txt for license details.
  *
  * Author: Adyen <magento@adyen.com>

--- a/Model/Cron/IsAutoCapture.php
+++ b/Model/Cron/IsAutoCapture.php
@@ -1,0 +1,198 @@
+<?php
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2015 Adyen BV (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+declare(strict_types=1);
+
+namespace Adyen\Payment\Model\Cron;
+
+use Adyen\Payment\Helper\Data;
+use Adyen\Payment\Logger\AdyenLogger;
+use Adyen\Payment\Model\Config\Source\ManualCaptureMethods;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Sales\Api\Data\OrderInterface;
+use Magento\Store\Model\ScopeInterface;
+
+class IsAutoCapture
+{
+    private $adyenHelper;
+    private $adyenLogger;
+    private $scopeConfig;
+    private $manualCaptureMethods;
+
+    public function __construct(
+        Data $adyenHelper,
+        AdyenLogger $adyenLogger,
+        ScopeConfigInterface $scopeConfig,
+        ManualCaptureMethods $manualCaptureMethods
+    ) {
+        $this->adyenHelper = $adyenHelper;
+        $this->adyenLogger = $adyenLogger;
+        $this->scopeConfig = $scopeConfig;
+        $this->manualCaptureMethods = $manualCaptureMethods;
+    }
+
+    /**
+     * Validate if this payment methods allows manual capture
+     * This is a default can be forced differently to overrule on acquirer level
+     *
+     * @param string $paymentMethod
+     * @return bool
+     */
+    private function manualCaptureAllowed(string $paymentMethod): bool
+    {
+        // For all openinvoice methods manual capture is the default
+        if ($this->adyenHelper->isPaymentMethodOpenInvoiceMethod($paymentMethod)) {
+            return true;
+        }
+
+        return in_array($paymentMethod, array_map(function ($method) {
+            return $method['value'];
+        }, $this->manualCaptureMethods->toOptionArray()));
+    }
+
+    private function getConfigData(string $field, string $paymentMethodCode, int $storeId)
+    {
+        $path = 'payment/' . $paymentMethodCode . '/' . $field;
+        return $this->scopeConfig->getValue($path, ScopeInterface::SCOPE_STORE, $storeId);
+    }
+
+    private function isManualCapturePaypal(int $storeId): bool
+    {
+        return (bool) $this->getConfigData('paypal_capture_mode', 'adyen_abstract', $storeId);
+    }
+
+    private function isCaptureModeOpenInvoice(int $storeId): bool
+    {
+        return (bool) $this->getConfigData('auto_capture_openinvoice', 'adyen_abstract', $storeId);
+    }
+
+    private function getCaptureMode(int $storeId): string
+    {
+        return trim($this->getConfigData('capture_mode', 'adyen_abstract', $storeId));
+    }
+
+    private function getSepaFlow(int $storeId): string
+    {
+        return trim($this->getConfigData('sepa_flow', 'adyen_abstract', $storeId));
+    }
+
+    public function check(OrderInterface $order, string $paymentMethod): bool
+    {
+        // validate if payment methods allows manual capture
+        if ($this->manualCaptureAllowed($paymentMethod)) {
+            $storeId = (int) $order->getStoreId();
+            $sepaFlow = $this->getSepaFlow($storeId);
+
+            /*
+             * if you are using authcap the payment method is manual.
+             * There will be a capture send to indicate if payment is successful
+             */
+            if ($paymentMethod === 'sepadirectdebit' && $sepaFlow === 'authcap') {
+                $this->adyenLogger->addAdyenNotificationCronjob(
+                    'Manual Capture is applied for sepa because it is in authcap flow'
+                );
+                return false;
+            }
+
+            $paymentCode = $order->getPayment()->getMethod();
+
+            // payment method ideal, cash adyen_boleto has direct capture
+            if ($paymentMethod === 'sepadirectdebit' && $sepaFlow !== 'authcap') {
+                $this->adyenLogger->addAdyenNotificationCronjob(
+                    'This payment method does not allow manual capture.(2) paymentCode:' .
+                    $paymentCode . ' paymentMethod:' . $paymentMethod . ' sepaFLow:' . $sepaFlow
+                );
+                return true;
+            }
+
+            if ($paymentCode === 'adyen_pos_cloud') {
+                $captureModePos = $this->adyenHelper->getAdyenPosCloudConfigData(
+                    'capture_mode_pos',
+                    $storeId
+                );
+                if (strcmp($captureModePos, 'auto') === 0) {
+                    $this->adyenLogger->addAdyenNotificationCronjob(
+                        'This payment method is POS Cloud and configured to be working as auto capture '
+                    );
+                    return true;
+                } elseif (strcmp($captureModePos, 'manual') === 0) {
+                    $this->adyenLogger->addAdyenNotificationCronjob(
+                        'This payment method is POS Cloud and configured to be working as manual capture '
+                    );
+                    return false;
+                }
+            }
+
+            // if auto capture mode for openinvoice is turned on then use auto capture
+            if ($this->isCaptureModeOpenInvoice($storeId) &&
+                $this->adyenHelper->isPaymentMethodOpenInvoiceMethod($paymentMethod)
+            ) {
+                $this->adyenLogger->addAdyenNotificationCronjob(
+                    'This payment method is configured to be working as auto capture '
+                );
+                return true;
+            }
+
+            // if PayPal capture modues is different from the default use this one
+            if (strcmp($paymentMethod, 'paypal') === 0) {
+                if ($this->isManualCapturePaypal($storeId)) {
+                    $this->adyenLogger->addAdyenNotificationCronjob(
+                        'This payment method is paypal and configured to work as manual capture'
+                    );
+                    return false;
+                } else {
+                    $this->adyenLogger->addAdyenNotificationCronjob(
+                        'This payment method is paypal and configured to work as auto capture'
+                    );
+                    return true;
+                }
+            }
+            if (strcmp($this->getCaptureMode($storeId), 'manual') === 0) {
+                $this->adyenLogger->addAdyenNotificationCronjob(
+                    'Capture mode for this payment is set to manual'
+                );
+                return false;
+            }
+
+            /*
+             * online capture after delivery, use Magento backend to online invoice
+             * (if the option auto capture mode for openinvoice is not set)
+             */
+            if ($this->adyenHelper->isPaymentMethodOpenInvoiceMethod($paymentMethod)) {
+                $this->adyenLogger->addAdyenNotificationCronjob(
+                    'Capture mode for klarna is by default set to manual'
+                );
+                return false;
+            }
+
+            $this->adyenLogger->addAdyenNotificationCronjob('Capture mode is set to auto capture');
+            return true;
+        } else {
+            // does not allow manual capture so is always immediate capture
+            $this->adyenLogger->addAdyenNotificationCronjob(
+                'This payment method does not allow manual capture'
+            );
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
**Description**

In one of our recent Adyen implementations, there is a need to change auto-capturing dynamically.

Some orders will be partially financed with the deposit being paid through Adyen, and capture/cancellation will be determined later based on their eligibility for financing.

To facilitate this I have introduced a new class `Adyen\Payment\Model\Cron\IsAutoCapture`. This contains the same logic that was previously in `Adyen\Payment\Model\Cron::_isAutoCapture` method. Some cleanup was done to the body of this method.

`Adyen\Payment\Model\Cron` is mostly unchanged, except for calling into this new class and ordering some class imports.

I also introduced a `ManualCaptureMethods` config source, to make things even cleaner.

What this now allows us to do is create plugins on `IsAutoCapture`, and implement any logic required.

I personally think that `Cron` class has become a bit of a monstrosity (2000+ LOC and ~30 dependencies) and could benefit from more composition, but I wanted to keep scope for this PR small to gauge your thoughts. Opening as a draft PR to discuss.