### PR TITLE
[PW-5005] Capture subject amount instead of order full amount

### DIFF
--- a/Gateway/Request/CaptureDataBuilder.php
+++ b/Gateway/Request/CaptureDataBuilder.php
@@ -65,12 +65,12 @@ class CaptureDataBuilder implements BuilderInterface
     {
         /** @var \Magento\Payment\Gateway\Data\PaymentDataObject $paymentDataObject */
         $paymentDataObject = \Magento\Payment\Gateway\Helper\SubjectReader::readPayment($buildSubject);
+        $amount = \Magento\Payment\Gateway\Helper\SubjectReader::readAmount($buildSubject);
         $payment = $paymentDataObject->getPayment();
         $order = $payment->getOrder();
         $pspReference = $payment->getCcTransId();
         $orderAmountCurrency = $this->chargedCurrency->getOrderAmountCurrency($order, false);
         $currency = $orderAmountCurrency->getCurrencyCode();
-        $amount = $orderAmountCurrency->getAmount();
         $amount = $this->adyenHelper->formatAmount($amount, $currency);
 
         $modificationAmount = ['currency' => $currency, 'value' => $amount];


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
The Capture builder can use the subject amount instead of the order amount for the capture request. The subject amount could be the full order or a set of items.

**Tested scenarios**
Partial capture
Full capture

**Fixed issue**:  PW-5005