### PR TITLE
[PW-5238] Remove cc check so are not ignored for offer_closed

### DIFF
--- a/Helper/PaymentMethods.php
+++ b/Helper/PaymentMethods.php
@@ -456,24 +456,5 @@ class PaymentMethods extends AbstractHelper
 
         return $paymentMethodsExtraDetails;
     }
-
-    /**
-     * Checks if a payment is wallet payment method
-     * @param $notificationPaymentMethod
-     * @return bool
-     */
-    public function isWalletPaymentMethod($notificationPaymentMethod): bool
-    {
-        $walletPaymentMethods = [
-            'googlepay',
-            'paywithgoogle',
-            'wechatpayWeb',
-            'amazonpay',
-            'applepay',
-            'wechatpayQR',
-            'alipay',
-            'alipay_hk'
-        ];
-        return in_array($notificationPaymentMethod, $walletPaymentMethods);
-    }
 }
+

--- a/Helper/PaymentMethods.php
+++ b/Helper/PaymentMethods.php
@@ -457,4 +457,3 @@ class PaymentMethods extends AbstractHelper
         return $paymentMethodsExtraDetails;
     }
 }
-

--- a/Helper/PaymentMethods.php
+++ b/Helper/PaymentMethods.php
@@ -456,4 +456,24 @@ class PaymentMethods extends AbstractHelper
 
         return $paymentMethodsExtraDetails;
     }
+
+    /**
+     * Checks if a payment is wallet payment method
+     * @param $notificationPaymentMethod
+     * @return bool
+     */
+    public function isWalletPaymentMethod($notificationPaymentMethod): bool
+    {
+        $walletPaymentMethods = [
+            'googlepay',
+            'paywithgoogle',
+            'wechatpayWeb',
+            'amazonpay',
+            'applepay',
+            'wechatpayQR',
+            'alipay',
+            'alipay_hk'
+        ];
+        return in_array($notificationPaymentMethod, $walletPaymentMethods);
+    }
 }

--- a/Model/Cron.php
+++ b/Model/Cron.php
@@ -1181,7 +1181,8 @@ class Cron
                 $isOrderCc = strcmp(
                         $this->_paymentMethodCode(),
                         'adyen_cc'
-                    ) == 0 || strcmp($this->_paymentMethodCode(), 'adyen_oneclick') == 0;
+                    ) == 0 || strcmp($this->_paymentMethodCode(), 'adyen_oneclick') == 0
+                    || $this->isWalletPaymentMethod($this->_paymentMethodCode());
 
                 /*
                  * If the order was made with an Alternative payment method,
@@ -1190,13 +1191,12 @@ class Cron
                  */
                 if (!$isOrderCc && strcmp($notificationPaymentMethod, $orderPaymentMethod) !== 0) {
                     $this->_adyenLogger->addAdyenNotificationCronjob(
-                        "Order is not a credit card,
+                        "Order is not a credit card, wallet payment method
                     or the payment method in the notification does not match the payment method of the order,
                     skipping OFFER_CLOSED"
                     );
                     break;
                 }
-
                 if (!$this->_order->canCancel() && $this->configHelper->getNotificationsCanCancel(
                         $this->_order->getStoreId()
                     )) {
@@ -2242,5 +2242,16 @@ class Cron
             $this->_order->addStatusHistoryComment($comment, $this->_order->getStatus());
             $this->_order->save();
         }
+    }
+
+    /**
+     * Checks if a payment is wallet payment method
+     * @param $notificationPaymentMethod
+     * @return bool
+     */
+    private function isWalletPaymentMethod($notificationPaymentMethod): bool
+    {
+        $walletPaymentMethods = array('googlepay', 'paywithgoogle', 'wechatpayWeb', 'amazonpay', 'applepay');
+        return in_array($notificationPaymentMethod, $walletPaymentMethods);
     }
 }

