### PR TITLE
[PW-5124] fix check for magento initiated refund

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -37,7 +37,7 @@ class Data extends AbstractHelper
     // Only used for backend orders! Checkout in front-end is using different checkout version see web folder, will be removed in v8.0.0
     const CHECKOUT_COMPONENT_JS_LIVE = 'https://checkoutshopper-live.adyen.com/checkoutshopper/sdk/4.5.0/adyen.js';
     const CHECKOUT_COMPONENT_JS_TEST = 'https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/4.5.0/adyen.js';
-    const PSP_REFERENCE_REGEX = '/[0-9.A-Z]{16}/';
+    const PSP_REFERENCE_REGEX = '/(?P<pspReference>[0-9.A-Z]{16})(?P<suffix>[a-z\-]*)/';
 
     /**
      * @var \Magento\Framework\Encryption\EncryptorInterface
@@ -1788,23 +1788,22 @@ class Data extends AbstractHelper
     }
 
     /**
-     * Get pspReference only if there are additional string attached
-     * @param $pspReference
+     * Parse transactionId to separate PSP reference from suffix.
+     * e.g 882629192021269E-capture => [882629192021269E, -capture]
+     *
+     * @param $transactionId
+     * @return mixed
      */
-    public function getPspReferenceWithNoAdditions($pspReference)
+    public function parseTransactionId($transactionId)
     {
-        if (empty($pspReference)) {
-            return '';
-        }
         preg_match(
             self::PSP_REFERENCE_REGEX,
-            trim($pspReference),
-            $match,
-            PREG_OFFSET_CAPTURE
+            trim((string)$transactionId),
+            $matches
         );
-        if (!empty($match[0])) {
-            return $match[0][0];
-        }
-        return $pspReference;
+
+        return array_filter($matches, function($index) {
+            return is_string($index);
+        }, ARRAY_FILTER_USE_KEY);
     }
 }

--- a/Model/Cron.php
+++ b/Model/Cron.php
@@ -1462,11 +1462,14 @@ class Cron
         }
 
         /*
-         * Don't create a credit memo if refund is initialize in Magento
-         * because in this case the credit memo already exists
+         * Don't create a credit memo if refund is initialized in Magento
+         * because in this case the credit memo already exists.
+         * Refunds initialized in Magento have a suffix such as '-refund', '-capture' or '-capture-refund' appended
+         * to the original reference.
          */
         $lastTransactionId = $this->_order->getPayment()->getLastTransId();
-        if ($this->_adyenHelper->getPspReferenceWithNoAdditions($lastTransactionId) != $this->_originalReference) {
+        $matches = $this->_adyenHelper->parseTransactionId($lastTransactionId);
+        if (($matches['pspReference'] ?? '') == $this->_originalReference && empty($matches['suffix'])) {
             // refund is done through adyen backoffice so create a credit memo
             $order = $this->_order;
             if ($order->canCreditmemo()) {

--- a/Test/Unit/Helper/DataTest.php
+++ b/Test/Unit/Helper/DataTest.php
@@ -127,10 +127,22 @@ class DataTest extends \PHPUnit\Framework\TestCase
     }
 
     public function testGetPspReferenceWithNoAdditions(){
-        $this->assertEquals('852621234567890A', $this->dataHelper->getPspReferenceWithNoAdditions('852621234567890A'));
-        $this->assertEquals('852621234567890A', $this->dataHelper->getPspReferenceWithNoAdditions('852621234567890A-refund'));
-        $this->assertEquals('852621234567890A', $this->dataHelper->getPspReferenceWithNoAdditions('852621234567890A-capture'));
-        $this->assertEquals('852621234567890A', $this->dataHelper->getPspReferenceWithNoAdditions('852621234567890A-capture-refund'));
+        $this->assertEquals(
+            ['pspReference' => '852621234567890A', 'suffix' => ''],
+            $this->dataHelper->parseTransactionId('852621234567890A')
+        );
+        $this->assertEquals(
+            ['pspReference' => '852621234567890A', 'suffix' => '-refund'],
+            $this->dataHelper->parseTransactionId('852621234567890A-refund')
+        );
+        $this->assertEquals(
+            ['pspReference' => '852621234567890A', 'suffix' => '-capture'],
+            $this->dataHelper->parseTransactionId('852621234567890A-capture')
+        );
+        $this->assertEquals(
+            ['pspReference' => '852621234567890A', 'suffix' => '-capture-refund'],
+            $this->dataHelper->parseTransactionId('852621234567890A-capture-refund')
+        );
     }
 
     public static function checkoutEnvironmentsProvider()


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Refunds made through Magento have a transaction ID made up of the original Psp Reference with a suffix such as '-capture' appended to it.
E.g Payment PSP reference: 1234ABCD5678EFGHXXYY
credit memo transactionId: 1234ABCD5678EFGHXXYY-refund

Updated the check to parse the transactionId, compare the PSP reference and only avoid creating a credit memo when there is no suffix (like -refund) appended to it.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
Create credit memo through M2 => no extra ghost credit memo is created when REFUND notification is processed
Trigger refund from Adyen CA => credit memo is created when REFUND notification is processed
**Fixed issue**:  Resolves #1092 <!-- #-prefixed issue number -->