### PR TITLE
[PW-3060] remove 3ds2 toggle config and usage

### DIFF
--- a/Gateway/Request/CheckoutDataBuilder.php
+++ b/Gateway/Request/CheckoutDataBuilder.php
@@ -214,9 +214,7 @@ class CheckoutDataBuilder implements BuilderInterface
             unset($requestBody['installments']);
         }
 
-        if ($this->adyenHelper->isCreditCardThreeDS2Enabled($storeId)) {
-            $requestBody['additionalData']['allow3DS2'] = true;
-        }
+        $requestBody['additionalData']['allow3DS2'] = true;
 
         $requestBody['origin'] = $this->adyenHelper->getOrigin($storeId);
         $requestBody['channel'] = 'web';

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -1687,17 +1687,6 @@ class Data extends AbstractHelper
     }
 
     /**
-     * Check if 3DS2.0 is enabled for credit cards
-     *
-     * @param null|int|string $storeId
-     * @return mixed
-     */
-    public function isCreditCardThreeDS2Enabled($storeId = null)
-    {
-        return $this->getAdyenCcConfigDataFlag('threeds2_enabled', $storeId);
-    }
-
-    /**
      * @param $client
      * @return \Adyen\Service\Checkout
      */

--- a/Helper/Requests.php
+++ b/Helper/Requests.php
@@ -337,25 +337,19 @@ class Requests extends AbstractHelper
      */
     public function buildThreeDS2Data($additionalData, $storeId, $request = [])
     {
-        if ($this->adyenHelper->isCreditCardThreeDS2Enabled($storeId)) {
-            $request['additionalData']['allow3DS2'] = true;
-            $request['origin'] = $this->adyenHelper->getOrigin($storeId);
-            $request['channel'] = 'web';
-            $request['browserInfo']['screenWidth'] = $additionalData[AdyenCcDataAssignObserver::SCREEN_WIDTH];
-            $request['browserInfo']['screenHeight'] = $additionalData[AdyenCcDataAssignObserver::SCREEN_HEIGHT];
-            $request['browserInfo']['colorDepth'] = $additionalData[AdyenCcDataAssignObserver::SCREEN_COLOR_DEPTH];
-            $request['browserInfo']['timeZoneOffset'] = $additionalData[AdyenCcDataAssignObserver::TIMEZONE_OFFSET];
-            $request['browserInfo']['language'] = $additionalData[AdyenCcDataAssignObserver::LANGUAGE];
+        $request['additionalData']['allow3DS2'] = true;
+        $request['origin'] = $this->adyenHelper->getOrigin($storeId);
+        $request['channel'] = 'web';
+        $request['browserInfo']['screenWidth'] = $additionalData[AdyenCcDataAssignObserver::SCREEN_WIDTH];
+        $request['browserInfo']['screenHeight'] = $additionalData[AdyenCcDataAssignObserver::SCREEN_HEIGHT];
+        $request['browserInfo']['colorDepth'] = $additionalData[AdyenCcDataAssignObserver::SCREEN_COLOR_DEPTH];
+        $request['browserInfo']['timeZoneOffset'] = $additionalData[AdyenCcDataAssignObserver::TIMEZONE_OFFSET];
+        $request['browserInfo']['language'] = $additionalData[AdyenCcDataAssignObserver::LANGUAGE];
 
-            if ($javaEnabled = $additionalData[AdyenCcDataAssignObserver::JAVA_ENABLED]) {
-                $request['browserInfo']['javaEnabled'] = $javaEnabled;
-            } else {
-                $request['browserInfo']['javaEnabled'] = false;
-            }
+        if ($javaEnabled = $additionalData[AdyenCcDataAssignObserver::JAVA_ENABLED]) {
+            $request['browserInfo']['javaEnabled'] = $javaEnabled;
         } else {
-            $request['additionalData']['allow3DS2'] = false;
-            $request['origin'] = $this->adyenHelper->getOrigin($storeId);
-            $request['channel'] = 'web';
+            $request['browserInfo']['javaEnabled'] = false;
         }
     }
 

--- a/Helper/Requests.php
+++ b/Helper/Requests.php
@@ -330,30 +330,6 @@ class Requests extends AbstractHelper
     }
 
     /**
-     * @param array $request
-     * @param $additionalData
-     * @param $storeId
-     * @return array
-     */
-    public function buildThreeDS2Data($additionalData, $storeId, $request = [])
-    {
-        $request['additionalData']['allow3DS2'] = true;
-        $request['origin'] = $this->adyenHelper->getOrigin($storeId);
-        $request['channel'] = 'web';
-        $request['browserInfo']['screenWidth'] = $additionalData[AdyenCcDataAssignObserver::SCREEN_WIDTH];
-        $request['browserInfo']['screenHeight'] = $additionalData[AdyenCcDataAssignObserver::SCREEN_HEIGHT];
-        $request['browserInfo']['colorDepth'] = $additionalData[AdyenCcDataAssignObserver::SCREEN_COLOR_DEPTH];
-        $request['browserInfo']['timeZoneOffset'] = $additionalData[AdyenCcDataAssignObserver::TIMEZONE_OFFSET];
-        $request['browserInfo']['language'] = $additionalData[AdyenCcDataAssignObserver::LANGUAGE];
-
-        if ($javaEnabled = $additionalData[AdyenCcDataAssignObserver::JAVA_ENABLED]) {
-            $request['browserInfo']['javaEnabled'] = $javaEnabled;
-        } else {
-            $request['browserInfo']['javaEnabled'] = false;
-        }
-    }
-
-    /**
      * @param InfoInterface $payment
      * @param array $request
      * @return array

--- a/etc/adminhtml/system/adyen_cc.xml
+++ b/etc/adminhtml/system/adyen_cc.xml
@@ -53,13 +53,6 @@
             <source_model>Adyen\Payment\Model\Config\Source\CcType</source_model>
             <config_path>payment/adyen_cc/cctypes</config_path>
         </field>
-        <field id="adyen_cc_threeds2" translate="label" type="select" sortOrder="50" showInDefault="1" showInWebsite="1"
-               showInStore="1">
-            <label>3DS2.0 Enabled</label>
-            <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-            <config_path>payment/adyen_cc/threeds2_enabled</config_path>
-        </field>
-
         <group id="adyen_cc_advanced_settings" translate="label" showInDefault="1" showInWebsite="1" showInStore="1"
                sortOrder="60">
             <label>Advanced Settings</label>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -65,7 +65,6 @@
                 <can_cancel>1</can_cancel>
                 <can_authorize_vault>1</can_authorize_vault>
                 <can_capture_vault>1</can_capture_vault>
-                <threeds2_enabled>1</threeds2_enabled>
                 <group>adyen</group>
             </adyen_cc>
             <adyen_cc_vault>


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Toggle for enabling/disabling 3ds2 was introduced during transition period from 3ds1 to 3ds2
Now we enable 3ds2 by default and remove this config option
**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
3ds2 CC payment
**Fixed issue**:  <!-- #-prefixed issue number -->