### PR TITLE
[PW-4496] Remove storing additionalData for banktransfer iban and boleto

### DIFF
--- a/Gateway/Validator/CheckoutResponseValidator.php
+++ b/Gateway/Validator/CheckoutResponseValidator.php
@@ -96,47 +96,6 @@ class CheckoutResponseValidator extends AbstractValidator
             switch ($resultCode) {
                 case "Authorised":
                 case "Received":
-                    // TODO refactor since the full additionalData is stored in additionalInformation already
-                    // For banktransfers store all bankTransfer details
-                    if (!empty($response['additionalData']['bankTransfer.owner'])) {
-                        foreach ($response['additionalData'] as $key => $value) {
-                            if (strpos($key, 'bankTransfer') === 0) {
-                                $payment->setAdditionalInformation($key, $value);
-                            }
-                        }
-                    } elseif (!empty($response['additionalData']['comprafacil.entity'])) {
-                        //Multibanco resultCode has changed after checkout v49 and
-                        // comprafacil.entity is not received anymore
-                        foreach ($response['additionalData'] as $key => $value) {
-                            if (strpos($key, 'comprafacil') === 0) {
-                                $payment->setAdditionalInformation($key, $value);
-                            }
-                        }
-                    }
-
-                if (isset($response['additionalData']) && is_array($response['additionalData'])) {
-                    $additionalData = $response['additionalData'];
-                    if (isset($additionalData['boletobancario.dueDate'])) {
-                        $payment->setAdditionalInformation(
-                            'dueDate',
-                            $additionalData['boletobancario.dueDate']
-                        );
-                    }
-
-                    if (isset($additionalData['boletobancario.expirationDate'])) {
-                        $payment->setAdditionalInformation(
-                            'expirationDate',
-                            $additionalData['boletobancario.expirationDate']
-                        );
-                    }
-
-                    if (isset($additionalData['boletobancario.url'])) {
-                        $payment->setAdditionalInformation(
-                            'url',
-                            $additionalData['boletobancario.url']
-                        );
-                    }
-                }
 
                 // Save cc_type if available in the response
                 if (!empty($response['additionalData']['paymentMethod'])) {
@@ -146,9 +105,7 @@ class CheckoutResponseValidator extends AbstractValidator
                     $payment->setAdditionalInformation('cc_type', $ccType);
                     $payment->setCcType($ccType);
                 }
-
-
-                    break;
+                break;
                 case "IdentifyShopper":
                 case "ChallengeShopper":
                 case "PresentToShopper":


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Remove additionalData storing specifically for banktransfer iban and boleto from the Gateway/Validator/CheckoutResponseValidator.php 

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
Boleto
Banktransfer
**Fixed issue**:  <!-- #-prefixed issue number -->