### PR TITLE
Getting item taxAmount from row's taxAmount

### DIFF
--- a/Gateway/Request/CheckoutDataBuilder.php
+++ b/Gateway/Request/CheckoutDataBuilder.php
@@ -286,7 +286,6 @@ class CheckoutDataBuilder implements BuilderInterface
             $formFields['lineItems'][] = [
                 'id' => $item->getId(),
                 'amountExcludingTax' => $formattedPriceExcludingTax,
-                'taxAmount' => $formattedTaxAmount,
                 'description' => $item->getName(),
                 'quantity' => $numberOfItems,
                 'taxCategory' => $item->getProduct()->getAttributeText('tax_class_id'),
@@ -305,7 +304,6 @@ class CheckoutDataBuilder implements BuilderInterface
             $formFields['lineItems'][] = [
                 'id' => 'Discount',
                 'amountExcludingTax' => $itemAmount,
-                'taxAmount' => $itemVatAmount,
                 'description' => $description,
                 'quantity' => $numberOfItems,
                 'taxCategory' => 'None',
@@ -337,7 +335,6 @@ class CheckoutDataBuilder implements BuilderInterface
             $formFields['lineItems'][] = [
                 'id' => 'shippingCost',
                 'amountExcludingTax' => $formattedPriceExcludingTax,
-                'taxAmount' => $formattedTaxAmount,
                 'description' => $order->getShippingDescription(),
                 'quantity' => 1,
                 'taxPercentage' => $formattedTaxPercentage

--- a/Helper/ChargedCurrency.php
+++ b/Helper/ChargedCurrency.php
@@ -103,14 +103,14 @@ class ChargedCurrency
                 $item->getBasePrice(),
                 $item->getQuote()->getBaseCurrencyCode(),
                 $item->getBaseDiscountAmount(),
-                $item->getBaseTaxAmount()
+                $item->getBaseTaxAmount() / $item->getQty()
             );
         }
         return new AdyenAmountCurrency(
             $item->getRowTotal() / $item->getQty(),
             $item->getQuote()->getQuoteCurrencyCode(),
             $item->getDiscountAmount(),
-            $item->getTaxAmount()
+            $item->getTaxAmount() / $item->getQty()
         );
     }
 
@@ -126,14 +126,14 @@ class ChargedCurrency
                 $item->getBasePrice(),
                 $item->getInvoice()->getBaseCurrencyCode(),
                 null,
-                $item->getBaseTaxAmount()
+                $item->getBaseTaxAmount() / $item->getQty()
             );
         }
         return new AdyenAmountCurrency(
             $item->getPrice(),
             $item->getInvoice()->getOrderCurrencyCode(),
             null,
-            $item->getTaxAmount()
+            $item->getTaxAmount() / $item->getQty()
         );
     }
 
@@ -149,14 +149,14 @@ class ChargedCurrency
                 $item->getBasePrice(),
                 $item->getCreditMemo()->getInvoice()->getBaseCurrencyCode(),
                 null,
-                $item->getBaseTaxAmount()
+                $item->getBaseTaxAmount() / $item->getQty()
             );
         }
         return new AdyenAmountCurrency(
             $item->getPrice(),
             $item->getCreditMemo()->getInvoice()->getOrderCurrencyCode(),
             null,
-            $item->getTaxAmount()
+            $item->getTaxAmount() / $item->getQty()
         );
     }
 


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
Payment, Capture and Refund requests were sending the item taxAmount incorrectly as this value in Magento's objects is not per item but rather per row. So rows with qty>1 were using the wrong taxAmount.

The taxAmount in the payments call is not required for open invoice items so it is being removed to avoid further similar issues in that step at least.

**Tested scenarios**
Payment, capture and refund of orders with multiple line items with qty>1, shipping costs and discounts.

**Fixed issue**:  PW-4638