### PR TITLE
[PW-5489] reproduce address formatting logic in frontend component

### DIFF
--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -187,7 +187,7 @@ class Config
      */
     public function getHouseNumberStreetLine($storeId = null)
     {
-        return $this->adyenHelper->getAdyenAbstractConfigDataFlag(self::XML_HOUSE_NUMBER_STREET_LINE, $storeId);
+        return $this->adyenHelper->getAdyenAbstractConfigData(self::XML_HOUSE_NUMBER_STREET_LINE, $storeId);
     }
 
 

--- a/Helper/Requests.php
+++ b/Helper/Requests.php
@@ -185,9 +185,8 @@ class Requests extends AbstractHelper
             // Save the defaults for later to compare if anything has changed
             $requestBilling = $requestBillingDefaults;
 
-            $houseNumberStreetLine = $this->adyenHelper->getConfigData(
-                'house_number_street_line',
-                'adyen_abstract',
+            $houseNumberStreetLine = $this->adyenHelper->getAdyenAbstractConfigDataFlag(
+                Config::XML_HOUSE_NUMBER_STREET_LINE,
                 $storeId
             );
 

--- a/Model/Ui/AdyenGenericConfigProvider.php
+++ b/Model/Ui/AdyenGenericConfigProvider.php
@@ -86,9 +86,9 @@ class AdyenGenericConfigProvider implements ConfigProviderInterface
         $config['payment']['adyen']['chargedCurrency'] = $this->adyenConfigHelper->getChargedCurrency($storeId);
         $config['payment']['adyen']['hasHolderName'] = $this->adyenConfigHelper->getHasHolderName($storeId);
         $config['payment']['adyen']['holderNameRequired'] = $this->adyenConfigHelper->getHolderNameRequired($storeId);
-        $config['payment']['adyen']['houseNumberStreetLine'] = $this->adyenConfigHelper->getHouseNumberStreetLine(
-            $storeId
-        );
+        $config['payment']['adyen']['houseNumberStreetLine'] = $this->adyenConfigHelper
+            ->getHouseNumberStreetLine($storeId);
+        $config['payment']['customerStreetLinesEnabled'] = $this->adyenHelper->getCustomerStreetLinesEnabled($storeId);
 
         return $config;
     }

--- a/view/frontend/web/js/model/adyen-configuration.js
+++ b/view/frontend/web/js/model/adyen-configuration.js
@@ -48,6 +48,9 @@ define(
             getHouseNumberStreetLine: function() {
                 return window.checkoutConfig.payment.adyen.houseNumberStreetLine;
             },
+            getCustomerStreetLinesEnabled: function () {
+                return window.checkoutConfig.payment.customerStreetLinesEnabled;
+            },
         };
     },
 );


### PR DESCRIPTION


<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Add the config based logic for formatting shopper address to the web component
Update regex to search for different address formats, e.g. 1A streetname, Streetname 1 A
**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

**Fixed issue**:  <!-- #-prefixed issue number -->