### PR TITLE
[PW-4715] Disabling Boleto for admin orders because it returns PresentToShopper

### DIFF
--- a/etc/config.xml
+++ b/etc/config.xml
@@ -176,7 +176,7 @@
                 <can_authorize>1</can_authorize>
                 <can_capture>1</can_capture>
                 <can_capture_partial>1</can_capture_partial>
-                <can_use_internal>1</can_use_internal>
+                <can_use_internal>0</can_use_internal>
                 <can_refund_partial_per_invoice>1</can_refund_partial_per_invoice>
                 <can_refund>1</can_refund>
                 <can_void>1</can_void>


### PR DESCRIPTION

<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
Boleto returns PresentToShopper, so it could only be used by the shopper on the frontend.

**Tested scenarios**
While placing an admin order Boleto is not available.

**Fixed issue**:  PW-4715