### PR TITLE
[PW-4369] Add Cartes Bancaires logo to Magento 2 card logos

### DIFF
--- a/Model/Config/Source/CcType.php
+++ b/Model/Config/Source/CcType.php
@@ -54,7 +54,7 @@ class CcType extends \Magento\Payment\Model\Source\Cctype
      */
     public function getAllowedTypes()
     {
-        return ['VI', 'MC', 'AE', 'DI', 'JCB', 'UN', 'MI', 'DN', 'BCMC', 'HIPERCARD', 'ELO', 'TROY', 'DANKORT'];
+        return ['VI', 'MC', 'AE', 'DI', 'JCB', 'UN', 'MI', 'DN', 'BCMC', 'HIPERCARD', 'ELO', 'TROY', 'DANKORT', 'CB'];
     }
 
     /**

--- a/etc/adyen_payment.xml
+++ b/etc/adyen_payment.xml
@@ -81,5 +81,9 @@
             <label>Dankort</label>
             <code_alt>dankort</code_alt>
         </type>
+        <type id="CB" order="140">
+            <label>Cartes Bancaire</label>
+            <code_alt>cartebancaire</code_alt>
+        </type>
     </adyen_credit_cards>
 </payment>


### PR DESCRIPTION
**Description**
Adding Cartes Bancaires to supported payment methods.
**Tested scenarios**
- [x] the logo shows up when you enter the test credit card details for Cartes Bancaires

**Fixed issue**:  
[PW-4369] Add Cartes Bancaires logo to Magento 2 card logos
