### PR TITLE
Prevent division by zero in Adyen\Payment\Helper\ChargedCurrency::getCreditMemoItemAmountCurrency when a creditmemo's item quantity is 0

### DIFF
--- a/Gateway/Request/RefundDataBuilder.php
+++ b/Gateway/Request/RefundDataBuilder.php
@@ -204,10 +204,13 @@ class RefundDataBuilder implements BuilderInterface
         $creditMemo = $payment->getCreditMemo();
 
         foreach ($creditMemo->getItems() as $refundItem) {
+            $numberOfItems = (int)$refundItem->getQty();
+            if ($numberOfItems == 0) {
+                continue;
+            }
+
             ++$count;
             $itemAmountCurrency = $this->chargedCurrency->getCreditMemoItemAmountCurrency($refundItem);
-
-            $numberOfItems = (int)$refundItem->getQty();
 
             $formFields = $this->adyenHelper->createOpenInvoiceLineItem(
                 $formFields,


### PR DESCRIPTION
Prevent division by zero in Adyen\Payment\Helper\ChargedCurrency::getCreditMemoItemAmountCurrency when creditmemo item quantity is 0

<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
This bug-fix prevents a division by zero in the ChargedCurrency::getCreditMemoItemAmountCurrency when a creditmemo item's quantity is 0.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

**Fixed issue**:  <!-- #-prefixed issue number -->