### PR TITLE
[PW-4885] Attempt to join address lines in HPP renderer only if it is an array

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/adyen-hpp-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-hpp-method.js
@@ -258,9 +258,10 @@ define(
                                     city = quote.shippingAddress().city;
                                     country = quote.shippingAddress().countryId;
                                     postalCode = quote.shippingAddress().postcode;
-                                    street = quote.shippingAddress().
-                                        street.
-                                        join(' ');
+                                    street = Array.isArray(quote.shippingAddress().street) ?
+                                        quote.shippingAddress().street.join(' ') :
+                                        quote.shippingAddress().street
+
                                     firstName = quote.shippingAddress().firstname;
                                     lastName = quote.shippingAddress().lastname;
                                     telephone = quote.shippingAddress().telephone;


### PR DESCRIPTION


<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
When using some checkout plugins the street object in the HPP renderer might not be an array.

**Tested scenarios**
HPP payment methods.

**Fixed issue**:  fixes #1043 