### PR TITLE
[PW-5545] - Create fallback for 'Number of lines in a street address' config value not existing

### DIFF
--- a/Helper/Requests.php
+++ b/Helper/Requests.php
@@ -203,6 +203,15 @@ class Requests extends AbstractHelper
 
             $customerStreetLinesEnabled = $this->adyenHelper->getCustomerStreetLinesEnabled($storeId);
 
+            // If config is not found (will occur on Adobe Commerce), attempt to get the value from the adyen config instead.
+            if (!$customerStreetLinesEnabled) {
+                $customerStreetLinesEnabled = $this->adyenHelper->getConfigData(
+                    'override_magento_number_of_lines',
+                    'adyen_abstract',
+                    $storeId
+                );
+            }
+
             $address = $this->addressHelper->getStreetAndHouseNumberFromAddress(
                 $billingAddress,
                 $houseNumberStreetLine,

--- a/etc/adminhtml/system/adyen_checkout_experience.xml
+++ b/etc/adminhtml/system/adyen_checkout_experience.xml
@@ -48,7 +48,13 @@
             <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
             <tooltip><![CDATA[3DS1, 3DS2 and redirect failed payments can restore the previous quote or clone it for a retry.]]></tooltip>
         </field>
-        <field id="house_number_street_line" translate="label" type="select" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
+        <field id="override_magento_number_of_lines" translate="label" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
+            <label>Override Magento 'Number of lines in a street address' config</label>
+            <config_path>payment/adyen_abstract/override_magento_number_of_lines</config_path>
+            <comment>Valid range: 1-4</comment>
+            <tooltip><![CDATA[This field will override the magento 'Number of lines in a street address' config. It should only be used on Adobe commerce, where the aforementioned field does not exist]]></tooltip>
+        </field>
+        <field id="house_number_street_line" translate="label" type="select" sortOrder="50" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
             <label>Address street line used for the house number input</label>
             <config_path>payment/adyen_abstract/house_number_street_line</config_path>
             <source_model>Adyen\Payment\Model\Config\Source\HouseNumberStreetLine</source_model>

--- a/etc/adminhtml/system/adyen_checkout_experience.xml
+++ b/etc/adminhtml/system/adyen_checkout_experience.xml
@@ -51,7 +51,7 @@
         <field id="override_magento_number_of_lines" translate="label" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
             <label>Override Magento 'Number of lines in a street address' config</label>
             <config_path>payment/adyen_abstract/override_magento_number_of_lines</config_path>
-            <validate>required-entry validate-digits validate-not-negative-number validate-digits-range digits-range-1-4</validate>
+            <validate>validate-digits validate-not-negative-number validate-digits-range digits-range-1-4</validate>
             <comment>Valid range: 1-4</comment>
             <tooltip><![CDATA[This field will override the Magento 'Number of lines in a street address' config. It should only be used on Adobe Commerce, where the aforementioned field does not exist]]></tooltip>
         </field>

--- a/etc/adminhtml/system/adyen_checkout_experience.xml
+++ b/etc/adminhtml/system/adyen_checkout_experience.xml
@@ -52,7 +52,7 @@
             <label>Override Magento 'Number of lines in a street address' config</label>
             <config_path>payment/adyen_abstract/override_magento_number_of_lines</config_path>
             <comment>Valid range: 1-4</comment>
-            <tooltip><![CDATA[This field will override the magento 'Number of lines in a street address' config. It should only be used on Adobe commerce, where the aforementioned field does not exist]]></tooltip>
+            <tooltip><![CDATA[This field will override the Magento 'Number of lines in a street address' config. It should only be used on Adobe Commerce, where the aforementioned field does not exist]]></tooltip>
         </field>
         <field id="house_number_street_line" translate="label" type="select" sortOrder="50" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
             <label>Address street line used for the house number input</label>

--- a/etc/adminhtml/system/adyen_checkout_experience.xml
+++ b/etc/adminhtml/system/adyen_checkout_experience.xml
@@ -51,6 +51,7 @@
         <field id="override_magento_number_of_lines" translate="label" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
             <label>Override Magento 'Number of lines in a street address' config</label>
             <config_path>payment/adyen_abstract/override_magento_number_of_lines</config_path>
+            <validate>required-entry validate-digits validate-not-negative-number validate-digits-range digits-range-1-4</validate>
             <comment>Valid range: 1-4</comment>
             <tooltip><![CDATA[This field will override the Magento 'Number of lines in a street address' config. It should only be used on Adobe Commerce, where the aforementioned field does not exist]]></tooltip>
         </field>


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
Based on these magento [docs](https://docs.magento.com/user-guide/configuration/customers/customer-configuration.html#open-source-options) and a merchant call, it seems that the **Number of Lines in a Street Address** config value will not be available on Adobe Commerce. Hence, in this specific case the `getCustomerStreetLinesEnabled()` function will return 0 and it will cause both the houseNumber and the street sent in the payment request to be `N\/A`.

Hence, this PR will create a new config value to override this magento default value. The tooltip should make it clear that this config field will only be useful on Adobe commerce, since on the open source version, the magento config will be present.