### PR TITLE
[PW-4642 ]Add padding in shopper reference for disable token request

### DIFF
--- a/Model/Api/PaymentRequest.php
+++ b/Model/Api/PaymentRequest.php
@@ -218,7 +218,7 @@ class PaymentRequest extends DataObject
     public function disableRecurringContract($recurringDetailReference, $shopperReference, $storeId)
     {
         $merchantAccount = $this->_adyenHelper->getAdyenAbstractConfigData("merchant_account", $storeId);
-
+        $shopperReference = str_pad($shopperReference, 3, '0', STR_PAD_LEFT);
         $request = [
             "merchantAccount" => $merchantAccount,
             "shopperReference" => $shopperReference,


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Add padding in shopper reference for disable token request. The issue was that the api was returning an validation error 422 because the shopper reference length was equal to 1. The shopper reference should be at least 3 digits. 
**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

**Fixed issue**:  <!-- #-prefixed issue number -->