### PR TITLE
Use order status on addStatusHistoryComment

### DIFF
--- a/Controller/Process/Result.php
+++ b/Controller/Process/Result.php
@@ -339,7 +339,7 @@ class Result extends \Magento\Framework\App\Action\Action
         }
 
         $history = $this->_orderHistoryFactory->create()
-            //->setStatus($status)
+            ->setStatus($order->getStatus())
             ->setComment($comment)
             ->setEntityName('order')
             ->setOrder($order);

--- a/Gateway/Response/CheckoutPaymentCommentHistoryHandler.php
+++ b/Gateway/Response/CheckoutPaymentCommentHistoryHandler.php
@@ -34,10 +34,9 @@ class CheckoutPaymentCommentHistoryHandler implements HandlerInterface
      */
     public function handle(array $handlingSubject, array $response)
     {
-        $payment = \Magento\Payment\Gateway\Helper\SubjectReader::readPayment($handlingSubject);
+        $readPayment = \Magento\Payment\Gateway\Helper\SubjectReader::readPayment($handlingSubject);
 
-        /** @var OrderPaymentInterface $payment */
-        $payment = $payment->getPayment();
+        $payment = $readPayment->getPayment();
 
         $comment = __("Adyen Result response:");
 
@@ -67,7 +66,7 @@ class CheckoutPaymentCommentHistoryHandler implements HandlerInterface
             $comment .= '<br /> ' . __('pspReference:') . ' ' . $pspReference;
         }
 
-        $payment->getOrder()->addStatusHistoryComment($comment);
+        $payment->getOrder()->addStatusHistoryComment($comment, $payment->getOrder()->getStatus());
 
         return $this;
     }

--- a/Gateway/Response/PaymentCommentHistoryHandler.php
+++ b/Gateway/Response/PaymentCommentHistoryHandler.php
@@ -34,10 +34,9 @@ class PaymentCommentHistoryHandler implements HandlerInterface
      */
     public function handle(array $handlingSubject, array $response)
     {
-        $payment = \Magento\Payment\Gateway\Helper\SubjectReader::readPayment($handlingSubject);
+        $readPayment = \Magento\Payment\Gateway\Helper\SubjectReader::readPayment($handlingSubject);
 
-        /** @var OrderPaymentInterface $payment */
-        $payment = $payment->getPayment();
+        $payment = $readPayment->getPayment();
 
         if (isset($response['resultCode'])) {
             $responseCode = $response['resultCode'];
@@ -68,7 +67,7 @@ class PaymentCommentHistoryHandler implements HandlerInterface
             $payment->getOrder()->setAdyenResulturlEventCode($responseCode);
         }
 
-        $payment->getOrder()->addStatusHistoryComment($comment);
+        $payment->getOrder()->addStatusHistoryComment($comment, $payment->getOrder()->getStatus());
 
         return $this;
     }

--- a/Gateway/Response/PaymentCommentHistoryRefundHandler.php
+++ b/Gateway/Response/PaymentCommentHistoryRefundHandler.php
@@ -68,7 +68,7 @@ class PaymentCommentHistoryRefundHandler implements HandlerInterface
                 $payment->getOrder()->setAdyenResulturlEventCode($responseCode);
             }
 
-            $payment->getOrder()->addStatusHistoryComment($comment, $payment->getOrder()->getStatus);
+            $payment->getOrder()->addStatusHistoryComment($comment, $payment->getOrder()->getStatus());
         }
 
         return $this;

--- a/Gateway/Response/PaymentCommentHistoryRefundHandler.php
+++ b/Gateway/Response/PaymentCommentHistoryRefundHandler.php
@@ -34,10 +34,9 @@ class PaymentCommentHistoryRefundHandler implements HandlerInterface
      */
     public function handle(array $handlingSubject, array $response)
     {
-        $payment = \Magento\Payment\Gateway\Helper\SubjectReader::readPayment($handlingSubject);
+        $readPayment = \Magento\Payment\Gateway\Helper\SubjectReader::readPayment($handlingSubject);
 
-        /** @var OrderPaymentInterface $payment */
-        $payment = $payment->getPayment();
+        $payment = $readPayment->getPayment();
 
         foreach ($response as $singleResponse) {
             if (isset($singleResponse['resultCode'])) {
@@ -69,7 +68,7 @@ class PaymentCommentHistoryRefundHandler implements HandlerInterface
                 $payment->getOrder()->setAdyenResulturlEventCode($responseCode);
             }
 
-            $payment->getOrder()->addStatusHistoryComment($comment);
+            $payment->getOrder()->addStatusHistoryComment($comment, $payment->getOrder()->getStatus);
         }
 
         return $this;

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -1606,7 +1606,7 @@ class Data extends AbstractHelper
                 $this->adyenLogger->error("exception: " . $message);
             }
 
-            $comment = $order->addStatusHistoryComment($message);
+            $comment = $order->addStatusHistoryComment($message, $order->getStatus());
 
             $order->addRelatedObject($comment);
             $order->save();

--- a/Helper/PaymentResponseHandler.php
+++ b/Helper/PaymentResponseHandler.php
@@ -160,7 +160,8 @@ class PaymentResponseHandler
             case self::PRESENT_TO_SHOPPER:
             case self::PENDING:
             case self::RECEIVED:
