### PR TITLE
[PW-4363] Map zh_Hans_* to zh_CN locale code

### DIFF
--- a/Gateway/Request/RefundDataBuilder.php
+++ b/Gateway/Request/RefundDataBuilder.php
@@ -204,10 +204,13 @@ class RefundDataBuilder implements BuilderInterface
         $creditMemo = $payment->getCreditMemo();
 
         foreach ($creditMemo->getItems() as $refundItem) {
+            $numberOfItems = (int)$refundItem->getQty();
+            if ($numberOfItems == 0) {
+                continue;
+            }
+
             ++$count;
             $itemAmountCurrency = $this->chargedCurrency->getCreditMemoItemAmountCurrency($refundItem);
-
-            $numberOfItems = (int)$refundItem->getQty();
 
             $formFields = $this->adyenHelper->createOpenInvoiceLineItem(
                 $formFields,

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -1794,7 +1794,10 @@ class Data extends AbstractHelper
      */
     public function mapLocaleCode($localeCode)
     {
-        if ($localeCode && str_contains($localeCode, 'zh_Hans_')) {
+        if ($localeCode && $localeCode == 'zh_Hant_TW') {
+            $localeCode = 'zh-TW';
+        }
+        elseif ($localeCode && ($localeCode == 'zh_Hans_CN'||$localeCode== 'zh_Hant_HK')) {
             $localeCode = 'zh-CN';
         }
         return $localeCode;

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -144,6 +144,11 @@ class Data extends AbstractHelper
     private $componentRegistrar;
 
     /**
+     * @var \Adyen\Payment\Helper\Locale;
+     */
+    private $locale;
+
+    /**
      * Data constructor.
      *
      * @param \Magento\Framework\App\Helper\Context $context
@@ -167,6 +172,7 @@ class Data extends AbstractHelper
      * @param \Magento\Framework\App\Config\ScopeConfigInterface $config
      * @param \Magento\Backend\Helper\Data $helperBackend
      * @param \Magento\Framework\Serialize\SerializerInterface $serializer
+     * @param \Adyen\Payment\Helper\Locale $locale
      */
     public function __construct(
         \Magento\Framework\App\Helper\Context $context,
@@ -190,7 +196,8 @@ class Data extends AbstractHelper
         \Magento\Framework\App\Config\ScopeConfigInterface $config,
         \Magento\Backend\Helper\Data $helperBackend,
         \Magento\Framework\Serialize\SerializerInterface $serializer,
-        \Magento\Framework\Component\ComponentRegistrarInterface $componentRegistrar
+        \Magento\Framework\Component\ComponentRegistrarInterface $componentRegistrar,
+        \Adyen\Payment\Helper\Locale $locale
     ) {
         parent::__construct($context);
         $this->_encryptor = $encryptor;
@@ -214,6 +221,7 @@ class Data extends AbstractHelper
         $this->helperBackend = $helperBackend;
         $this->serializer = $serializer;
         $this->componentRegistrar = $componentRegistrar;
+        $this->locale = $locale;
     }
 
     /**
@@ -1071,7 +1079,7 @@ class Data extends AbstractHelper
     {
         $path = \Magento\Directory\Helper\Data::XML_PATH_DEFAULT_LOCALE;
         $storeLocale = $this->scopeConfig->getValue($path, \Magento\Store\Model\ScopeInterface::SCOPE_STORE, $storeId);
-        return $this->mapLocaleCode($storeLocale);
+        return $this->locale->mapLocaleCode($storeLocale);
     }
 
     public function getCustomerStreetLinesEnabled($storeId)
@@ -1748,12 +1756,12 @@ class Data extends AbstractHelper
     {
         $localeCode = $this->getAdyenHppConfigData('shopper_locale', $storeId);
         if ($localeCode != "") {
-            return $this->mapLocaleCode($localeCode);
+            return $this->locale->mapLocaleCode($localeCode);
         }
 
         $locale = $this->localeResolver->getLocale();
         if ($locale) {
-            return $this->mapLocaleCode($locale);
+            return $this->locale->mapLocaleCode($locale);
         }
 
         // should have the value if not fall back to default
@@ -1763,7 +1771,7 @@ class Data extends AbstractHelper
             $this->storeManager->getStore($storeId)->getCode()
         );
 
-        return $this->mapLocaleCode($localeCode);
+        return $this->locale->mapLocaleCode($localeCode);
     }
 
     /**
@@ -1785,21 +1793,5 @@ class Data extends AbstractHelper
             $checkoutEnvironment,
             $pspReference
         );
-    }
-
-    /**
-     * Maps zh_Hans_* locale code to zh_CN
-     * @param $localeCode
-     * @return mixed|string
-     */
-    public function mapLocaleCode($localeCode)
-    {
-        if ($localeCode && $localeCode == 'zh_Hant_TW') {
-            $localeCode = 'zh-TW';
-        }
-        elseif ($localeCode && ($localeCode == 'zh_Hans_CN'||$localeCode== 'zh_Hant_HK')) {
-            $localeCode = 'zh-CN';
-        }
-        return $localeCode;
     }
 }

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -1070,7 +1070,8 @@ class Data extends AbstractHelper
     public function getStoreLocale($storeId)
     {
         $path = \Magento\Directory\Helper\Data::XML_PATH_DEFAULT_LOCALE;
-        return $this->scopeConfig->getValue($path, \Magento\Store\Model\ScopeInterface::SCOPE_STORE, $storeId);
+        $storeLocale = $this->scopeConfig->getValue($path, \Magento\Store\Model\ScopeInterface::SCOPE_STORE, $storeId);
+        return $this->mapLocaleCode($storeLocale);
     }
 
     public function getCustomerStreetLinesEnabled($storeId)
@@ -1747,12 +1748,12 @@ class Data extends AbstractHelper
     {
         $localeCode = $this->getAdyenHppConfigData('shopper_locale', $storeId);
         if ($localeCode != "") {
-            return $localeCode;
+            return $this->mapLocaleCode($localeCode);
         }
 
         $locale = $this->localeResolver->getLocale();
         if ($locale) {
-            return $locale;
+            return $this->mapLocaleCode($locale);
         }
 
         // should have the value if not fall back to default
@@ -1762,7 +1763,7 @@ class Data extends AbstractHelper
             $this->storeManager->getStore($storeId)->getCode()
         );
 
-        return $localeCode;
+        return $this->mapLocaleCode($localeCode);
     }
 
     /**
@@ -1784,5 +1785,18 @@ class Data extends AbstractHelper
             $checkoutEnvironment,
             $pspReference
         );
+    }
+
+    /**
+     * Maps zh_Hans_* locale code to zh_CN
+     * @param $localeCode
+     * @return mixed|string
+     */
+    public function mapLocaleCode($localeCode)
+    {
+        if ($localeCode && str_contains($localeCode, 'zh_Hans_')) {
+            $localeCode = 'zh-CN';
+        }
+        return $localeCode;
     }
 }

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -146,7 +146,7 @@ class Data extends AbstractHelper
     /**
      * @var \Adyen\Payment\Helper\Locale;
      */
-    private $locale;
+    private $localeHelper;
 
     /**
      * Data constructor.
@@ -172,7 +172,7 @@ class Data extends AbstractHelper
      * @param \Magento\Framework\App\Config\ScopeConfigInterface $config
      * @param \Magento\Backend\Helper\Data $helperBackend
      * @param \Magento\Framework\Serialize\SerializerInterface $serializer
-     * @param \Adyen\Payment\Helper\Locale $locale
+     * @param \Adyen\Payment\Helper\Locale $localeHelper
      */
     public function __construct(
         \Magento\Framework\App\Helper\Context $context,
@@ -197,7 +197,7 @@ class Data extends AbstractHelper
         \Magento\Backend\Helper\Data $helperBackend,
         \Magento\Framework\Serialize\SerializerInterface $serializer,
         \Magento\Framework\Component\ComponentRegistrarInterface $componentRegistrar,
-        \Adyen\Payment\Helper\Locale $locale
+        \Adyen\Payment\Helper\Locale $localeHelper
     ) {
         parent::__construct($context);
         $this->_encryptor = $encryptor;
@@ -221,7 +221,7 @@ class Data extends AbstractHelper
         $this->helperBackend = $helperBackend;
         $this->serializer = $serializer;
         $this->componentRegistrar = $componentRegistrar;
-        $this->locale = $locale;
+        $this->localeHelper = $localeHelper;
     }
 
     /**
@@ -1079,7 +1079,7 @@ class Data extends AbstractHelper
     {
         $path = \Magento\Directory\Helper\Data::XML_PATH_DEFAULT_LOCALE;
         $storeLocale = $this->scopeConfig->getValue($path, \Magento\Store\Model\ScopeInterface::SCOPE_STORE, $storeId);
-        return $this->locale->mapLocaleCode($storeLocale);
+        return $this->localeHelper->mapLocaleCode($storeLocale);
     }
 
     public function getCustomerStreetLinesEnabled($storeId)
@@ -1756,12 +1756,12 @@ class Data extends AbstractHelper
     {
         $localeCode = $this->getAdyenHppConfigData('shopper_locale', $storeId);
         if ($localeCode != "") {
-            return $this->locale->mapLocaleCode($localeCode);
+            return $this->localeHelper->mapLocaleCode($localeCode);
         }
 
         $locale = $this->localeResolver->getLocale();
         if ($locale) {
-            return $this->locale->mapLocaleCode($locale);
+            return $this->localeHelper->mapLocaleCode($locale);
         }
 
         // should have the value if not fall back to default
@@ -1771,7 +1771,7 @@ class Data extends AbstractHelper
             $this->storeManager->getStore($storeId)->getCode()
         );
 
-        return $this->locale->mapLocaleCode($localeCode);
+        return $this->localeHelper->mapLocaleCode($localeCode);
     }
 
     /**

--- a/Helper/Locale.php
+++ b/Helper/Locale.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2021 Adyen BV (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\Payment\Helper;
+
+/**
+ * Class Locale
+ * @package Adyen\Payment\Helper
+ */
+class Locale
+{
+    const ZH_HANS_CN = 'zh_Hans_CN';
+    const ZH_HANT_HK = 'zh_Hant_HK';
+    const ZH_HANT_TW = 'zh_Hant_TW';
+    const ZH_CN = 'zh-CN';
+    const ZH_TW = 'zh-TW';
+
+    private static $chineseLocaleCodes = array(
+        self::ZH_HANS_CN,
+        self::ZH_HANT_HK
+    );
+    private static $taiwanLocaleCodes = array(
+        self::ZH_HANT_TW
+    );
+
+    /**
+     * Maps zh_Hans_* locale code to zh_CN
+     * @param $localeCode
+     * @return mixed|string
+     */
+    public function mapLocaleCode($localeCode)
+    {
+        if (in_array($localeCode, self::$chineseLocaleCodes)) {
+            $localeCode = self::ZH_CN;
+        } elseif (in_array($localeCode, self::$taiwanLocaleCodes)) {
+            $localeCode = self::ZH_TW;
+        }
+        return $localeCode;
+    }
+}

--- a/Helper/Locale.php
+++ b/Helper/Locale.php
@@ -29,32 +29,19 @@ namespace Adyen\Payment\Helper;
  */
 class Locale
 {
-    const ZH_HANS_CN = 'zh_Hans_CN';
-    const ZH_HANT_HK = 'zh_Hant_HK';
-    const ZH_HANT_TW = 'zh_Hant_TW';
-    const ZH_CN = 'zh-CN';
-    const ZH_TW = 'zh-TW';
 
-    private static $chineseLocaleCodes = array(
-        self::ZH_HANS_CN,
-        self::ZH_HANT_HK
-    );
-    private static $taiwanLocaleCodes = array(
-        self::ZH_HANT_TW
+    private static $localeMappings = array(
+        'zh_Hans_CN' => 'zh-CN',
+        'zh_Hant_HK' => 'zh-CN',
+        'zh_Hant_TW' => 'zh-TW'
     );
 
     /**
-     * Maps zh_Hans_* locale code to zh_CN
      * @param $localeCode
      * @return mixed|string
      */
     public function mapLocaleCode($localeCode)
     {
-        if (in_array($localeCode, self::$chineseLocaleCodes)) {
-            $localeCode = self::ZH_CN;
-        } elseif (in_array($localeCode, self::$taiwanLocaleCodes)) {
-            $localeCode = self::ZH_TW;
-        }
-        return $localeCode;
+        return !empty(self::$localeMappings[$localeCode]) ? self::$localeMappings[$localeCode] : $localeCode;
     }
 }

--- a/Test/Unit/Helper/LocaleTest.php
+++ b/Test/Unit/Helper/LocaleTest.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2021 Adyen BV (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\Payment\Tests\Helper;
+
+class LocaleTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var \Adyen\Payment\Helper\Locale
+     */
+    private $localeHelper;
+
+    public function setUp()
+    {
+        $this->localeHelper =  new \Adyen\Payment\Helper\Locale();
+    }
+
+    public function testMapLocaleCode()
+    {
+        $this->assertEquals('zh-CN', $this->localeHelper->mapLocaleCode('zh_Hans_CN'));
+        $this->assertEquals('zh-CN', $this->localeHelper->mapLocaleCode('zh_Hant_HK'));
+        $this->assertEquals('zh-TW', $this->localeHelper->mapLocaleCode('zh_Hant_TW'));
+    }
+}


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
In the checkout configuration the locale for the Chinese locale code is zh-CN as described in the documentation [here](https://docs.adyen.com/online-payments/components-web/localization-components#change-language). Same for Taiwan, too. The  Magento, returns the code for this same locale as  zh_Hans_* which is not matching with the Adyen's checkout

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
Tested with: NL, CN variants and TW

**Fixed issue**:  <!-- #-prefixed issue number -->