--- a/Model/Cron.php
+++ b/Model/Cron.php
@@ -292,11 +292,6 @@ class Cron
     private $chargedCurrency;
 
     /**
-     * @var \Adyen\Payment\Helper\PaymentMethods
-     */
-    protected $paymentMethodsHelper;
-
-    /**
      * Cron constructor.
      *
      * @param \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
@@ -328,7 +323,6 @@ class Cron
      * @param PaymentTokenRepositoryInterface $paymentTokenRepository
      * @param EncryptorInterface $encryptor
      * @param ChargedCurrency $chargedCurrency
-     * @param \Adyen\Payment\Helper\PaymentMethods $paymentMethodsHelper
      */
     public function __construct(
         \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,
@@ -359,8 +353,7 @@ class Cron
         PaymentTokenFactoryInterface $paymentTokenFactory,
         PaymentTokenRepositoryInterface $paymentTokenRepository,
         EncryptorInterface $encryptor,
-        ChargedCurrency $chargedCurrency,
-        \Adyen\Payment\Helper\PaymentMethods $paymentMethodsHelper
+        ChargedCurrency $chargedCurrency
     ) {
         $this->_scopeConfig = $scopeConfig;
         $this->_adyenLogger = $adyenLogger;
@@ -391,7 +384,6 @@ class Cron
         $this->paymentTokenRepository = $paymentTokenRepository;
         $this->encryptor = $encryptor;
         $this->chargedCurrency = $chargedCurrency;
-        $this->paymentMethodsHelper = $paymentMethodsHelper;
     }
 
     /**
@@ -1185,19 +1177,12 @@ class Cron
                 * For alternatives, it can be 'ideal', 'directEbanking',...
                 */
                 $orderPaymentMethod = $this->_order->getPayment()->getCcType();
-
-                $isOrderCc = strcmp(
-                        $this->_paymentMethodCode(),
-                        'adyen_cc'
-                    ) == 0 || strcmp($this->_paymentMethodCode(), 'adyen_oneclick') == 0
-                    || $this->paymentMethodsHelper->isWalletPaymentMethod($notificationPaymentMethod);
-
                 /*
                  * If the order was made with an Alternative payment method,
                  * continue with the cancellation only if the payment method of
                  * the notification matches the payment method of the order.
                  */
