### PR TITLE
[PW-5016] Remove AddressAdapterInterface type declaration

### DIFF
--- a/Helper/Address.php
+++ b/Helper/Address.php
@@ -39,7 +39,7 @@ class Address
      * @return array
      */
     public function getStreetAndHouseNumberFromAddress(
-        AddressAdapterInterface $address,
+        $address,
         $houseNumberStreetLine,
         $customerStreetLinesEnabled
     ): array {


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
The getBillingAddress() return type can be overwritten by third party
modules and that might break the interface's return type hint, therefore
the getStreetAndHouseNumberFromAddress should not require an address
that implements the AddressAdapterInterface

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

**Fixed issue**:  <!-- #-prefixed issue number -->
#1082 [PW-5016] Issue with getStreetAndHouseNumberFromAddress Not allowing checkout 