### PR TITLE
[PW-4365] Return JSON encoded array instead of PHP array for empty payment methods

### DIFF
--- a/Helper/PaymentMethods.php
+++ b/Helper/PaymentMethods.php
@@ -172,13 +172,14 @@ class PaymentMethods extends AbstractHelper
         $merchantAccount = $this->adyenHelper->getAdyenAbstractConfigData('merchant_account', $store->getId());
 
         if (!$merchantAccount) {
-            return [];
+            return json_encode([]);
         }
 
         $paymentMethodRequest = $this->getPaymentMethodsRequest($merchantAccount, $store, $country, $quote);
         $responseData = $this->getPaymentMethodsResponse($paymentMethodRequest, $store);
 
         if (empty($responseData['paymentMethods'])) {
+            var_dump($responseData);
             return json_encode([]);
         }
 

--- a/Helper/PaymentMethods.php
+++ b/Helper/PaymentMethods.php
@@ -179,7 +179,6 @@ class PaymentMethods extends AbstractHelper
         $responseData = $this->getPaymentMethodsResponse($paymentMethodRequest, $store);
 
         if (empty($responseData['paymentMethods'])) {
-            var_dump($responseData);
             return json_encode([]);
         }
 

--- a/Helper/PaymentMethods.php
+++ b/Helper/PaymentMethods.php
@@ -179,7 +179,7 @@ class PaymentMethods extends AbstractHelper
         $responseData = $this->getPaymentMethodsResponse($paymentMethodRequest, $store);
 
         if (empty($responseData['paymentMethods'])) {
-            return [];
+            return json_encode([]);
         }
 
         $paymentMethods = $responseData['paymentMethods'];

--- a/view/frontend/web/js/view/payment/adyen-methods.js
+++ b/view/frontend/web/js/view/payment/adyen-methods.js
@@ -77,7 +77,12 @@ define(
                     fullScreenLoader.startLoader();
                     // Retrieve adyen payment methods
                     adyenPaymentService.retrievePaymentMethods().done(function(paymentMethods) {
+                        try {
                         paymentMethods = JSON.parse(paymentMethods);
+                        } catch(error) {
+                            console.log(error);
+                            paymentMethods = null;
+                        }
                         adyenPaymentService.setPaymentMethods(paymentMethods);
                         fullScreenLoader.stopLoader();
                     }).fail(function() {


### PR DESCRIPTION
**Description**
As we were returning a PHP array if the payment methods in the /paymentMethods request is empty, the request now returns the JSON representation of a value.
Wrapping the paymentMethods in adyen-methods.js file in try/catch block, in case the paymentMethods function returns an empty array, as JSON.parse can't parse empty arrays. In case that happens, we catch the error and console log it.

**Tested scenarios**
Disabling all the payment methods on my merchant account should throw the following error: https://github.com/Adyen/adyen-magento2/blob/fc10555ba49f491a18bfcd76eea88d48b6240d07/view/frontend/web/js/view/payment/adyen-methods.js#L84 
Before, it was throwing the error that was pointing to the following line of code: https://github.com/Adyen/adyen-magento2/blob/fc10555ba49f491a18bfcd76eea88d48b6240d07/view/frontend/web/js/view/payment/adyen-methods.js#L80.
The error is now correctly thrown by the function:
![Screen Shot 2021-07-06 at 4 26 21 PM](https://user-images.githubusercontent.com/59090063/124617053-ea19d200-de76-11eb-9f89-59638c4e1e9a.png)


**Fixed issue**:  PW-4365