### PR TITLE
[PW-4636] Remove non-digits from postcode for Brazilian addresses

### DIFF
--- a/Helper/Requests.php
+++ b/Helper/Requests.php
@@ -277,7 +277,7 @@ class Requests extends AbstractHelper
                     $requestDelivery["postalCode"] = preg_replace(
                         '/[^\d]/',
                         '',
-                        $shippingAddress->getPostcode()
+                        $requestDelivery["postalCode"]
                     );
                 }
             }

--- a/Helper/Requests.php
+++ b/Helper/Requests.php
@@ -204,6 +204,13 @@ class Requests extends AbstractHelper
 
             if (!empty($billingAddress->getPostcode())) {
                 $requestBilling["postalCode"] = $billingAddress->getPostcode();
+                if ($billingAddress->getCountryId() == "BR") {
+                    $requestBilling["postalCode"] = preg_replace(
+                        '/[^\d]/',
+                        '',
+                        $billingAddress->getPostcode()
+                    );
+                }
             }
 
             if (!empty($billingAddress->getCity())) {
@@ -254,6 +261,13 @@ class Requests extends AbstractHelper
 
             if (!empty($shippingAddress->getPostcode())) {
                 $requestDelivery["postalCode"] = $shippingAddress->getPostcode();
+                if ($billingAddress->getCountryId() == "BR") {
+                    $requestBilling["postalCode"] = preg_replace(
+                        '/[^\d]/',
+                        '',
+                        $billingAddress->getPostcode()
+                    );
+                }
             }
 
             if (!empty($shippingAddress->getCity())) {

--- a/Helper/Requests.php
+++ b/Helper/Requests.php
@@ -202,17 +202,6 @@ class Requests extends AbstractHelper
                 $requestBilling["houseNumberOrName"] = $address["house_number"];
             }
 
-            if (!empty($billingAddress->getPostcode())) {
-                $requestBilling["postalCode"] = $billingAddress->getPostcode();
-                if ($billingAddress->getCountryId() == "BR") {
-                    $requestBilling["postalCode"] = preg_replace(
-                        '/[^\d]/',
-                        '',
-                        $billingAddress->getPostcode()
-                    );
-                }
-            }
-
             if (!empty($billingAddress->getCity())) {
                 $requestBilling["city"] = $billingAddress->getCity();
             }
@@ -223,6 +212,17 @@ class Requests extends AbstractHelper
 
             if (!empty($billingAddress->getCountryId())) {
                 $requestBilling["country"] = $billingAddress->getCountryId();
+            }
+
+            if (!empty($billingAddress->getPostcode())) {
+                $requestBilling["postalCode"] = $billingAddress->getPostcode();
+                if ($billingAddress->getCountryId() == "BR") {
+                    $requestBilling["postalCode"] = preg_replace(
+                        '/[^\d]/',
+                        '',
+                        $billingAddress->getPostcode()
+                    );
+                }
             }
 
             // If nothing is changed which means delivery address is not filled
@@ -259,17 +259,6 @@ class Requests extends AbstractHelper
                 $requestDelivery["houseNumberOrName"] = $address["house_number"];
             }
 
-            if (!empty($shippingAddress->getPostcode())) {
-                $requestDelivery["postalCode"] = $shippingAddress->getPostcode();
-                if ($billingAddress->getCountryId() == "BR") {
-                    $requestBilling["postalCode"] = preg_replace(
-                        '/[^\d]/',
-                        '',
-                        $billingAddress->getPostcode()
-                    );
-                }
-            }
-
             if (!empty($shippingAddress->getCity())) {
                 $requestDelivery["city"] = $shippingAddress->getCity();
             }
@@ -280,6 +269,17 @@ class Requests extends AbstractHelper
 
             if (!empty($shippingAddress->getCountryId())) {
                 $requestDelivery["country"] = $shippingAddress->getCountryId();
+            }
+
+            if (!empty($shippingAddress->getPostcode())) {
+                $requestDelivery["postalCode"] = $shippingAddress->getPostcode();
+                if ($shippingAddress->getCountryId() == "BR") {
+                    $requestDelivery["postalCode"] = preg_replace(
+                        '/[^\d]/',
+                        '',
+                        $shippingAddress->getPostcode()
+                    );
+                }
             }
 
             // If nothing is changed which means delivery address is not filled

--- a/Helper/Requests.php
+++ b/Helper/Requests.php
@@ -220,7 +220,7 @@ class Requests extends AbstractHelper
                     $requestBilling["postalCode"] = preg_replace(
                         '/[^\d]/',
                         '',
-                        $billingAddress->getPostcode()
+                        $requestBilling["postalCode"]
                     );
                 }
             }


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
The post codes for Brazilian address includes a `-` or other symbols that we need to remove before the payments request. 


**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
Tested with boleto
**Fixed issue**:  <!-- #-prefixed issue number -->