### PR TITLE
[PW-4732] Adding lineItem parameters and correcting calculations (v7)

### DIFF
--- a/Gateway/Request/CheckoutDataBuilder.php
+++ b/Gateway/Request/CheckoutDataBuilder.php
@@ -304,7 +304,9 @@ class CheckoutDataBuilder implements BuilderInterface
         // Discount cost
         if ($discountAmount != 0) {
             $description = __('Discount');
-            $itemAmount = -$this->adyenHelper->formatAmount($discountAmount, $itemAmountCurrency->getCurrencyCode());
+            $itemAmount = -$this->adyenHelper->formatAmount(
+                $discountAmount + $cart->getShippingAddress()->getShippingDiscountAmount(),
+                $itemAmountCurrency->getCurrencyCode());
             $itemVatAmount = "0";
             $itemVatPercentage = "0";
             $numberOfItems = 1;

--- a/Gateway/Request/CheckoutDataBuilder.php
+++ b/Gateway/Request/CheckoutDataBuilder.php
@@ -277,15 +277,22 @@ class CheckoutDataBuilder implements BuilderInterface
                 $itemAmountCurrency->getCurrencyCode()
             );
 
+            $formattedPriceIncludingTax = $this->adyenHelper->formatAmount(
+                $itemAmountCurrency->getAmountIncludingTax(),
+                $itemAmountCurrency->getCurrencyCode()
+            );
+
             $formattedTaxAmount = $this->adyenHelper->formatAmount(
                 $itemAmountCurrency->getTaxAmount(),
                 $itemAmountCurrency->getCurrencyCode()
             );
-            $formattedTaxPercentage = $item->getTaxPercent() * 100;
+
+            $formattedTaxPercentage = $this->adyenHelper->formatAmount($item->getTaxPercent(), $currency);
 
             $formFields['lineItems'][] = [
                 'id' => $item->getId(),
                 'amountExcludingTax' => $formattedPriceExcludingTax,
+                'amountIncludingTax' => $formattedPriceIncludingTax,
                 'taxAmount' => $formattedTaxAmount,
                 'description' => $item->getName(),
                 'quantity' => $numberOfItems,
@@ -305,6 +312,7 @@ class CheckoutDataBuilder implements BuilderInterface
             $formFields['lineItems'][] = [
                 'id' => 'Discount',
                 'amountExcludingTax' => $itemAmount,
+                'amountIncludingTax' => $itemAmount,
                 'taxAmount' => $itemVatAmount,
                 'description' => $description,
                 'quantity' => $numberOfItems,
@@ -319,28 +327,29 @@ class CheckoutDataBuilder implements BuilderInterface
         ) {
             $shippingAmountCurrency = $this->chargedCurrency->getQuoteShippingAmountCurrency($cart);
 
-            $priceExcludingTax = $shippingAmountCurrency->getAmount();
+            $formattedPriceExcludingTax = $this->adyenHelper->formatAmount(
+                $shippingAmountCurrency->getAmount(),
+                $currency
+            );
+
+            $formattedPriceIncludingTax = $this->adyenHelper->formatAmount(
+                $shippingAmountCurrency->getAmountIncludingTax(),
+                $currency
+            );
 
             $formattedTaxAmount = $this->adyenHelper->formatAmount(
                 $shippingAmountCurrency->getTaxAmount(),
                 $currency
             );
 
-            $formattedPriceExcludingTax = $this->adyenHelper->formatAmount($priceExcludingTax, $currency);
-
-            $formattedTaxPercentage = 0;
-
-            if ($priceExcludingTax !== 0) {
-                $formattedTaxPercentage = $shippingAmountCurrency->getTaxAmount() / $priceExcludingTax * 100 * 100;
-            }
-
             $formFields['lineItems'][] = [
                 'id' => 'shippingCost',
                 'amountExcludingTax' => $formattedPriceExcludingTax,
+                'amountIncludingTax' => $formattedPriceIncludingTax,
                 'taxAmount' => $formattedTaxAmount,
                 'description' => $order->getShippingDescription(),
                 'quantity' => 1,
-                'taxPercentage' => $formattedTaxPercentage
+                'taxPercentage' => ($formattedTaxAmount / $formattedPriceExcludingTax) * 100 * 100
             ];
         }
 

--- a/Helper/ChargedCurrency.php
+++ b/Helper/ChargedCurrency.php
@@ -103,14 +103,18 @@ class ChargedCurrency
                 $item->getBasePrice(),
                 $item->getQuote()->getBaseCurrencyCode(),
                 $item->getBaseDiscountAmount(),
-                $item->getBaseTaxAmount() / $item->getQty()
+                $item->getBasePriceInclTax() - $item->getBasePrice(),
+                null,
+                $item->getBasePriceInclTax()
             );
         }
         return new AdyenAmountCurrency(
-            $item->getRowTotal() / $item->getQty(),
+            $item->getPrice(),
             $item->getQuote()->getQuoteCurrencyCode(),
             $item->getDiscountAmount(),
-            $item->getTaxAmount() / $item->getQty()
+            $item->getPriceInclTax() - $item->getPrice(),
+            null,
+            $item->getPriceInclTax()
         );
     }
 
