### PR TITLE
Return result from set-shipping-information mixin so it can be extended

### DIFF
--- a/view/frontend/web/js/model/set-shipping-information-mixin.js
+++ b/view/frontend/web/js/model/set-shipping-information-mixin.js
@@ -26,6 +26,7 @@ define([
                 }).fail(function() {
                     console.log('Fetching the payment methods failed!');
                 })
+                return result;
             });
         });
 


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
The set-shipping-information mixin needs to return the result so that the following extensions also work.

**Tested scenarios**
Updating the address details sends correct order amount for Apple Pay

**Fixed issue**: Fixes #1155