### PR TITLE
[PW-4688] Declare storeCc in adyen-cc-method

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/adyen-cc-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-cc-method.js
@@ -65,6 +65,7 @@ define(
                 template: 'Adyen_Payment/payment/cc-form',
                 installment: '', // keep it until the component implements installments
                 orderId: 0, // TODO is this the best place to store it?
+                storeCc: false,
             },
             /**
              * @returns {exports.initialize}
@@ -127,6 +128,7 @@ define(
                     brands: self.getAvailableCardTypeAltCodes(),
                     onChange: function(state, component) {
                         self.placeOrderAllowed(!!state.isValid);
+                        self.storeCc = !!state.data.storePaymentMethod;
                     },
                     // Keep onBrand as is until checkout component supports installments
                     onBrand: function(state) {


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->

Currently whenever there is a stored credit card details then the `is_visible` is set to 0 and the reason is that the `storecc` property in the `adyen-cc-method.js` is undefined.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

**Fixed issue**:  <!-- #-prefixed issue number -->#1044