### PR TITLE
Using charged currency to enable the grand total display

### DIFF
--- a/Model/Ui/AdyenGenericConfigProvider.php
+++ b/Model/Ui/AdyenGenericConfigProvider.php
@@ -23,32 +23,42 @@
 
 namespace Adyen\Payment\Model\Ui;
 
+use Adyen\Payment\Helper\Config;
+use Adyen\Payment\Helper\Data;
+use Adyen\Payment\Model\Config\Source\RenderMode;
 use Magento\Checkout\Model\ConfigProviderInterface;
+use Magento\Store\Model\StoreManagerInterface;
 
 class AdyenGenericConfigProvider implements ConfigProviderInterface
 {
     const CODE = 'adyen_abstract';
 
     /**
-     * @var \Adyen\Payment\Helper\Data
+     * @var Data
      */
     protected $adyenHelper;
 
     /**
-     * @var \Magento\Store\Model\StoreManagerInterface
+     * @var StoreManagerInterface
      */
     protected $storeManager;
+    /**
+     * @var Config
+     */
+    private $adyenConfigHelper;
 
     /**
      * AdyenGenericConfigProvider constructor.
      *
-     * @param \Adyen\Payment\Helper\Data $adyenHelper
+     * @param Data $adyenHelper
      */
     public function __construct(
-        \Adyen\Payment\Helper\Data $adyenHelper,
-        \Magento\Store\Model\StoreManagerInterface $storeManager
+        Data $adyenHelper,
+        Config $adyenConfigHelper,
+        StoreManagerInterface $storeManager
     ) {
         $this->adyenHelper = $adyenHelper;
+        $this->adyenConfigHelper = $adyenConfigHelper;
         $this->storeManager = $storeManager;
     }
 
@@ -59,6 +69,7 @@ class AdyenGenericConfigProvider implements ConfigProviderInterface
      */
     public function getConfig()
     {
+        $storeId = $this->storeManager->getStore()->getId();
         $config = [
             'payment' => []
         ];
@@ -70,12 +81,9 @@ class AdyenGenericConfigProvider implements ConfigProviderInterface
         }
 
         $config['payment']['adyen']['clientKey'] = $this->adyenHelper->getClientKey();
-        $config['payment']['adyen']['checkoutEnvironment'] = $this->adyenHelper->getCheckoutEnvironment(
-            $this->storeManager->getStore()->getId()
-        );
-        $config['payment']['adyen']['locale'] = $this->adyenHelper->getStoreLocale(
-            $this->storeManager->getStore()->getId()
-        );
+        $config['payment']['adyen']['checkoutEnvironment'] = $this->adyenHelper->getCheckoutEnvironment($storeId);
+        $config['payment']['adyen']['locale'] = $this->adyenHelper->getStoreLocale($storeId);
+        $config['payment']['adyen']['chargedCurrency'] = $this->adyenConfigHelper->getChargedCurrency($storeId);
 
         return $config;
     }
@@ -86,7 +94,7 @@ class AdyenGenericConfigProvider implements ConfigProviderInterface
     protected function showLogos()
     {
         $showLogos = $this->adyenHelper->getAdyenAbstractConfigData('title_renderer');
-        if ($showLogos == \Adyen\Payment\Model\Config\Source\RenderMode::MODE_TITLE_IMAGE) {
+        if ($showLogos == RenderMode::MODE_TITLE_IMAGE) {
             return true;
         }
         return false;

--- a/view/frontend/requirejs-config.js
+++ b/view/frontend/requirejs-config.js
@@ -7,8 +7,8 @@
 var config = {
     config: {
         mixins: {
-            'Adyen_Payment/js/action/place-order': {
-                'Magento_CheckoutAgreements/js/model/place-order-mixin': true
+            'Magento_Tax/js/view/checkout/summary/grand-total': {
+                'Adyen_Payment/js/view/checkout/summary/grand-total-mixin': true
             }
         }
     }

--- a/view/frontend/web/js/model/adyen-configuration.js
+++ b/view/frontend/web/js/model/adyen-configuration.js
@@ -20,23 +20,25 @@
  * Author: Adyen <magento@adyen.com>
  */
 define(
-    [
-    ],
+    [],
     function () {
-      'use strict';
-      return {
-        getClientKey: function () {
-          return window.checkoutConfig.payment.adyen.clientKey;
-        },
-        showLogo: function () {
-          return window.checkoutConfig.payment.adyen.showLogo;
-        },
-        getLocale: function () {
-          return window.checkoutConfig.payment.adyen.locale;
-        },
-        getCheckoutEnvironment: function () {
-          return window.checkoutConfig.payment.adyen.checkoutEnvironment;
-        },
-      };
+        'use strict';
+        return {
+            getClientKey: function () {
+                return window.checkoutConfig.payment.adyen.clientKey;
+            },
+            showLogo: function () {
+                return window.checkoutConfig.payment.adyen.showLogo;
+            },
+            getLocale: function () {
+                return window.checkoutConfig.payment.adyen.locale;
+            },
+            getCheckoutEnvironment: function () {
+                return window.checkoutConfig.payment.adyen.checkoutEnvironment;
+            },
+            getChargedCurrency: function () {
+                return window.checkoutConfig.payment.adyen.chargedCurrency;
+            },
+        };
     }
 );

--- a/view/frontend/web/js/view/checkout/summary/grand-total-mixin.js
+++ b/view/frontend/web/js/view/checkout/summary/grand-total-mixin.js
@@ -1,0 +1,45 @@
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2021 Adyen BV (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+define(
+    [
+        'Adyen_Payment/js/model/adyen-configuration',
+    ], function (adyenConfiguration) {
+        "use strict";
+        return function (target) {
+            return target.extend({
+                    /**
+                     * @return {*}
+                     */
+                    isBaseGrandTotalDisplayNeeded: function () {
+                        let total = this.totals();
+                        if (!total) {
+                            return false;
+                        }
+                        let chargedCurrency = adyenConfiguration.getChargedCurrency();
+                        return chargedCurrency === 'base' &&
+                            (total['base_currency_code'] != total['quote_currency_code']); //eslint-disable-line eqeqeq
+                    }
+                }
+            );
+        }
+    })
+;


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
Now that the plugin can be configured to process payments in the base or the display currency we're using the configuration value to modify the return from `Magento_Tax/js/view/checkout/summary/grand-total::isBaseGrandTotalDisplayNeeded` through a mixin. For reference, this is the function that is being overriden.

```
isBaseGrandTotalDisplayNeeded: function () {

            var total = this.totals();

            if (!total) {
                return false;
            }

            return total['base_currency_code'] != total['quote_currency_code']; //eslint-disable-line eqeqeq
        }
```

**Tested scenarios**

- Configured charged currency base, base currency differs from storeview's: The "You will be charged for XX" message is shown.
- Configured charged currency base, base currency equal to the storeview's: No message is shown.
- Configured charged currency display, base currency differs from storeview's: No message is shown.
- Configured charged currency display, base currency equal to the storeview's: No message is shown.

**Fixed issue**:  PW-4480