### PR TITLE
[PW-4652] CC holder name config toggles

### DIFF
--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -36,6 +36,8 @@ class Config
     const XML_NOTIFICATIONS_HMAC_KEY_LIVE = "notification_hmac_key_live";
     const XML_NOTIFICATIONS_HMAC_KEY_TEST = "notification_hmac_key_test";
     const XML_CHARGED_CURRENCY = "charged_currency";
+    const XML_HAS_HOLDER_NAME = "has_holder_name";
+    const XML_HOLDER_NAME_REQUIRED = "holder_name_required";
 
     /**
      * @var Magento\Framework\App\Config\ScopeConfigInterface
@@ -163,6 +165,28 @@ class Config
     public function getChargedCurrency($storeId = null)
     {
         return $this->adyenHelper->getAdyenAbstractConfigData(self::XML_CHARGED_CURRENCY, $storeId);
+    }
+
+    /**
+     * Retrieve has_holder_name config
+     *
+     * @param null|int|string $storeId
+     * @return mixed
+     */
+    public function getHasHolderName($storeId = null)
+    {
+        return $this->adyenHelper->getAdyenCcConfigDataFlag(self::XML_HAS_HOLDER_NAME, $storeId);
+    }
+
+    /**
+     * Retrieve holder_name_required config
+     *
+     * @param null|int|string $storeId
+     * @return mixed
+     */
+    public function getHolderNameRequired($storeId = null)
+    {
+        return $this->adyenHelper->getAdyenCcConfigDataFlag(self::XML_HOLDER_NAME_REQUIRED, $storeId);
     }
 
     /**

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -175,7 +175,7 @@ class Config
      */
     public function getHasHolderName($storeId = null)
     {
-        return $this->adyenHelper->getAdyenCcConfigDataFlag(self::XML_HAS_HOLDER_NAME, $storeId);
+        return $this->adyenHelper->getAdyenAbstractConfigDataFlag(self::XML_HAS_HOLDER_NAME, $storeId);
     }
 
     /**
@@ -186,7 +186,7 @@ class Config
      */
     public function getHolderNameRequired($storeId = null)
     {
-        return $this->adyenHelper->getAdyenCcConfigDataFlag(self::XML_HOLDER_NAME_REQUIRED, $storeId);
+        return $this->adyenHelper->getAdyenAbstractConfigDataFlag(self::XML_HOLDER_NAME_REQUIRED, $storeId);
     }
 
     /**

--- a/Model/Ui/AdyenGenericConfigProvider.php
+++ b/Model/Ui/AdyenGenericConfigProvider.php
@@ -84,6 +84,8 @@ class AdyenGenericConfigProvider implements ConfigProviderInterface
         $config['payment']['adyen']['checkoutEnvironment'] = $this->adyenHelper->getCheckoutEnvironment($storeId);
         $config['payment']['adyen']['locale'] = $this->adyenHelper->getStoreLocale($storeId);
         $config['payment']['adyen']['chargedCurrency'] = $this->adyenConfigHelper->getChargedCurrency($storeId);
+        $config['payment']['adyen']['hasHolderName'] = $this->adyenConfigHelper->getHasHolderName($storeId);
+        $config['payment']['adyen']['holderNameRequired'] = $this->adyenConfigHelper->getHolderNameRequired($storeId);
 
         return $config;
     }

--- a/etc/adminhtml/system/adyen_cc.xml
+++ b/etc/adminhtml/system/adyen_cc.xml
@@ -86,23 +86,6 @@
                 <backend_model>Adyen\Payment\Model\Config\Backend\Installments</backend_model>
                 <config_path>payment/adyen_cc/installments</config_path>
             </field>
-            <field id="has_holder_name" translate="label" type="select" sortOrder="30" showInDefault="1"
-                   showInWebsite="1" showInStore="1">
-                <label>Show holder name field</label>
-                <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-                <tooltip>Set to Yes to show the input field for the card holder name</tooltip>
-                <config_path>payment/adyen_cc/has_holder_name</config_path>
-            </field>
-            <field id="holder_name_required" translate="label" type="select" sortOrder="40" showInDefault="1"
-                   showInWebsite="1" showInStore="1">
-                <label>Holder name required</label>
-                <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-                <tooltip>Set to Yes to make the card holder name a required field</tooltip>
-                <config_path>payment/adyen_cc/holder_name_required</config_path>
-                <depends>
-                    <field id="has_holder_name">1</field>
-                </depends>
-            </field>
         </group>
 
         <group id="adyen_cc_country_specific" translate="label" showInDefault="1" showInWebsite="1" sortOrder="70">

--- a/etc/adminhtml/system/adyen_cc.xml
+++ b/etc/adminhtml/system/adyen_cc.xml
@@ -93,6 +93,16 @@
                 <tooltip>Set to Yes to show the input field for the card holder name</tooltip>
                 <config_path>payment/adyen_cc/has_holder_name</config_path>
             </field>
+            <field id="holder_name_required" translate="label" type="select" sortOrder="40" showInDefault="1"
+                   showInWebsite="1" showInStore="1">
+                <label>Holder name required</label>
+                <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                <tooltip>Set to Yes to make the card holder name a required field</tooltip>
+                <config_path>payment/adyen_cc/holder_name_required</config_path>
+                <depends>
+                    <field id="has_holder_name">1</field>
+                </depends>
+            </field>
         </group>
 
         <group id="adyen_cc_country_specific" translate="label" showInDefault="1" showInWebsite="1" sortOrder="70">

--- a/etc/adminhtml/system/adyen_cc.xml
+++ b/etc/adminhtml/system/adyen_cc.xml
@@ -64,14 +64,14 @@
                sortOrder="60">
             <label>Advanced Settings</label>
             <frontend_model>Magento\Config\Block\System\Config\Form\Fieldset</frontend_model>
-            <field id="enable_installments" translate="label" type="select" sortOrder="219" showInDefault="1"
+            <field id="enable_installments" translate="label" type="select" sortOrder="10" showInDefault="1"
                    showInWebsite="1" showInStore="1">
                 <label>Enable Installments</label>
                 <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 <tooltip>Enable installments for each credit card type.</tooltip>
                 <config_path>payment/adyen_cc/enable_installments</config_path>
             </field>
-            <field id="installments" translate="label" sortOrder="700" showInDefault="1" showInWebsite="1"
+            <field id="installments" translate="label" sortOrder="20" showInDefault="1" showInWebsite="1"
                    showInStore="1">
                 <label>Installments</label>
                 <depends>
@@ -86,18 +86,25 @@
                 <backend_model>Adyen\Payment\Model\Config\Backend\Installments</backend_model>
                 <config_path>payment/adyen_cc/installments</config_path>
             </field>
+            <field id="has_holder_name" translate="label" type="select" sortOrder="30" showInDefault="1"
+                   showInWebsite="1" showInStore="1">
+                <label>Show holder name field</label>
+                <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                <tooltip>Set to Yes to show the input field for the card holder name</tooltip>
+                <config_path>payment/adyen_cc/has_holder_name</config_path>
+            </field>
         </group>
 
-        <group id="adyen_cc_country_specific" translate="label" showInDefault="1" showInWebsite="1" sortOrder="80">
+        <group id="adyen_cc_country_specific" translate="label" showInDefault="1" showInWebsite="1" sortOrder="70">
             <label>Country Specific Settings</label>
             <frontend_model>Magento\Config\Block\System\Config\Form\Fieldset</frontend_model>
-            <field id="allowspecific" translate="label" type="allowspecific" sortOrder="100" showInDefault="1"
+            <field id="allowspecific" translate="label" type="allowspecific" sortOrder="10" showInDefault="1"
                    showInWebsite="1" showInStore="0">
                 <label>Payment from Applicable Countries</label>
                 <source_model>Magento\Payment\Model\Config\Source\Allspecificcountries</source_model>
                 <config_path>payment/adyen_cc/allowspecific</config_path>
             </field>
-            <field id="specificcountry" translate="label" type="multiselect" sortOrder="90" showInDefault="1"
+            <field id="specificcountry" translate="label" type="multiselect" sortOrder="20" showInDefault="1"
                    showInWebsite="1" showInStore="0">
                 <label>Payment from Specific Countries</label>
                 <source_model>Magento\Directory\Model\Config\Source\Country</source_model>

--- a/etc/adminhtml/system/adyen_checkout_experience.xml
+++ b/etc/adminhtml/system/adyen_checkout_experience.xml
@@ -54,5 +54,22 @@
             <source_model>Adyen\Payment\Model\Config\Source\HouseNumberStreetLine</source_model>
             <tooltip><![CDATA[Select which of the address lines will be the house number. Make sure to enable enough "Number of Lines in a Street Address" in Magento's Customer Configuration]]></tooltip>
         </field>
+        <field id="has_holder_name" translate="label" type="select" sortOrder="50" showInDefault="1"
+               showInWebsite="1" showInStore="1">
+            <label>Show holder name field for card payment methods</label>
+            <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+            <tooltip>Set to Yes to show the input field for the card holder name</tooltip>
+            <config_path>payment/adyen_abstract/has_holder_name</config_path>
+        </field>
+        <field id="holder_name_required" translate="label" type="select" sortOrder="60" showInDefault="1"
+               showInWebsite="1" showInStore="1">
+            <label>Holder name required</label>
+            <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+            <tooltip>Set to Yes to make the card holder name a required field</tooltip>
+            <config_path>payment/adyen_abstract/holder_name_required</config_path>
+            <depends>
+                <field id="has_holder_name">1</field>
+            </depends>
+        </field>
     </group>
 </include>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -50,6 +50,7 @@
                 <cctypes>AE,VI,MC,DI</cctypes>
                 <useccv>1</useccv>
                 <has_holder_name>1</has_holder_name>
+                <holder_name_required>0</holder_name_required>
                 <payment_action>authorize</payment_action>
                 <is_gateway>1</is_gateway>
                 <can_use_checkout>1</can_use_checkout>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -49,6 +49,7 @@
                 <sort_order>2</sort_order>
                 <cctypes>AE,VI,MC,DI</cctypes>
                 <useccv>1</useccv>
+                <has_holder_name>1</has_holder_name>
                 <payment_action>authorize</payment_action>
                 <is_gateway>1</is_gateway>
                 <can_use_checkout>1</can_use_checkout>

--- a/view/frontend/web/js/model/adyen-configuration.js
+++ b/view/frontend/web/js/model/adyen-configuration.js
@@ -39,6 +39,12 @@ define(
             getChargedCurrency: function () {
                 return window.checkoutConfig.payment.adyen.chargedCurrency;
             },
+            getHasHolderName: function () {
+                return window.checkoutConfig.payment.adyen.hasHolderName;
+            },
+            getHolderNameRequired: function () {
+                return window.checkoutConfig.payment.adyen.holderNameRequired;
+            },
         };
     }
 );

--- a/view/frontend/web/js/view/payment/method-renderer/adyen-cc-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-cc-method.js
@@ -77,7 +77,6 @@ define(
                 this.vaultEnabler.isActivePaymentTokenEnabler(false);
 
                 this.checkoutComponent = new AdyenCheckout({
-                        hasHolderName: true,
                         locale: adyenConfiguration.getLocale(),
                         clientKey: adyenConfiguration.getClientKey(),
                         environment: adyenConfiguration.getCheckoutEnvironment(),

--- a/view/frontend/web/js/view/payment/method-renderer/adyen-cc-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-cc-method.js
@@ -126,6 +126,10 @@ define(
                 self.cardComponent = self.checkoutComponent.create('card', {
                     enableStoreDetails: self.getEnableStoreDetails(),
                     brands: self.getAvailableCardTypeAltCodes(),
+                    hasHolderName: adyenConfiguration.getHasHolderName(),
+                    holderNameRequired: adyenConfiguration.getHasHolderName() ?
+                        adyenConfiguration.getHolderNameRequired() :
+                        false,
                     onChange: function(state, component) {
                         self.placeOrderAllowed(!!state.isValid);
                         self.storeCc = !!state.data.storePaymentMethod;

--- a/view/frontend/web/js/view/payment/method-renderer/adyen-cc-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-cc-method.js
@@ -127,9 +127,8 @@ define(
                     enableStoreDetails: self.getEnableStoreDetails(),
                     brands: self.getAvailableCardTypeAltCodes(),
                     hasHolderName: adyenConfiguration.getHasHolderName(),
-                    holderNameRequired: adyenConfiguration.getHasHolderName() ?
-                        adyenConfiguration.getHolderNameRequired() :
-                        false,
+                    holderNameRequired: adyenConfiguration.getHasHolderName() &&
+                        adyenConfiguration.getHolderNameRequired(),
                     onChange: function(state, component) {
                         self.placeOrderAllowed(!!state.isValid);
                         self.storeCc = !!state.data.storePaymentMethod;

--- a/view/frontend/web/js/view/payment/method-renderer/adyen-hpp-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-hpp-method.js
@@ -106,7 +106,6 @@ define(
                 if (!!paymentMethodsResponse.paymentMethodsResponse) {
                     var paymentMethods = paymentMethodsResponse.paymentMethodsResponse.paymentMethods;
                     this.checkoutComponent = new AdyenCheckout({
-                            hasHolderName: true,
                             locale: adyenConfiguration.getLocale(),
                             clientKey: adyenConfiguration.getClientKey(),
                             environment: adyenConfiguration.getCheckoutEnvironment(),
@@ -291,6 +290,9 @@ define(
                                     {
                                         showPayButton: showPayButton,
                                         countryCode: country,
+                                        hasHolderName: adyenConfiguration.getHasHolderName(),
+                                        holderNameRequired: adyenConfiguration.getHasHolderName() &&
+                                            adyenConfiguration.getHolderNameRequired(),
                                         data: {
                                             personalDetails: {
                                                 firstName: firstName,


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
When using the Web Component is possible to toggle the holder name field and if it is required. Here a couple of configs are being added to control this feature.

**Tested scenarios**
has_holder_name toggles if the holder name is shown.
holder_name_required toggles if the holder name is required.

**Fixed issue**:  PW-4652