### PR TITLE
[PW4572] Update the time calculation between offer closed and created

### DIFF
--- a/Model/Cron.php
+++ b/Model/Cron.php
@@ -415,8 +415,7 @@ class Cron
                 // OFFER_CLOSED notifications needs to be at least 10 minutes old to be processed
                 $offerClosedMinDate = new \DateTime('-10 minutes');
                 $createdAt = \DateTime::createFromFormat('Y-m-d H:i:s', $notification['created_at']);
-
-                $minutesUntilProcessing = $createdAt->diff($offerClosedMinDate)->i;
+                $minutesUntilProcessing = ($createdAt->format('U') - $offerClosedMinDate->format('U')) / 60;
 
                 if ($minutesUntilProcessing > 0) {
                     $this->_adyenLogger->addAdyenNotificationCronjob(


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
The usage of  `->i` is not accurate to calculate the minutes difference between the two DateTime objects created and offer closed . The "i" attribute doesn't take into account the hours and the days in DateInterval.
Using `$minutesUntilProcessing = ($createdAt->format('U') - $offerClosedMinDate->format('U')) / 60; ` Is taking the account the days and the hours

Example: 
~~~php
$offerClosedMinDate = new \DateTime('2021-04-26 12:40:00'); 
$createdAt = \DateTime::createFromFormat('Y-m-d H:i:s', '2021-04-25 12:45:00'); 
$minutesUntilProcessing1 = ($createdAt->format('U') - $offerClosedMinDate->format('U')) / 60; //-1435
$minutesUntilProcessing2 = $createdAt->diff($offerClosedMinDate)->i; //55
~~~
**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

**Fixed issue**:  <!-- #-prefixed issue number --> 
fixes #1014