### PR TITLE
[PW-4531] Add support for AmazonPay

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/adyen-hpp-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-hpp-method.js
@@ -347,6 +347,7 @@ define(
                                 // Extra apple pay configuration
                                 if (paymentMethod.methodIdentifier.includes('amazonpay')) {
                                     configuration = self.createAmazonPayConfiguration(configuration);
+                                    debugger;
                                 }
 
                                 try {
@@ -721,12 +722,15 @@ define(
             },
             createAmazonPayConfiguration: function (configuration) {
                 return Object.assign(configuration, {
+                    showOrderButton:true,
                     productType: 'PayOnly',
                     checkoutMode: 'ProcessOrder',
-                    returnUrl: location.href,
-                    checkoutReviewReturnUrl: location.href,
-                    prePayRedirect: true,
-                    sessionKey: amazonSessionKey
+                    returnUrl: "http://localhost:8080/index.php/",
+                    configuration: {
+                        merchantId: 'AAUL9GPRGTX1U',
+                        storeId: 'amzn1.application-oa2-client.3e5db0a580f7468da2d9903dda981fce',
+                        publicKeyId: 'AGDRUNN37LQHSOCHN24AEYYB'
+                    }
                 });
             }
         });


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->
This adds support for AmazonPay as a payment method

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
The web component redirects the shopper to the Amazon website where they choose a payment method from their account. Amazon redirects the shopper to the merchant's website, adding a token in the URL which is used to finally submit the payment.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
Payment with AmazonPay

**Fixed issue**:  #995 