### PR TITLE
[PW-4538] Using type-brand structure for giftcards

### DIFF
--- a/Controller/Process/Result.php
+++ b/Controller/Process/Result.php
@@ -29,6 +29,26 @@ use Magento\Framework\App\Request\Http as Http;
 
 class Result extends \Magento\Framework\App\Action\Action
 {
+
+    const DETAILS_ALLOWED_PARAM_KEYS = [
+        'MD',
+        'PaReq',
+        'PaRes',
+        'billingToken',
+        'cupsecureplus.smscode',
+        'facilitatorAccessToken',
+        'oneTimePasscode',
+        'orderID',
+        'payerID',
+        'payload',
+        'paymentID',
+        'paymentStatus',
+        'redirectResult',
+        'threeDSResult',
+        'threeds2.challengeResult',
+        'threeds2.fingerprint'
+    ];
+
     /**
      * @var \Adyen\Payment\Helper\Data
      */
@@ -429,16 +449,9 @@ class Result extends \Magento\Framework\App\Action\Action
         $request = [];
 
         // filter details to match the keys
-        $allowedParams = $payment->getAdditionalInformation('details');
         $details = $result;
-        if (!empty($allowedParams)) {
-            $allowedParamsArray = [];
-            // TODO build a validator class which also validates the type of the param
-            foreach ($allowedParams as $allowedParam) {
-                $allowedParamsArray[] = $allowedParam['key'];
-            }
-            $details = DataArrayValidator::getArrayOnlyWithApprovedKeys($details, $allowedParamsArray);
-        }
+        // TODO build a validator class which also validates the type of the param
+        $details = DataArrayValidator::getArrayOnlyWithApprovedKeys($details, self::DETAILS_ALLOWED_PARAM_KEYS);
 
         // Remove helper params in case left in the request
         $helperParams = ['isAjax', 'merchantReference'];

--- a/Helper/PaymentMethods.php
+++ b/Helper/PaymentMethods.php
@@ -30,6 +30,11 @@ use Magento\Framework\App\Helper\AbstractHelper;
  */
 class PaymentMethods extends AbstractHelper
 {
+
+    const METHODS_WITH_BRAND_LOGO = [
+        "giftcard"
+    ];
+
     /**
      * @var \Magento\Quote\Api\CartRepositoryInterface
      */
@@ -183,7 +188,10 @@ class PaymentMethods extends AbstractHelper
         // Add extra details per payment method
         $paymentMethodsExtraDetails = [];
         $paymentMethodsExtraDetails = $this->showLogosPaymentMethods($paymentMethods, $paymentMethodsExtraDetails);
-        $paymentMethodsExtraDetails = $this->addExtraConfigurationToPaymentMethods($paymentMethods, $paymentMethodsExtraDetails);
+        $paymentMethodsExtraDetails = $this->addExtraConfigurationToPaymentMethods(
+            $paymentMethods,
+            $paymentMethodsExtraDetails
+        );
         $response['paymentMethodsExtraDetails'] = $paymentMethodsExtraDetails;
 
         //TODO this should be the implemented with an interface
@@ -389,7 +397,9 @@ class PaymentMethods extends AbstractHelper
             );
 
             foreach ($paymentMethods as $paymentMethod) {
-                $paymentMethodCode = $paymentMethod['type'];
+                $paymentMethodCode = array_search($paymentMethod['type'], self::METHODS_WITH_BRAND_LOGO) !== false
+                    ? $paymentMethod['brand']
+                    : $paymentMethod['type'];
 
                 $asset = $this->assetRepo->createAsset(
                     'Adyen_Payment::images/logos/' .
@@ -425,7 +435,8 @@ class PaymentMethods extends AbstractHelper
         return $paymentMethodsExtraDetails;
     }
 
-    protected function addExtraConfigurationToPaymentMethods($paymentMethods, array $paymentMethodsExtraDetails) {
+    protected function addExtraConfigurationToPaymentMethods($paymentMethods, array $paymentMethodsExtraDetails)
+    {
         $quote = $this->getQuote();
         $currencyCode = $this->chargedCurrency->getQuoteAmountCurrency($quote)->getCurrencyCode();
         $amountValue = $this->adyenHelper->formatAmount($this->getCurrentPaymentAmount(), $currencyCode);

--- a/Helper/PaymentMethods.php
+++ b/Helper/PaymentMethods.php
@@ -397,7 +397,7 @@ class PaymentMethods extends AbstractHelper
             );
 
             foreach ($paymentMethods as $paymentMethod) {
-                $paymentMethodCode = array_search($paymentMethod['type'], self::METHODS_WITH_BRAND_LOGO) !== false
+                $paymentMethodCode = in_array($paymentMethod['type'], self::METHODS_WITH_BRAND_LOGO)
                     ? $paymentMethod['brand']
                     : $paymentMethod['type'];
 

--- a/view/frontend/web/template/payment/hpp-form.html
+++ b/view/frontend/web/template/payment/hpp-form.html
@@ -32,15 +32,15 @@
 <!-- ko foreach: adyenPaymentMethods -->
     <div class="payment-method"
          data-bind="
-         css: {'_active': (paymentMethod.type == $parent.getSelectedAlternativePaymentMethodType())},
+         css: {'_active': (paymentMethod.methodIdentifier == $parent.getSelectedAlternativePaymentMethodType())},
          visible: isAvailable()">
         <div class="payment-method-title field choice">
             <span data-bind="text: payment[method]"></span>
             <input type="radio"
                    name="payment[method]"
                    class="radio"
-                   data-bind="attr: {'id': 'adyen_' + paymentMethod.type}, value: 'adyen_' + paymentMethod.type, checked: paymentMethod.type == $parent.getSelectedAlternativePaymentMethodType, click: $parent.selectPaymentMethodType"/>
-            <label data-bind="attr: {'for': 'adyen_' + paymentMethod.type}" class="label">
+                   data-bind="attr: {'id': 'adyen_' + paymentMethod.methodIdentifier}, value: 'adyen_' + paymentMethod.methodIdentifier, checked: paymentMethod.methodIdentifier == $parent.getSelectedAlternativePaymentMethodType, click: $parent.selectPaymentMethodType"/>
+            <label data-bind="attr: {'for': 'adyen_' + paymentMethod.methodIdentifier}" class="label">
 
                 <!-- ko if: icon -->
                 <img data-bind="attr: {
@@ -58,7 +58,7 @@
             <!-- ko template: getTemplate() --><!-- /ko -->
             <!--/ko-->
             <div>
-                <span class="message message-error error hpp-message" data-bind="attr: {id: 'messages-' + paymentMethod.type}"></span>
+                <span class="message message-error error hpp-message" data-bind="attr: {id: 'messages-' + paymentMethod.methodIdentifier}"></span>
             </div>
 
             <div class="payment-method-billing-address">
@@ -68,7 +68,7 @@
             </div>
 
             <form class="form" data-role="adyen-hpp-form" action="#" method="post"
-                  data-bind="mageInit: { 'validation':[]}, attr: {id: 'payment_form_' + $parent.getCode() + '_' + paymentMethod.type}">
+                  data-bind="mageInit: { 'validation':[]}, attr: {id: 'payment_form_' + $parent.getCode() + '_' + paymentMethod.methodIdentifier}">
 
                 <!-- ko ifnot: showPlaceOrderButton() -->
                 <div class="checkout-agreements-block">
@@ -79,8 +79,8 @@
                 <!--/ko-->
 
                 <fieldset class="fieldset"
-                          data-bind='attr: {id: "payment_fieldset_" + $parent.getCode() + "_" + paymentMethod.type}'>
-                    <div data-bind='attr: {id: "adyen-alternative-payment-container-" + paymentMethod.type}'
+                          data-bind='attr: {id: "payment_fieldset_" + $parent.getCode() + "_" + paymentMethod.methodIdentifier}'>
+                    <div data-bind='attr: {id: "adyen-alternative-payment-container-" + paymentMethod.methodIdentifier}'
                          afterRender="renderCheckoutComponent()"></div>
                 </fieldset>
 


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
In Checkout API v65 giftcards now include the `brand` parameter as an identifier for the type of payment method and this requires some adjustments to the following:

- The adyen_hpp JS component renderer now checks for `brandMethods` so that the `type` and `brand` are assigned to `methodGroup` and `methodIdentifier`. Regular methods assign the `type` to both.
- The adyen_hpp HTML template now uses the `methodIdentifier` to render the methods forms.
- The /payments/details call in the Result controller validates the params from the Open API specs of v67, previously a `type` param was being sent that rejected the calls for giftcards.
- The type-brand methods are now checked to get the specific logo instead of the group (e.g. vvvcadeaubon instead of giftcard).

**Tested scenarios**
E2E tests
Giftcard payments with multiple brands enabled
HPP payments

**Fixed issue**:  PW-4538 fixes #1011 