### PR TITLE
Adding CSP policy values type connect-src

### DIFF
--- a/etc/csp_whitelist.xml
+++ b/etc/csp_whitelist.xml
@@ -16,5 +16,10 @@
                 <value id="adyen" type="host">*.adyen.com</value>
             </values>
         </policy>
+        <policy id="connect-src">
+            <values>
+                <value id="adyen" type="host">*.adyen.com</value>
+            </values>
+        </policy>
     </policies>
 </csp_whitelist>


### PR DESCRIPTION
Description
Magento >=2.3.5 uses CSP headers. *.adyen.com has been added so that requests to .adyen.com/checkoutshopper/v1/analytics/log are allowed at checkout.

Tested scenarios
Checkout with Magento_Csp enabled doesn't block Adyen resources.

Fixed issue: N\A