### PR TITLE
[PW-4496] POST redirect is not possible therefore the isAjax is not needed for v67

### DIFF
--- a/Controller/Process/Result.php
+++ b/Controller/Process/Result.php
@@ -119,14 +119,6 @@ class Result extends \Magento\Framework\App\Action\Action
         $this->storeManager = $storeManager;
         $this->quoteHelper = $quoteHelper;
         parent::__construct($context);
-        //TODO check if needed with version v67
-        if (interface_exists(\Magento\Framework\App\CsrfAwareActionInterface::class)) {
-            $request = $this->getRequest();
-            if ($request instanceof Http && $request->isPost()) {
-                $request->setParam('isAjax', true);
-                $request->getHeaders()->addHeaderLine('X_REQUESTED_WITH', 'XMLHttpRequest');
-            }
-        }
     }
 
     /**


### PR DESCRIPTION


<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Todo related to v67 POST redirect back in the Controller/Process/Result.php line 122 confirmed. In v67 no POST redirect is possible therefore the isAjax is not needed
**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
Ideal 
3DS1
**Fixed issue**:  <!-- #-prefixed issue number -->