### PR TITLE
Allowing zero sub totals in Helper/PaymentMethods.php

### DIFF
--- a/Helper/PaymentMethods.php
+++ b/Helper/PaymentMethods.php
@@ -217,13 +217,13 @@ class PaymentMethods extends AbstractHelper
 
         $total = (float)$total;
 
-        if ($total > 0) {
+        if ($total >= 0) {
             return $total;
         }
 
         throw new \Exception(
             sprintf(
-                'Cannot retrieve a valid grand total from quote ID: `%s`. Expected a float > `0`, got `%f`.',
+                'Cannot retrieve a valid grand total from quote ID: `%s`. Expected a float >= `0`, got `%f`.',
                 $this->getQuote()->getEntityId(),
                 $total
             )


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
It is possible to place an order with a 0 grand total, and the plugin was checking for >0.

**Tested scenarios**
Placing order with 0 grand total + shipping costs.
Placing order with 0 grand total + free shipping.

**Fixed issue**:  #1023 