@@ -172,14 +176,18 @@ class ChargedCurrency
                 $quote->getShippingAddress()->getBaseShippingAmount(),
                 $quote->getBaseCurrencyCode(),
                 $quote->getShippingAddress()->getBaseShippingDiscountAmount(),
-                $quote->getShippingAddress()->getBaseShippingTaxAmount()
+                $quote->getShippingAddress()->getBaseShippingTaxAmount(),
+                null,
+                $quote->getShippingAddress()->getBaseShippingInclTax()
             );
         }
         return new AdyenAmountCurrency(
             $quote->getShippingAddress()->getShippingAmount(),
             $quote->getQuoteCurrencyCode(),
             $quote->getShippingAddress()->getShippingDiscountAmount(),
-            $quote->getShippingAddress()->getShippingTaxAmount()
+            $quote->getShippingAddress()->getShippingTaxAmount(),
+            null,
+            $quote->getShippingAddress()->getShippingInclTax()
         );
     }
 

--- a/Model/AdyenAmountCurrency.php
+++ b/Model/AdyenAmountCurrency.php
@@ -27,6 +27,8 @@ class AdyenAmountCurrency
 {
     protected $amount;
 
+    protected $amountIncludingTax;
+
     protected $discountAmount;
 
     protected $taxAmount;
@@ -35,9 +37,16 @@ class AdyenAmountCurrency
 
     protected $amountDue;
 
-    public function __construct($amount, $currencyCode, $discountAmount = 0, $taxAmount = 0, $amountDue = 0)
-    {
+    public function __construct(
+        $amount,
+        $currencyCode,
+        $discountAmount = 0,
+        $taxAmount = 0,
+        $amountDue = 0,
+        $amountIncludingTax = 0
+    ) {
         $this->amount = $amount;
+        $this->amountIncludingTax = $amountIncludingTax;
         $this->currencyCode = $currencyCode;
         $this->discountAmount = $discountAmount;
         $this->taxAmount = $taxAmount;
@@ -47,6 +56,11 @@ class AdyenAmountCurrency
     public function getAmount()
     {
         return $this->amount;
+    }
+
+    public function getAmountIncludingTax()
+    {
+        return $this->amountIncludingTax;
     }
 
     public function getCurrencyCode()

--- a/Test/Unit/Helper/ChargedCurrencyTest.php
+++ b/Test/Unit/Helper/ChargedCurrencyTest.php
@@ -43,7 +43,8 @@ class ChargedCurrencyTest extends TestCase
                 'currencyCode' => 'EUR',
                 'discountAmount' => 67.89,
                 'taxAmount' => 12.34,
-                'amountDue' => 56.78
+                'amountDue' => 56.78,
+                'amountIncludingTax' => 135.79
             ],
         'display' =>
             [
@@ -51,7 +52,8 @@ class ChargedCurrencyTest extends TestCase
                 'currencyCode' => 'USD',
                 'discountAmount' => 98.76,
                 'taxAmount' => 54.32,
-                'amountDue' => 10.98
+                'amountDue' => 10.98,
+                'amountIncludingTax' => 708.64
             ]
     ];
 
@@ -137,7 +139,9 @@ class ChargedCurrencyTest extends TestCase
                 'getBaseShippingTaxAmount',
                 'getShippingAmount',
                 'getShippingDiscountAmount',
-                'getShippingTaxAmount'
+                'getShippingTaxAmount',
+                'getBaseShippingInclTax',
+                'getShippingInclTax'
             ])
             ->getMock();
         $this->mockMethods($shippingAddress,
@@ -147,7 +151,9 @@ class ChargedCurrencyTest extends TestCase
                 'getBaseShippingTaxAmount' => self::AMOUNT_CURRENCY['base']['taxAmount'],
                 'getShippingAmount' => self::AMOUNT_CURRENCY['display']['amount'],
                 'getShippingDiscountAmount' => self::AMOUNT_CURRENCY['display']['discountAmount'],
-                'getShippingTaxAmount' => self::AMOUNT_CURRENCY['display']['taxAmount']
+                'getShippingTaxAmount' => self::AMOUNT_CURRENCY['display']['taxAmount'],
+                'getBaseShippingInclTax' => self::AMOUNT_CURRENCY['base']['amountIncludingTax'],
+                'getShippingInclTax' => self::AMOUNT_CURRENCY['display']['amountIncludingTax']
             ]
         );
 
