### PR TITLE
[PW-4639] The check for create credit memo is based on the original reference

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -1804,7 +1804,7 @@ class Data extends AbstractHelper
      */
     public function getPspReferenceWithNoAdditions($pspReference)
     {
-        if ($pspReference == '') {
+        if (empty($pspReference)) {
             return '';
         }
         preg_match(

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -37,6 +37,7 @@ class Data extends AbstractHelper
     // Only used for backend orders! Checkout in front-end is using different checkout version see web folder
     const CHECKOUT_COMPONENT_JS_LIVE = 'https://checkoutshopper-live.adyen.com/checkoutshopper/sdk/3.2.0/adyen.js';
     const CHECKOUT_COMPONENT_JS_TEST = 'https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/3.2.0/adyen.js';
+    const PSP_REFERENCE_REGEX = '[0-9][A-Z][15]';
 
     /**
      * @var \Magento\Framework\Encryption\EncryptorInterface
@@ -1795,5 +1796,26 @@ class Data extends AbstractHelper
             $checkoutEnvironment,
             $pspReference
         );
+    }
+
+    /**
+     * Get pspReference only if there are additional string attached
+     * @param $pspReference
+     */
+    public function getPspReferenceWithNoAdditions($pspReference)
+    {
+        if ($pspReference == '') {
+            return '';
+        }
+        preg_match(
+            self::PSP_REFERENCE_REGEX,
+            trim($pspReference),
+            $match,
+            PREG_OFFSET_CAPTURE
+        );
+        if (!empty($match[0])) {
+            return $match[0][0];
+        }
+        return $pspReference;
     }
 }

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -37,7 +37,7 @@ class Data extends AbstractHelper
     // Only used for backend orders! Checkout in front-end is using different checkout version see web folder
     const CHECKOUT_COMPONENT_JS_LIVE = 'https://checkoutshopper-live.adyen.com/checkoutshopper/sdk/3.2.0/adyen.js';
     const CHECKOUT_COMPONENT_JS_TEST = 'https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/3.2.0/adyen.js';
-    const PSP_REFERENCE_REGEX = '[0-9][A-Z][15]';
+    const PSP_REFERENCE_REGEX = '/[0-9.A-Z]{16}/';
 
     /**
      * @var \Magento\Framework\Encryption\EncryptorInterface

--- a/Model/Cron.php
+++ b/Model/Cron.php
@@ -1472,7 +1472,7 @@ class Cron
          * because in this case the credit memo already exists
          */
         $lastTransactionId = $this->_order->getPayment()->getLastTransId();
-        if ($lastTransactionId != $this->_pspReference) {
+        if ($lastTransactionId != $this->_originalReference . '-refund') {
             // refund is done through adyen backoffice so create a credit memo
             $order = $this->_order;
             if ($order->canCreditmemo()) {

--- a/Model/Cron.php
+++ b/Model/Cron.php
@@ -1471,7 +1471,9 @@ class Cron
          * Don't create a credit memo if refund is initialize in Magento
          * because in this case the credit memo already exists
          */
-        $lastTransactionId = $this->_order->getPayment()->getLastTransId();
+        $lastTransactionId = $this->_adyenHelper->getPspReferenceWithNoAdditions($this->_order->getPayment()->getLastTransId());
+        $this->_adyenLogger->addAdyenNotificationCronjob('OriginalReference' . $this->_originalReference);
+        $this->_adyenLogger->addAdyenNotificationCronjob('LastTransactionId' . $lastTransactionId);
         if ($lastTransactionId != $this->_originalReference . '-refund') {
             // refund is done through adyen backoffice so create a credit memo
             $order = $this->_order;

--- a/Model/Cron.php
+++ b/Model/Cron.php
@@ -1471,10 +1471,8 @@ class Cron
          * Don't create a credit memo if refund is initialize in Magento
          * because in this case the credit memo already exists
          */
-        $lastTransactionId = $this->_adyenHelper->getPspReferenceWithNoAdditions($this->_order->getPayment()->getLastTransId());
-        $this->_adyenLogger->addAdyenNotificationCronjob('OriginalReference' . $this->_originalReference);
-        $this->_adyenLogger->addAdyenNotificationCronjob('LastTransactionId' . $lastTransactionId);
-        if ($lastTransactionId != $this->_originalReference . '-refund') {
+        $lastTransactionId = $this->_order->getPayment()->getLastTransId();
+        if ($this->_adyenHelper->getPspReferenceWithNoAdditions($lastTransactionId) != $this->_originalReference) {
             // refund is done through adyen backoffice so create a credit memo
             $order = $this->_order;
             if ($order->canCreditmemo()) {

--- a/Test/Unit/Helper/DataTest.php
+++ b/Test/Unit/Helper/DataTest.php
@@ -99,7 +99,7 @@ class DataTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('1200', $this->dataHelper->formatAmount('12.00', 'USD'));
         $this->assertEquals('12', $this->dataHelper->formatAmount('12.00', 'JPY'));
     }
-    
+
     public function testisPaymentMethodOpenInvoiceMethod()
     {
         $this->assertEquals(true, $this->dataHelper->isPaymentMethodOpenInvoiceMethod('klarna'));
@@ -122,6 +122,13 @@ class DataTest extends \PHPUnit\Framework\TestCase
     {
         $pspSearchUrl = $this->dataHelper->getPspReferenceSearchUrl($pspReference, $checkoutEnvironment);
         $this->assertEquals($expectedResult, $pspSearchUrl);
+    }
+
+    public function testGetPspReferenceWithNoAdditions(){
+
+        $this->assertEquals(`852621234567890A`, $this->dataHelper->getPspReferenceWithNoAdditions('852621234567890A'));
+        $this->assertEquals(`852621234567890A`, $this->dataHelper->getPspReferenceWithNoAdditions('852621234567890A-refund'));
+        $this->assertEquals(`852621234567890A`, $this->dataHelper->getPspReferenceWithNoAdditions('852621234567890A-capture'));
     }
 
     public static function checkoutEnvironmentsProvider()

--- a/Test/Unit/Helper/DataTest.php
+++ b/Test/Unit/Helper/DataTest.php
@@ -66,6 +66,7 @@ class DataTest extends \PHPUnit\Framework\TestCase
         $serializer = $this->getSimpleMock(\Magento\Framework\Serialize\SerializerInterface::class);
         $componentRegistrar = $this->getSimpleMock(\Magento\Framework
                                                    \Component\ComponentRegistrarInterface::class);
+        $localeHelper = $this->getSimpleMock(\Adyen\Payment\Helper\Locale::class);
 
         $this->dataHelper = new \Adyen\Payment\Helper\Data(
             $context,
@@ -89,7 +90,8 @@ class DataTest extends \PHPUnit\Framework\TestCase
             $config,
             $helperBackend,
             $serializer,
-            $componentRegistrar
+            $componentRegistrar,
+            $localeHelper
         );
     }
 
@@ -125,11 +127,10 @@ class DataTest extends \PHPUnit\Framework\TestCase
     }
 
     public function testGetPspReferenceWithNoAdditions(){
-
-        $this->assertEquals(`852621234567890A`, $this->dataHelper->getPspReferenceWithNoAdditions('852621234567890A'));
-        $this->assertEquals(`852621234567890A`, $this->dataHelper->getPspReferenceWithNoAdditions('852621234567890A-refund'));
-        $this->assertEquals(`852621234567890A`, $this->dataHelper->getPspReferenceWithNoAdditions('852621234567890A-capture'));
-        $this->assertEquals(`852621234567890A`, $this->dataHelper->getPspReferenceWithNoAdditions('852621234567890A-capture-refund'));
+        $this->assertEquals('852621234567890A', $this->dataHelper->getPspReferenceWithNoAdditions('852621234567890A'));
+        $this->assertEquals('852621234567890A', $this->dataHelper->getPspReferenceWithNoAdditions('852621234567890A-refund'));
+        $this->assertEquals('852621234567890A', $this->dataHelper->getPspReferenceWithNoAdditions('852621234567890A-capture'));
+        $this->assertEquals('852621234567890A', $this->dataHelper->getPspReferenceWithNoAdditions('852621234567890A-capture-refund'));
     }
 
     public static function checkoutEnvironmentsProvider()

--- a/Test/Unit/Helper/DataTest.php
+++ b/Test/Unit/Helper/DataTest.php
@@ -129,6 +129,7 @@ class DataTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(`852621234567890A`, $this->dataHelper->getPspReferenceWithNoAdditions('852621234567890A'));
         $this->assertEquals(`852621234567890A`, $this->dataHelper->getPspReferenceWithNoAdditions('852621234567890A-refund'));
         $this->assertEquals(`852621234567890A`, $this->dataHelper->getPspReferenceWithNoAdditions('852621234567890A-capture'));
+        $this->assertEquals(`852621234567890A`, $this->dataHelper->getPspReferenceWithNoAdditions('852621234567890A-capture-refund'));
     }
 
     public static function checkoutEnvironmentsProvider()


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
The check for create credit memo was always failing as there was no scenario that the refund psp reference could match  the original reference with `refund` suffix. This is modified so now the lastTransactionId with `refund` is compared with transaction's originalReference . `refund`

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

Partial refund
Refund initiate from magento
Refund initiate from back office

**Fixed issue**:  <!-- #-prefixed issue number -->