### PR TITLE
[PW-5167] show component loading error only on test

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/adyen-hpp-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-hpp-method.js
@@ -456,7 +456,9 @@ define(
                                     result.component = component;
                                 } catch (err) {
                                     // The component does not exist yet
-                                    console.log(err);
+                                    if ('test' === adyenConfiguration.getCheckoutEnvironment()) {
+                                        console.log(err);
+                                    }
                                 }
                             },
                             placeOrder: function() {


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Hide console error when loading component on production 
**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

**Fixed issue**: resolves #1106 <!-- #-prefixed issue number -->