@@ -177,25 +183,31 @@ class ChargedCurrencyTest extends TestCase
             ->disableOriginalConstructor()
             ->setMethods([
                 'getBasePrice',
+                'getPrice',
                 'getBaseDiscountAmount',
                 'getBaseTaxAmount',
                 'getQuote',
                 'getRowTotal',
                 'getQty',
                 'getDiscountAmount',
-                'getTaxAmount'
+                'getTaxAmount',
+                'getBasePriceInclTax',
+                'getPriceInclTax'
             ])
             ->getMock();
         $this->mockMethods($this->quoteItem,
             [
                 'getBasePrice' => self::AMOUNT_CURRENCY['base']['amount'],
+                'getPrice' => self::AMOUNT_CURRENCY['display']['amount'],
                 'getBaseDiscountAmount' => self::AMOUNT_CURRENCY['base']['discountAmount'],
                 'getBaseTaxAmount' => self::AMOUNT_CURRENCY['base']['taxAmount'],
                 'getRowTotal' => self::AMOUNT_CURRENCY['display']['amount'],
                 'getQty' => 1,
                 'getDiscountAmount' => self::AMOUNT_CURRENCY['display']['discountAmount'],
                 'getTaxAmount' => self::AMOUNT_CURRENCY['display']['taxAmount'],
-                'getQuote' => $this->quote
+                'getQuote' => $this->quote,
+                'getBasePriceInclTax' => self::AMOUNT_CURRENCY['base']['amountIncludingTax'],
+                'getPriceInclTax' => self::AMOUNT_CURRENCY['display']['amountIncludingTax']
             ]
         );
 
@@ -230,7 +242,8 @@ class ChargedCurrencyTest extends TestCase
                 'getInvoice',
                 'getBaseTaxAmount',
                 'getPrice',
-                'getTaxAmount'
+                'getTaxAmount',
+                'getQty'
             ])
             ->getMock();
         $this->mockMethods($this->invoiceItem,
@@ -239,7 +252,8 @@ class ChargedCurrencyTest extends TestCase
                 'getInvoice' => $this->invoice,
                 'getBaseTaxAmount' => self::AMOUNT_CURRENCY['base']['taxAmount'],
                 'getPrice' => self::AMOUNT_CURRENCY['display']['amount'],
-                'getTaxAmount' => self::AMOUNT_CURRENCY['display']['taxAmount']
+                'getTaxAmount' => self::AMOUNT_CURRENCY['display']['taxAmount'],
+                'getQty' => 1
             ]
         );
 
