### PR TITLE
Support for Blik

### DIFF
--- a/Model/Cron.php
+++ b/Model/Cron.php
@@ -445,7 +445,7 @@ class Cron
                 $authorisationSuccessFalseMinDate = new \DateTime('-10 minutes');
                 $createdAt = \DateTime::createFromFormat('Y-m-d H:i:s', $notification['created_at']);
 
-                $minutesUntilProcessing = $createdAt->diff($authorisationSuccessFalseMinDate)->i;
+                $minutesUntilProcessing = ($createdAt->format('U') - $authorisationSuccessFalseMinDate->format('U')) / 60;
 
                 if ($minutesUntilProcessing > 0) {
                     $this->_adyenLogger->addAdyenNotificationCronjob(

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ If you need to setup your cronjob in Magento <a href="http://devdocs.magento.com
    * Ratepay
    * Oxxo
    * Econtexts
+   * Blik
 
 _This is not an extensive list of all the supported payment methods but only the ones that have been already verified. In case you would like to see other payment methods in the list as well please contact us to verify those too._
 

--- a/view/frontend/web/js/view/payment/method-renderer/adyen-hpp-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-hpp-method.js
@@ -244,13 +244,6 @@ define(
                                     showPayButton = true;
                                 }
 
-                                // If the details are empty and the pay button does not needs to be rendered by the component
-                                // simply skip rendering the adyen checkout component
-                                if (!paymentMethod.details && !showPayButton) {
-                                    result.isPlaceOrderAllowed(true);
-                                    return;
-                                }
-
                                 var city = '';
                                 var country = '';
                                 var postalCode = '';
@@ -359,8 +352,6 @@ define(
                                             component.mount(containerId);
                                         }).catch(e => {
                                             result.isAvailable(false);
-                                            console.log(paymentMethod.methodIdentifier +
-                                                ' is not available, the method will be hidden from the payment list');
                                         });
                                     } else {
                                         component.mount(containerId);


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
The payment method Blik doesn't return details in the paymentMethods object, so instead of checking for this object we're attempting to create and mount all HPP payment methods instead. If there isn't a Web Component the error is handled by the try/catch.

Unhappy flows for Blik send a AUTHORISATION success=false notification that was being ignored in some scenarios during cron run, same as #1014 

**Tested scenarios**
Happy and unhappy flows for Blik
ShowPayButton methods like Paypal
Details methods like iDeal

**Fixed issue**:  PW-4528