### PR TITLE
add an if statement that checks whether the Stored payment methods ha…

### DIFF
--- a/Helper/Requests.php
+++ b/Helper/Requests.php
@@ -389,21 +389,25 @@ class Requests extends AbstractHelper
 
         $enableOneclick = $this->adyenHelper->getAdyenAbstractConfigData('enable_oneclick', $storeId);
         $enableVault = $this->adyenHelper->isCreditCardVaultEnabled();
+        $storedPaymentMethodsEnabled = $this->adyenHelper->getAdyenOneclickConfigData('active', $storeId);
 
         // TODO Remove it in version 7
         if ($payment->getAdditionalInformation(AdyenCcDataAssignObserver::STORE_CC)) {
             $request['storePaymentMethod'] = true;
         }
         //recurring
-        if ($enableVault) {
-            $request['recurringProcessingModel'] = 'Subscription';
-        } else {
-            if ($enableOneclick) {
-                $request['recurringProcessingModel'] = 'CardOnFile';
-            } else {
+        if ($storedPaymentMethodsEnabled) {
+            if ($enableVault) {
                 $request['recurringProcessingModel'] = 'Subscription';
+            } else {
+                if ($enableOneclick) {
+                    $request['recurringProcessingModel'] = 'CardOnFile';
+                } else {
+                    $request['recurringProcessingModel'] = 'Subscription';
+                }
             }
         }
+
         return $request;
     }
 


### PR DESCRIPTION
**Description**
Adding a variable $storedPaymentMethodsEnabled that stores the value of the 'Enabled' field of the 'Stored payment methods' configuration section. Afterwards, adding an if statement that checks whether the value of this field is 'yes' and in case the Stored payment methods are not enabled this check prevents assigning the recurringProcessingModel. 

**Tested Scenarios**
I have tested 4 scenarios with the according settings in Magento admin panel and Adyen Customer Area, and the Recurring processing model for test transactions was as is expected:
1. Non recurring payments with the recurring payments turned off in Adyen Customer Area and Magento environment: test transaction doesn't have a Recurring processing model assigned.
2. Transaction with Stored payment methods enabled, Vault and OneClick disabled: test transaction has a Recurring processing model 'Subscription'
3. Vault transactions with Vault enabled and OneClick disabled: test transaction has a Recurring processing model of 'Subscription'
4. OneClick transaction with Vault disabled and OneClick enabled: test transaction has a Recurring processing model of 'CardOnFile'

**Fixed issue**:  [PW-4731]