### PR TITLE
[PW-4758] Save order and recurring token for non-3DS, 3DS1 and 3DS2 cards

### DIFF
--- a/Controller/Process/Result.php
+++ b/Controller/Process/Result.php
@@ -90,10 +90,12 @@ class Result extends \Magento\Framework\App\Action\Action
     private $quoteHelper;
 
     private $payment;
+
     /**
      * @var \Adyen\Payment\Helper\Vault
      */
     private $vaultHelper;
+
     /**
      * @var \Magento\Sales\Model\ResourceModel\Order
      */

--- a/Helper/PaymentResponseHandler.php
+++ b/Helper/PaymentResponseHandler.php
@@ -58,6 +58,11 @@ class PaymentResponseHandler
     private $vaultHelper;
 
     /**
+     * @var \Magento\Sales\Model\ResourceModel\Order
+     */
+    private $orderResourceModel;
+
+    /**
      * PaymentResponseHandler constructor.
      *
      * @param AdyenLogger $adyenLogger
@@ -67,11 +72,13 @@ class PaymentResponseHandler
     public function __construct(
         AdyenLogger $adyenLogger,
         Data $adyenHelper,
-        Vault $vaultHelper
+        Vault $vaultHelper,
+        \Magento\Sales\Model\ResourceModel\Order $orderResourceModel
     ) {
         $this->adyenLogger = $adyenLogger;
         $this->adyenHelper = $adyenHelper;
         $this->vaultHelper = $vaultHelper;
+        $this->orderResourceModel = $orderResourceModel;
     }
 
     public function formatPaymentResponse($resultCode, $action = null, $additionalData = null)
@@ -191,6 +198,7 @@ class PaymentResponseHandler
                         $this->adyenHelper->createAdyenBillingAgreement($order, $paymentsResponse['additionalData']);
                     }
                 }
+                $this->orderResourceModel->save($order);
             case self::IDENTIFY_SHOPPER:
             case self::CHALLENGE_SHOPPER:
                 break;


### PR DESCRIPTION

<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
After payments with non-3DS, 3DS1 and 3DS2 cards that request saving the payment details for later use the order and vault payment token were not being saved.

**Tested scenarios**
Saving non-3DS, 3DS1 and 3DS2 cards in vault and then using the token for payment.

**Fixed issue**:  PW-4758