@@ -260,7 +274,8 @@ class ChargedCurrencyTest extends TestCase
                 'getInvoice',
                 'getCreditMemo',
                 'getBaseTaxAmount',
-                'getTaxAmount'
+                'getTaxAmount',
+                'getQty'
             ])
             ->getMock();
         $this->mockMethods($this->creditMemoItem,
@@ -270,7 +285,8 @@ class ChargedCurrencyTest extends TestCase
                 'getCreditMemo' => $creditMemo,
                 'getBaseTaxAmount' => self::AMOUNT_CURRENCY['base']['taxAmount'],
                 'getPrice' => self::AMOUNT_CURRENCY['display']['amount'],
-                'getTaxAmount' => self::AMOUNT_CURRENCY['display']['taxAmount']
+                'getTaxAmount' => self::AMOUNT_CURRENCY['display']['taxAmount'],
+                'getQty' => 1
             ]
         );
 
@@ -361,13 +377,15 @@ class ChargedCurrencyTest extends TestCase
                     $expectedResult->getAmount(),
                     $expectedResult->getCurrencyCode(),
                     $expectedResult->getDiscountAmount(),
-                    $expectedResult->getTaxAmount()
+                    $expectedResult->getTaxAmount(),
+                    $expectedResult->getAmountIncludingTax()
                 ],
                 [
                     $result->getAmount(),
                     $result->getCurrencyCode(),
                     $result->getDiscountAmount(),
-                    $result->getTaxAmount()
+                    $result->getTaxAmount(),
+                    $result->getAmountIncludingTax()
                 ]
             );
         } else {
@@ -459,13 +477,15 @@ class ChargedCurrencyTest extends TestCase
                 $expectedResult->getAmount(),
                 $expectedResult->getCurrencyCode(),
                 $expectedResult->getDiscountAmount(),
-                $expectedResult->getTaxAmount()
+                $expectedResult->getTaxAmount(),
+                $expectedResult->getAmountIncludingTax(),
             ],
             [
                 $result->getAmount(),
                 $result->getCurrencyCode(),
                 $result->getDiscountAmount(),
-                $result->getTaxAmount()
+                $result->getTaxAmount(),
+                $result->getAmountIncludingTax(),
             ]
         );
 
@@ -515,7 +535,8 @@ class ChargedCurrencyTest extends TestCase
             self::AMOUNT_CURRENCY['base']['currencyCode'],
             self::AMOUNT_CURRENCY['base']['discountAmount'],
             self::AMOUNT_CURRENCY['base']['taxAmount'],
-            self::AMOUNT_CURRENCY['base']['amountDue']
+            self::AMOUNT_CURRENCY['base']['amountDue'],
+            self::AMOUNT_CURRENCY['base']['amountIncludingTax']
         );
 
         $adyenAmountCurrencyDisplay = new AdyenAmountCurrency(
@@ -523,7 +544,8 @@ class ChargedCurrencyTest extends TestCase
             self::AMOUNT_CURRENCY['display']['currencyCode'],
             self::AMOUNT_CURRENCY['display']['discountAmount'],
             self::AMOUNT_CURRENCY['display']['taxAmount'],
-            self::AMOUNT_CURRENCY['display']['amountDue']
+            self::AMOUNT_CURRENCY['display']['amountDue'],
+            self::AMOUNT_CURRENCY['display']['amountIncludingTax']
         );
 
         return array(


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
Here some adjustments are being made to the open invoice line item parameters. And in order to avoid miscalculations of Adyen adding extra lines or completing amounts all parameters are used (amountIncludingTax, amountExcludingTax, taxAmount, taxPercentage) both for products/discounts and shipping costs.

**Tested scenarios**
Open invoice payments:
* Percent of product price discount
* Fixed amount discount
* Fixed amount discount for whole cart
* Buy X get Y free (discount amount is Y)
* Shipping costs including and excluding tax
* Unit, Row Total and Total tax calculation.

**Fixed issue**: PW-4740