### PR TITLE
[BUGFIX] Fix integrity constraint violation with 'entity_id' 

### DIFF
--- a/Helper/Quote.php
+++ b/Helper/Quote.php
@@ -124,7 +124,7 @@ class Quote
         $order = reset($orderList);
 
         $quoteList = $this->cartRepository->getList(
-            $this->searchCriteriaBuilder->addFilter('entity_id', $order->getQuoteId())->create()
+            $this->searchCriteriaBuilder->addFilter('main_table.entity_id', $order->getQuoteId())->create()
         )->getItems();
         $quote = reset($quoteList);
 


### PR DESCRIPTION
Fix integrity constraint violation with 'entity_id' where clause is ambiguous

Affected ambiguous query:

SQLSTATE[23000]: Integrity constraint violation: 1052 Column 'entity_id' in where clause is ambiguous, query was: SELECT `main_table`.*, `extension_attribute_amazon_order_reference_id`.`amazon_order_reference_id` AS `extension_attribute_amazon_order_reference_id_amazon_order_reference_id`, `extension_attribute_amazon_order_reference_id`.`quote_id` AS `extension_attribute_amazon_order_reference_id_quote_id`, `extension_attribute_amazon_order_reference_id`.`sandbox_simulation_reference` AS `extension_attribute_amazon_order_reference_id_sandbox_simulation_reference`, `extension_attribute_amazon_order_reference_id`.`confirmed` AS `extension_attribute_amazon_order_reference_id_confirmed` FROM `quote` AS `main_table`
 LEFT JOIN `amazon_quote` AS `extension_attribute_amazon_order_reference_id` ON main_table.entity_id = extension_attribute_amazon_order_reference_id.quote_id WHERE ((`entity_id` = ?))

Problem is caused when Amazon Pay module is enabled and extension attributes are loaded.

<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
Fixes an ambiguous constructed query when Amazon Pay module (Commerce Module) is enabled.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

**Fixed issue**:  <!-- #-prefixed issue number -->