### PR TITLE
[PW-5278] Reload pm after applying or canceling discount code

### DIFF
--- a/view/frontend/web/js/view/payment/adyen-methods.js
+++ b/view/frontend/web/js/view/payment/adyen-methods.js
@@ -95,11 +95,11 @@ define(
                     shippingAddressCountry = quote.shippingAddress().countryId;
                     retrievePaymentMethods();
                 });
-                //Retrieve payment methods when applying the discount code
+                //Retrieve payment methods to ensure the amount is updated, when applying the discount code
                 setCouponCodeAction.registerSuccessCallback(function () {
                     retrievePaymentMethods();
                 });
-                //Retrieve payment methods when canceling the discount code
+                //Retrieve payment methods to ensure the amount is updated, when canceling the discount code
                 cancelCouponAction.registerSuccessCallback(function () {
                     retrievePaymentMethods();
                 });


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
When applying the coupon code in checkout the new amount is visible in the cart but not in the google pay pop up. Applying this fix the payment methods are retrieved again and reload the page. After the reload the amount in google pay matches with the one in cart. The same applies for canceling the coupon code.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
Tested with google pay applying and canceling the coupon code
**Fixed issue**:  <!-- #-prefixed issue number -->