-
+            case self::IDENTIFY_SHOPPER:
+            case self::CHALLENGE_SHOPPER:
                 break;
             //We don't need to handle these resultCodes
             case self::REDIRECT_SHOPPER:
@@ -175,7 +176,8 @@ class PaymentResponseHandler
                         The payment can be seen as unsuccessful.
                         <br />The order can be automatically cancelled based on the OFFER_CLOSED notification.
                         Please contact Adyen Support to enable this.'
-                        )
+                        ),
+                        $order->getStatus()
                     )->save();
                 }
                 break;
@@ -199,8 +201,6 @@ class PaymentResponseHandler
                     }
                 }
                 $this->orderResourceModel->save($order);
-            case self::IDENTIFY_SHOPPER:
-            case self::CHALLENGE_SHOPPER:
                 break;
             case self::REFUSED:
                 // Cancel order in case result is refused
@@ -217,6 +217,7 @@ class PaymentResponseHandler
                         $this->adyenLogger->addAdyenDebug('Order can not be canceled');
                     }
                 }
+                break;
             case self::ERROR:
             default:
                 $this->adyenLogger->error(

--- a/Model/Cron.php
+++ b/Model/Cron.php
@@ -1604,7 +1604,7 @@ class Cron
 
         //capture mode
         if (!$this->_isAutoCapture()) {
-            $this->_order->addStatusHistoryComment(__('Capture Mode set to Manual'));
+            $this->_order->addStatusHistoryComment(__('Capture Mode set to Manual'), $this->_order->getStatus());
             $this->_adyenLogger->addAdyenNotificationCronjob('Capture mode is set to Manual');
 
             // show message if order is in manual review

--- a/Model/Cron.php
+++ b/Model/Cron.php
@@ -1082,8 +1082,6 @@ class Cron
                 );
                 if ($ignoreRefundNotification != true) {
                     $this->_refundOrder();
-                    //refund completed
-                    $this->_setRefundAuthorized();
                 } else {
                     $this->_adyenLogger->addAdyenNotificationCronjob(
                         'Setting to ignore refund notification is enabled so ignore this notification'
@@ -1218,8 +1216,6 @@ class Cron
                         $this->_holdCancelOrder(true);
                     } elseif ($this->_modificationResult == "refund") {
                         $this->_refundOrder();
-                        //refund completed
-                        $this->_setRefundAuthorized();
                     }
                 } else {
                     if ($this->_order->isCanceled() ||
@@ -1236,8 +1232,6 @@ class Cron
                             $this->_adyenLogger->addAdyenNotificationCronjob('try to refund the order');
                             // refund
                             $this->_refundOrder();
-                            //refund completed
-                            $this->_setRefundAuthorized();
                         }
                     }
                 }
@@ -1480,6 +1474,7 @@ class Cron
                 $order->getPayment()->registerRefundNotification($amount);
 
                 $this->_adyenLogger->addAdyenNotificationCronjob('Created credit memo for order');
+                $order->addStatusHistoryComment(__('Adyen Refund Successfully completed'), $order->getStatus());
             } else {
                 $this->_adyenLogger->addAdyenNotificationCronjob('Could not create a credit memo for order');
             }
@@ -1488,17 +1483,6 @@ class Cron
                 'Did not create a credit memo for this order because refund is done through Magento'
             );
         }
-    }
-
-    /**
-     * @param $order
-     */
-    protected function _setRefundAuthorized()
-    {
-        $this->_adyenLogger->addAdyenNotificationCronjob(
-            'Status update to default status or refund_authorized status if this is set'
-        );
-        $this->_order->addStatusHistoryComment(__('Adyen Refund Successfully completed'));
     }
 
     /**

--- a/Model/Cron.php
+++ b/Model/Cron.php
@@ -880,7 +880,7 @@ class Cron
             return;
         }
 
-        $this->_order->addStatusHistoryComment($comment);
+        $this->_order->addStatusHistoryComment($comment, $this->_order->getStatus());
         $this->_adyenLogger->addAdyenNotificationCronjob('Created comment history for this notification');
     }
 

--- a/Model/Cron.php
+++ b/Model/Cron.php
@@ -1353,7 +1353,7 @@ class Cron
                     }
 
                     $this->_adyenLogger->addAdyenNotificationCronjob($message);
-                    $comment = $this->_order->addStatusHistoryComment($message);
+                    $comment = $this->_order->addStatusHistoryComment($message, $this->_order->getStatus());
                     $this->_order->addRelatedObject($comment);
                 }
                 //store recurring contract for alternative payments methods

--- a/Model/Cron.php
+++ b/Model/Cron.php
@@ -2239,7 +2239,7 @@ class Cron
     {
         $comment = __('The order failed to update: %1', $errorMessage);
         if ($this->_order) {
-            $this->_order->addStatusHistoryComment($comment);
+            $this->_order->addStatusHistoryComment($comment, $this->_order->getStatus());
             $this->_order->save();
         }
     }


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
By using the current order status on `addStatusHistoryComment` we make sure that the order is not going to change status when leaving an info-only history comment.

**Tested scenarios**
Cron cases where `addStatusHistoryComment` is used.
Checkout, Payment and Refund handlers.
RedirectShopper handling (iDeal).

**Fixed issue**:  PW-5027 #1085 