-                if (!$isOrderCc && strcmp($notificationPaymentMethod, $orderPaymentMethod) !== 0) {
+                if (strcmp($notificationPaymentMethod, $orderPaymentMethod) !== 0) {
                     $this->_adyenLogger->addAdyenNotificationCronjob(
                         "Order is not a credit card, wallet payment method
                     or the payment method in the notification does not match the payment method of the order,

--- a/Model/Cron.php
+++ b/Model/Cron.php
@@ -292,6 +292,11 @@ class Cron
     private $chargedCurrency;
 
     /**
+     * @var \Adyen\Payment\Helper\PaymentMethods
+     */
+    protected $paymentMethodsHelper;
+
+    /**
      * Cron constructor.
      *
      * @param \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
@@ -323,6 +328,7 @@ class Cron
      * @param PaymentTokenRepositoryInterface $paymentTokenRepository
      * @param EncryptorInterface $encryptor
      * @param ChargedCurrency $chargedCurrency
+     * @param \Adyen\Payment\Helper\PaymentMethods $paymentMethodsHelper
      */
     public function __construct(
         \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,
@@ -353,7 +359,8 @@ class Cron
         PaymentTokenFactoryInterface $paymentTokenFactory,
         PaymentTokenRepositoryInterface $paymentTokenRepository,
         EncryptorInterface $encryptor,
-        ChargedCurrency $chargedCurrency
+        ChargedCurrency $chargedCurrency,
+        \Adyen\Payment\Helper\PaymentMethods $paymentMethodsHelper
     ) {
         $this->_scopeConfig = $scopeConfig;
         $this->_adyenLogger = $adyenLogger;
@@ -384,6 +391,7 @@ class Cron
         $this->paymentTokenRepository = $paymentTokenRepository;
         $this->encryptor = $encryptor;
         $this->chargedCurrency = $chargedCurrency;
+        $this->paymentMethodsHelper = $paymentMethodsHelper;
     }
 
     /**
@@ -1182,7 +1190,7 @@ class Cron
                         $this->_paymentMethodCode(),
                         'adyen_cc'
                     ) == 0 || strcmp($this->_paymentMethodCode(), 'adyen_oneclick') == 0
-                    || $this->isWalletPaymentMethod($this->_paymentMethodCode());
+                    || $this->paymentMethodsHelper->isWalletPaymentMethod($notificationPaymentMethod);
 
                 /*
                  * If the order was made with an Alternative payment method,

--- a/Model/Cron.php
+++ b/Model/Cron.php
@@ -1166,29 +1166,6 @@ class Cron
                     break;
                 }
 
-                /*
-                 * For cards, it can be 'visa', 'maestro',...
-                 * For alternatives, it can be 'ideal', 'directEbanking',...
-                 */
-                $notificationPaymentMethod = $this->_paymentMethod;
-
-                /*
-                * For cards, it can be 'VI', 'MI',...
-                * For alternatives, it can be 'ideal', 'directEbanking',...
-                */
-                $orderPaymentMethod = $this->_order->getPayment()->getCcType();
-                /*
-                 * If the order was made with an Alternative payment method,
-                 * continue with the cancellation only if the payment method of
-                 * the notification matches the payment method of the order.
-                 */
-                if (strcmp($notificationPaymentMethod, $orderPaymentMethod) !== 0) {
-                    $this->_adyenLogger->addAdyenNotificationCronjob(
-                        "Notification does not match the payment method of the order,
-                    skipping OFFER_CLOSED"
-                    );
-                    break;
-                }
                 if (!$this->_order->canCancel() && $this->configHelper->getNotificationsCanCancel(
                         $this->_order->getStoreId()
                     )) {

--- a/Model/Cron.php
+++ b/Model/Cron.php
@@ -1184,13 +1184,17 @@ class Cron
                 * For alternatives, it can be 'ideal', 'directEbanking',...
                 */
                 $orderPaymentMethod = $this->_order->getPayment()->getCcType();
+
+                /*
+                 * Returns if the payment method is wallet like wechatpayWeb, amazonpay, applepay, paywithgoogle
+                 */
+                $isWalletPaymentMethod = $this->paymentMethodsHelper->isWalletPaymentMethod($orderPaymentMethod);
                 /*
                 * If the order was made with an Alternative payment method,
                 *  continue with the cancellation only if the payment method of
                 * the notification matches the payment method of the order.
                 */
-                if (strcmp($notificationPaymentMethod, $orderPaymentMethod) !== 0
-                    && !$this->paymentMethodsHelper->isWalletPaymentMethod($orderPaymentMethod)) {
+                if ( !$isWalletPaymentMethod && strcmp($notificationPaymentMethod, $orderPaymentMethod) !== 0) {
                     $this->_adyenLogger->addAdyenNotificationCronjob(
                         "The notification does not match the payment method of the order,
                     skipping OFFER_CLOSED"

--- a/Model/Cron.php
+++ b/Model/Cron.php
@@ -1184,8 +1184,7 @@ class Cron
                  */
                 if (strcmp($notificationPaymentMethod, $orderPaymentMethod) !== 0) {
                     $this->_adyenLogger->addAdyenNotificationCronjob(
-                        "Order is not a credit card, wallet payment method
-                    or the payment method in the notification does not match the payment method of the order,
+                        "Notification does not match the payment method of the order,
                     skipping OFFER_CLOSED"
                     );
                     break;

--- a/Model/Cron.php
+++ b/Model/Cron.php
@@ -2251,15 +2251,4 @@ class Cron
             $this->_order->save();
         }
     }
-
-    /**
-     * Checks if a payment is wallet payment method
-     * @param $notificationPaymentMethod
-     * @return bool
-     */
-    private function isWalletPaymentMethod($notificationPaymentMethod): bool
-    {
-        $walletPaymentMethods = array('googlepay', 'paywithgoogle', 'wechatpayWeb', 'amazonpay', 'applepay');
-        return in_array($notificationPaymentMethod, $walletPaymentMethods);
-    }
 }


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->

For `OFFER_CLOSED` notifications the order cancel was skipped if the payment methods was not cc and cancelled only if the payment method of the notification matches the payment method of the order. The purpose of this is If an order was made with an Alternative payment method it will continue with the cancellation only if the payment method of the notification matches the payment method of the order. 
On the other hand, that is causing all the wallet payment methods to be skipped because the notification and the order are never matching. For example it could be `paywithgoogle` with `visa`.

Furthermore, The check for CC or one click was rejecting all wallet payment methods because the payment method code is  `adyen_hpp` and could trigger `OFFER_CLOSED` notification so should be also canceled. 

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
Google pay with 3ds1

**Fixed issue**:  fixes #1121 