### PR TITLE
JSON Pretty log

### DIFF
--- a/Controller/Process/Json.php
+++ b/Controller/Process/Json.php
@@ -221,7 +221,7 @@ class Json extends \Magento\Framework\App\Action\Action
                 $response
             )) {
                 $this->_adyenLogger->addAdyenNotification(
-                    'HMAC key validation failed ' . print_r($response, 1)
+                    'HMAC key validation failed ' . json_encode($response)
                 );
                 return false;
             }
@@ -230,7 +230,7 @@ class Json extends \Magento\Framework\App\Action\Action
         if ($this->authorised($response)) {
             // log the notification
             $this->_adyenLogger->addAdyenNotification(
-                "The content of the notification item is: " . print_r($response, 1)
+                "The content of the notification item is: " . json_encode($response)
             );
 
             // check if notification already exists

--- a/Controller/Process/Result.php
+++ b/Controller/Process/Result.php
@@ -153,7 +153,7 @@ class Result extends \Magento\Framework\App\Action\Action
     {
         // GET and POST params together
         $response = $this->getRequest()->getParams();
-        $this->_adyenLogger->addAdyenResult(print_r($response, true));
+        $this->_adyenLogger->addAdyenResult(json_encode($response));
 
         if ($response) {
             $result = $this->validateResponse($response);

--- a/Gateway/Command/PayByMailCommand.php
+++ b/Gateway/Command/PayByMailCommand.php
@@ -204,7 +204,7 @@ class PayByMailCommand implements CommandInterface
         $merchantSig = \Adyen\Util\Util::calculateSha256Signature($hmacKey, $formFields);
         $formFields['merchantSig'] = $merchantSig;
 
-        $this->_adyenLogger->addAdyenDebug(print_r($formFields, true));
+        $this->_adyenLogger->addAdyenDebug(json_encode($formFields));
 
         return $formFields;
     }

--- a/Gateway/Validator/PosCloudResponseValidator.php
+++ b/Gateway/Validator/PosCloudResponseValidator.php
@@ -68,7 +68,7 @@ class PosCloudResponseValidator extends AbstractValidator
         $paymentDataObjectInterface = \Magento\Payment\Gateway\Helper\SubjectReader::readPayment($validationSubject);
         $payment = $paymentDataObjectInterface->getPayment();
 
-        $this->adyenLogger->addAdyenDebug(print_r($response, true));
+        $this->adyenLogger->addAdyenDebug(json_encode($response));
 
         // Check for errors
         if (!empty($response['error'])) {

--- a/Helper/PaymentResponseHandler.php
+++ b/Helper/PaymentResponseHandler.php
@@ -223,7 +223,7 @@ class PaymentResponseHandler
                 $this->adyenLogger->error(
                     sprintf("Payment details call failed for action, resultCode is %s Raw API responds: %s",
                             $paymentsResponse['resultCode'],
-                            print_r($paymentsResponse, true)
+                            json_encode($paymentsResponse)
                     ));
 
                 return false;

--- a/Helper/Vault.php
+++ b/Helper/Vault.php
@@ -106,7 +106,7 @@ class Vault
         try {
             $paymentToken = $this->getVaultPaymentToken($payment, $additionalData);
         } catch (Exception $exception) {
-            $this->adyenLogger->error(print_r($exception, true));
+            $this->adyenLogger->error(json_encode($exception));
             return;
         }
 

--- a/Model/Cron.php
+++ b/Model/Cron.php
@@ -511,7 +511,7 @@ class Cron
                 }
 
                 // log the executed notification
-                $this->_adyenLogger->addAdyenNotificationCronjob(print_r($notification->debug(), 1));
+                $this->_adyenLogger->addAdyenNotificationCronjob(json_encode($notification->debug()));
 
                 // get order
                 $incrementId = $notification->getMerchantReference();
@@ -1277,7 +1277,7 @@ class Cron
                         }
 
                         if ($contractDetail == null) {
-                            $this->_adyenLogger->addAdyenNotificationCronjob(print_r($listRecurringContracts, 1));
+                            $this->_adyenLogger->addAdyenNotificationCronjob(json_encode($listRecurringContracts));
                             $message = __(
                                 'Failed to create billing agreement for this order ' .
                                 '(listRecurringCall did not contain contract)'


### PR DESCRIPTION
**Description**
Using `print_r` for logs cause multiple lines on ECK, it's hard to debug when it is the case.

I've used `json_encode` as used on other Adyen logs.