### PR TITLE
[PW-5000] Prefill house number field in the checkout component 

### DIFF
--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -38,6 +38,7 @@ class Config
     const XML_CHARGED_CURRENCY = "charged_currency";
     const XML_HAS_HOLDER_NAME = "has_holder_name";
     const XML_HOLDER_NAME_REQUIRED = "holder_name_required";
+    const XML_HOUSE_NUMBER_STREET_LINE = "house_number_street_line";
 
     /**
      * @var Magento\Framework\App\Config\ScopeConfigInterface
@@ -177,6 +178,18 @@ class Config
     {
         return $this->adyenHelper->getAdyenAbstractConfigDataFlag(self::XML_HAS_HOLDER_NAME, $storeId);
     }
+
+    /**
+     * Retrieve house_number_street_line config
+     *
+     * @param null|int|string $storeId
+     * @return mixed
+     */
+    public function getHouseNumberStreetLine($storeId = null)
+    {
+        return $this->adyenHelper->getAdyenAbstractConfigDataFlag(self::XML_HOUSE_NUMBER_STREET_LINE, $storeId);
+    }
+
 
     /**
      * Retrieve holder_name_required config

--- a/Model/Ui/AdyenGenericConfigProvider.php
+++ b/Model/Ui/AdyenGenericConfigProvider.php
@@ -86,6 +86,9 @@ class AdyenGenericConfigProvider implements ConfigProviderInterface
         $config['payment']['adyen']['chargedCurrency'] = $this->adyenConfigHelper->getChargedCurrency($storeId);
         $config['payment']['adyen']['hasHolderName'] = $this->adyenConfigHelper->getHasHolderName($storeId);
         $config['payment']['adyen']['holderNameRequired'] = $this->adyenConfigHelper->getHolderNameRequired($storeId);
+        $config['payment']['adyen']['houseNumberStreetLine'] = $this->adyenConfigHelper->getHouseNumberStreetLine(
+            $storeId
+        );
 
         return $config;
     }

--- a/view/frontend/web/js/model/adyen-configuration.js
+++ b/view/frontend/web/js/model/adyen-configuration.js
@@ -21,30 +21,33 @@
  */
 define(
     [],
-    function () {
+    function() {
         'use strict';
         return {
-            getClientKey: function () {
+            getClientKey: function() {
                 return window.checkoutConfig.payment.adyen.clientKey;
             },
-            showLogo: function () {
+            showLogo: function() {
                 return window.checkoutConfig.payment.adyen.showLogo;
             },
-            getLocale: function () {
+            getLocale: function() {
                 return window.checkoutConfig.payment.adyen.locale;
             },
-            getCheckoutEnvironment: function () {
+            getCheckoutEnvironment: function() {
                 return window.checkoutConfig.payment.adyen.checkoutEnvironment;
             },
-            getChargedCurrency: function () {
+            getChargedCurrency: function() {
                 return window.checkoutConfig.payment.adyen.chargedCurrency;
             },
-            getHasHolderName: function () {
+            getHasHolderName: function() {
                 return window.checkoutConfig.payment.adyen.hasHolderName;
             },
-            getHolderNameRequired: function () {
+            getHolderNameRequired: function() {
                 return window.checkoutConfig.payment.adyen.holderNameRequired;
             },
+            getHouseNumberStreetLine: function() {
+                return window.checkoutConfig.payment.adyen.houseNumberStreetLine;
+            },
         };
-    }
+    },
 );

--- a/view/frontend/web/js/view/payment/method-renderer/adyen-hpp-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-hpp-method.js
@@ -264,12 +264,17 @@ define(
                                 shopperDateOfBirth = customerData.dob;
 
                                 var formattedShippingAddress = {};
+                                var formattedBillingAddress = {};
 
                                 if (!!quote.shippingAddress()) {
                                     formattedShippingAddress = getFormattedAddress(quote.shippingAddress());
                                 }
 
-                                // Use shipping address details as default
+                                if (!!quote.billingAddress()) {
+                                    formattedBillingAddress = getFormattedAddress(quote.billingAddress());
+                                }
+
+                                // Use shipping address details as default and fall back to billing address if missing
                                 if (formattedShippingAddress) {
                                     country = formattedShippingAddress.country;
                                 }
@@ -342,20 +347,20 @@ define(
                                             adyenConfiguration.getHolderNameRequired(),
                                         data: {
                                             personalDetails: {
-                                                firstName: formattedShippingAddress.firstName,
-                                                lastName: formattedShippingAddress.lastName,
-                                                telephoneNumber: formattedShippingAddress.telephone,
+                                                firstName: formattedBillingAddress.firstName,
+                                                lastName: formattedBillingAddress.lastName,
+                                                telephoneNumber: formattedBillingAddress.telephone,
                                                 shopperEmail: email,
                                                 gender: getAdyenGender(
                                                     shopperGender),
                                                 dateOfBirth: shopperDateOfBirth,
                                             },
                                             billingAddress: {
-                                                city: formattedShippingAddress.city,
-                                                country: formattedShippingAddress.country,
-                                                houseNumberOrName: formattedShippingAddress.houseNumber,
-                                                postalCode: formattedShippingAddress.postalCode,
-                                                street: formattedShippingAddress.street,
+                                                city: formattedBillingAddress.city,
+                                                country: formattedBillingAddress.country,
+                                                houseNumberOrName: formattedBillingAddress.houseNumber,
+                                                postalCode: formattedBillingAddress.postalCode,
+                                                street: formattedBillingAddress.street,
                                             },
                                         },
                                         onChange: function(state) {

--- a/view/frontend/web/js/view/payment/method-renderer/adyen-hpp-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-hpp-method.js
@@ -296,8 +296,10 @@ define(
                                             // removes the street line from array that is used to contain house number
                                             houseNumber = street.splice(adyenConfiguration.getHouseNumberStreetLine() - 1, 1);
                                         } else { // getHouseNumberStreetLine = 0 uses the last street line as house number
-                                            // removes last street line from array that is used to contain house number
-                                            houseNumber = street.pop();
+                                            // in case there is more than 1 street lines in use, removes last street line from array that should be used to contain house number
+                                            if (street.length > 1) {
+                                                houseNumber = street.pop();
+                                            }
                                         }
 
                                         // Concat street lines except house number

--- a/view/frontend/web/js/view/payment/method-renderer/adyen-hpp-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-hpp-method.js
@@ -277,6 +277,8 @@ define(
                                 // Use shipping address details as default and fall back to billing address if missing
                                 if (formattedShippingAddress) {
                                     country = formattedShippingAddress.country;
+                                } else {
+                                    country = formattedBillingAddress.country;
                                 }
 
                                 /**

--- a/view/frontend/web/js/view/payment/method-renderer/adyen-hpp-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-hpp-method.js
@@ -384,6 +384,16 @@ define(
                                         },
                                     });
 
+                                if (formattedShippingAddress) {
+                                    configuration.data.shippingAddress = {
+                                        city: formattedShippingAddress.city,
+                                        country: formattedShippingAddress.country,
+                                        houseNumberOrName: formattedShippingAddress.houseNumber,
+                                        postalCode: formattedShippingAddress.postalCode,
+                                        street: formattedShippingAddress.street,
+                                    }
+                                }
+
                                 // Use extra configuration from the paymentMethodsExtraInfo object if available
                                 if (paymentMethod.methodIdentifier in paymentMethodsExtraInfo && 'configuration' in paymentMethodsExtraInfo[paymentMethod.methodIdentifier]) {
                                     configuration = Object.assign(configuration, paymentMethodsExtraInfo[paymentMethod.methodIdentifier].configuration);

--- a/view/frontend/web/js/view/payment/method-renderer/adyen-hpp-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-hpp-method.js
@@ -245,8 +245,6 @@ define(
                                     showPayButton = true;
                                 }
 
-                                var country = '';
-
                                 var firstName = '';
                                 var lastName = '';
                                 var telephone = '';
@@ -272,13 +270,6 @@ define(
 
                                 if (!!quote.billingAddress()) {
                                     formattedBillingAddress = getFormattedAddress(quote.billingAddress());
-                                }
-
-                                // Use shipping address details as default and fall back to billing address if missing
-                                if (formattedShippingAddress) {
-                                    country = formattedShippingAddress.country;
-                                } else {
-                                    country = formattedBillingAddress.country;
                                 }
 
                                 /**
@@ -343,7 +334,7 @@ define(
                                 var configuration = Object.assign(paymentMethod,
                                     {
                                         showPayButton: showPayButton,
-                                        countryCode: country,
+                                        countryCode: formattedShippingAddress.country ? formattedShippingAddress.country : formattedBillingAddress.country, // Use shipping address details as default and fall back to billing address if missing
                                         hasHolderName: adyenConfiguration.getHasHolderName(),
                                         holderNameRequired: adyenConfiguration.getHasHolderName() &&
                                             adyenConfiguration.getHolderNameRequired(),


### PR DESCRIPTION
**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Use the house_number_street_line admin config field on the frontend to be able to prefill the checkout component input fields with the correct address line values.
Create new helper function getFormattedAddress() to make it easier retrieving the correct address details for the component while introducing the houseNumber value.
Use the correct address type (shipping/billing) for the checkout component config fields.
Add shippingAddress configuration to the component.

See commit messages for more detailed steps.