### PR TITLE
[PW4496] Remove verified Todos

### DIFF
--- a/Controller/Process/Result.php
+++ b/Controller/Process/Result.php
@@ -207,27 +207,6 @@ class Result extends \Magento\Framework\App\Action\Action
 
         $this->_adyenLogger->addAdyenResult('Processing ResultUrl');
 
-        // TODO check if needed since response is validated when calling this function
-        if (empty($response)) {
-            $this->_adyenLogger->addAdyenResult(
-                'Response is empty, please check your webserver that the result url accepts parameters'
-            );
-
-            throw new \Magento\Framework\Exception\LocalizedException(
-                __('Response is empty, please check your webserver that the result url accepts parameters')
-            );
-        }
-
-        // If the merchant signature is present, authenticate the result url
-        // TODO validate if merchant signature is still used or can be removed
-        if (!empty($response['merchantSig'])) {
-            // authenticate result url
-            $authStatus = $this->_authenticate($response);
-            if (!$authStatus) {
-                throw new \Magento\Framework\Exception\LocalizedException(__('ResultUrl authentification failure'));
-            }
-        }
-
         // send the payload verification payment\details request to validate the response
         $response = $this->validatePayloadAndReturnResponse($response);
 
@@ -240,11 +219,6 @@ class Result extends \Magento\Framework\App\Action\Action
                 'adyen_response' => $response
             ]
         );
-
-        // TODO is handled in the response?
-        if (isset($response['handled'])) {
-            return $response['handled_response'];
-        }
 
         // update the order
         $result = $this->_validateUpdateOrder($order, $response);


### PR DESCRIPTION

<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
This is part of PW-4496 ticket
Todos related to the merchantSig, handled, handled_response fields has been verified, we don't need those anymore with checkout

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

**Fixed issue**:  <!-- #-prefixed issue number -->