### PR TITLE
[PW-4593] Do not change the email sending flag for boleto

### DIFF
--- a/Gateway/Response/CheckoutPaymentsDetailsHandler.php
+++ b/Gateway/Response/CheckoutPaymentsDetailsHandler.php
@@ -53,8 +53,11 @@ class CheckoutPaymentsDetailsHandler implements HandlerInterface
         // set transaction not to processing by default wait for notification
         $payment->setIsTransactionPending(true);
 
-        // no not send order confirmation mail
-        $payment->getOrder()->setCanSendNewEmailFlag(false);
+        // Email sending is set at CheckoutDataBuilder for Boleto
+        // Otherwise, we don't want to send a confirmation email
+        if ($payment->getMethod() != \Adyen\Payment\Model\Ui\AdyenBoletoConfigProvider::CODE) {
+            $payment->getOrder()->setCanSendNewEmailFlag(false);
+        }
 
         if (!empty($response['pspReference'])) {
             // set pspReference as transactionId


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
The checkout process changes the `canSendEmail` flag back and forth, and this ends up messing the flow for Boleto. The shopper would like to receive the email after a purchase that contains a link to download a copy of the barcode generated.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
Boleto payments send an email from the store

**Fixed issue**:  <!-- #-prefixed issue number -->