### PR TITLE
PW-5489 use config based logic for formatting address in web component

### DIFF
--- a/Helper/Address.php
+++ b/Helper/Address.php
@@ -28,9 +28,9 @@ use Magento\Payment\Gateway\Data\AddressAdapterInterface;
 
 class Address
 {
-
     // Regex to extract the house number from the street line if needed (e.g. 'Street address 1 A' => '1 A')
-    const HOUSE_NUMBER_REGEX = '/((\s\d{0,10})|(\s\d{0,10}\s?\w{1,3}))$/i';
+    const STREET_FIRST_REGEX = "/(?<streetName>[a-zA-Z.'\- ]+)\s+(?<houseNumber>\d{1,10}((\s)?\w{1,3})?)$/";
+    CONST NUMBER_FIRST_REGEX = "/^(?<houseNumber>\d{1,10}((\s)?\w{1,3})?)\s+(?<streetName>[a-zA-Z.'\- ]+)/";
 
     /**
      * @param AddressAdapterInterface $address
@@ -77,19 +77,17 @@ class Address
     {
         $addressString = implode(' ', $addressArray);
 
-        preg_match(
-            self::HOUSE_NUMBER_REGEX,
-            trim($addressString),
-            $houseNumber,
-            PREG_OFFSET_CAPTURE
-        );
+        // Match addresses where the street name comes first, e.g. John-Paul's Ave. 1 B
+        preg_match(self::STREET_FIRST_REGEX, trim($addressString), $streetFirstAddress);
+        // Match addresses where the house number comes first, e.g. 10 D John-Paul's Ave.
+        preg_match(self::NUMBER_FIRST_REGEX, trim($addressString), $numberFirstAddress);
 
-        if (!empty($houseNumber['0'])) {
-            $_houseNumber = trim($houseNumber['0']['0']);
-            $position = $houseNumber['0']['1'];
-            $streetName = trim(substr($addressString, 0, $position));
-            return $this->formatAddressArray($streetName, $_houseNumber);
+        if (!empty($streetFirstAddress)) {
+            return $this->formatAddressArray($streetFirstAddress['streetName'], $streetFirstAddress['houseNumber']);
+        } elseif (!empty($numberFirstAddress)) {
+            return $this->formatAddressArray($numberFirstAddress['streetName'], $numberFirstAddress['houseNumber']);
         }
+
         return $this->formatAddressArray($addressString, 'N/A');
     }
 

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -187,7 +187,7 @@ class Config
      */
     public function getHouseNumberStreetLine($storeId = null)
     {
-        return $this->adyenHelper->getAdyenAbstractConfigDataFlag(self::XML_HOUSE_NUMBER_STREET_LINE, $storeId);
+        return $this->adyenHelper->getAdyenAbstractConfigData(self::XML_HOUSE_NUMBER_STREET_LINE, $storeId);
     }
 
 

--- a/Helper/Requests.php
+++ b/Helper/Requests.php
@@ -187,9 +187,8 @@ class Requests extends AbstractHelper
             // Save the defaults for later to compare if anything has changed
             $requestBilling = $requestBillingDefaults;
 
-            $houseNumberStreetLine = $this->adyenHelper->getConfigData(
-                'house_number_street_line',
-                'adyen_abstract',
+            $houseNumberStreetLine = $this->adyenHelper->getAdyenAbstractConfigDataFlag(
+                Config::XML_HOUSE_NUMBER_STREET_LINE,
                 $storeId
             );
 

--- a/Helper/Requests.php
+++ b/Helper/Requests.php
@@ -187,7 +187,7 @@ class Requests extends AbstractHelper
             // Save the defaults for later to compare if anything has changed
             $requestBilling = $requestBillingDefaults;
 
-            $houseNumberStreetLine = $this->adyenHelper->getAdyenAbstractConfigDataFlag(
+            $houseNumberStreetLine = $this->adyenHelper->getAdyenAbstractConfigData(
                 Config::XML_HOUSE_NUMBER_STREET_LINE,
                 $storeId
             );

--- a/Model/Ui/AdyenGenericConfigProvider.php
+++ b/Model/Ui/AdyenGenericConfigProvider.php
@@ -86,9 +86,9 @@ class AdyenGenericConfigProvider implements ConfigProviderInterface
         $config['payment']['adyen']['chargedCurrency'] = $this->adyenConfigHelper->getChargedCurrency($storeId);
         $config['payment']['adyen']['hasHolderName'] = $this->adyenConfigHelper->getHasHolderName($storeId);
         $config['payment']['adyen']['holderNameRequired'] = $this->adyenConfigHelper->getHolderNameRequired($storeId);
-        $config['payment']['adyen']['houseNumberStreetLine'] = $this->adyenConfigHelper->getHouseNumberStreetLine(
-            $storeId
-        );
+        $config['payment']['adyen']['houseNumberStreetLine'] = $this->adyenConfigHelper
+            ->getHouseNumberStreetLine($storeId);
+        $config['payment']['customerStreetLinesEnabled'] = $this->adyenHelper->getCustomerStreetLinesEnabled($storeId);
 
         return $config;
     }

--- a/view/frontend/web/js/model/adyen-configuration.js
+++ b/view/frontend/web/js/model/adyen-configuration.js
@@ -48,6 +48,9 @@ define(
             getHouseNumberStreetLine: function() {
                 return window.checkoutConfig.payment.adyen.houseNumberStreetLine;
             },
+            getCustomerStreetLinesEnabled: function () {
+                return window.checkoutConfig.payment.customerStreetLinesEnabled;
+            },
         };
     },
 );

--- a/view/frontend/web/js/view/payment/method-renderer/adyen-hpp-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-hpp-method.js
@@ -245,9 +245,6 @@ define(
                                     showPayButton = true;
                                 }
 
-                                var firstName = '';
-                                var lastName = '';
-                                var telephone = '';
                                 var email = '';
                                 var shopperGender = '';
                                 var shopperDateOfBirth = '';
@@ -265,87 +262,11 @@ define(
                                 var formattedBillingAddress = {};
 
                                 if (!!quote.shippingAddress()) {
-                                    formattedShippingAddress = getFormattedAddress(quote.shippingAddress());
+                                    formattedShippingAddress = self.getFormattedAddress(quote.shippingAddress());
                                 }
 
                                 if (!!quote.billingAddress()) {
-                                    formattedBillingAddress = getFormattedAddress(quote.billingAddress());
-                                }
-
-                                function getStreetAndHouseNumberFromAddress(address, houseNumberStreetLine, customerStreetLinesEnabled) {
-                                    let street = address.street.slice(0, customerStreetLinesEnabled);
-                                    let drawHouseNumberWithRegex = parseInt(houseNumberStreetLine) === 0 || // Config is disabled
-                                        houseNumberStreetLine > customerStreetLinesEnabled || // Not enough street lines enabled
-                                        houseNumberStreetLine > street.length; // House number field is empty
-
-                                    let addressArray;
-                                    if (drawHouseNumberWithRegex) {
-                                        addressArray = getStreetAndHouseNumberWithRegex(street.join(' ').trim());
-                                    } else {
-                                        let houseNumber = street.splice(houseNumberStreetLine - 1, 1);
-                                        addressArray = {
-                                            streetName: street.join(' ').trim(),
-                                            houseNumber: houseNumber.join(' ').trim()
-                                        }
-                                    }
-                                    return addressArray;
-                                }
-
-                                function getStreetAndHouseNumberWithRegex(addressString) {
-                                    // Match addresses where the street name comes first, e.g. John-Paul's Ave. 1 B
-                                    let streetFirstRegex = /(?<streetName>[a-zA-Z.'\- ]+)\s+(?<houseNumber>\d{1,10}((\s)?\w{1,3})?)$/;
-                                    // Match addresses where the house number comes first, e.g. 10 D John-Paul's Ave.
-                                    let numberFirstRegex = /^(?<houseNumber>\d{1,10}((\s)?\w{1,3})?)\s+(?<streetName>[a-zA-Z.'\- ]+)/;
-
-                                    let streetFirstAddress = addressString.match(streetFirstRegex);
-                                    let numberFirstAddress = addressString.match(numberFirstRegex);
-
-                                    if (streetFirstAddress) {
-                                        return streetFirstAddress.groups;
-                                    } else if (numberFirstAddress) {
-                                        return numberFirstAddress.groups;
-                                    }
-
-                                    return {
-                                        streetName: addressString,
-                                        houseNumber: 'N/A'
-                                    };
-                                }
-
-                                /**
-                                 * @param address
-                                 * @returns {{country: (string|*), firstName: (string|*), lastName: (string|*), city: (*|string), street: *, postalCode: (*|string), houseNumber: string, telephone: (string|*)}}
-                                 */
-                                function getFormattedAddress(address) {
-                                    let city = '';
-                                    let country = '';
-                                    let postalCode = '';
-                                    let street = {};
-                                    city = address.city;
-
-                                    country = address.countryId;
-                                    postalCode = address.postcode;
-
-                                    street = getStreetAndHouseNumberFromAddress(
-                                        address,
-                                        adyenConfiguration.getHouseNumberStreetLine(),
-                                        adyenConfiguration.getCustomerStreetLinesEnabled()
-                                    );
-
-                                    firstName = address.firstname;
-                                    lastName = address.lastname;
-                                    telephone = address.telephone;
-
-                                    return {
-                                        city: city,
-                                        country: country,
-                                        postalCode: postalCode,
-                                        street: street.streetName,
-                                        houseNumber: street.houseNumber,
-                                        firstName: firstName,
-                                        lastName: lastName,
-                                        telephone: telephone
-                                    };
+                                    formattedBillingAddress = self.getFormattedAddress(quote.billingAddress());
                                 }
 
                                 function getAdyenGender(gender) {
@@ -813,6 +734,68 @@ define(
             getCode: function() {
                 return window.checkoutConfig.payment.adyenHpp.methodCode;
             },
+
+            /**
+             * @param address
+             * @returns {{country: (string|*), firstName: (string|*), lastName: (string|*), city: (*|string), street: *, postalCode: (*|string), houseNumber: string, telephone: (string|*)}}
+             */
+            getFormattedAddress: function(address) {
+                function getStreetAndHouseNumberFromAddress(address, houseNumberStreetLine, customerStreetLinesEnabled) {
+                    let street = address.street.slice(0, customerStreetLinesEnabled);
+                    let drawHouseNumberWithRegex = parseInt(houseNumberStreetLine) === 0 || // Config is disabled
+                        houseNumberStreetLine > customerStreetLinesEnabled || // Not enough street lines enabled
+                        houseNumberStreetLine > street.length; // House number field is empty
+
+                    let addressArray;
+                    if (drawHouseNumberWithRegex) {
+                        addressArray = getStreetAndHouseNumberWithRegex(street.join(' ').trim());
+                    } else {
+                        let houseNumber = street.splice(houseNumberStreetLine - 1, 1);
+                        addressArray = {
+                            streetName: street.join(' ').trim(),
+                            houseNumber: houseNumber.join(' ').trim()
+                        }
+                    }
+                    return addressArray;
+                }
+                function getStreetAndHouseNumberWithRegex(addressString) {
+                    // Match addresses where the street name comes first, e.g. John-Paul's Ave. 1 B
+                    let streetFirstRegex = /(?<streetName>[a-zA-Z.'\- ]+)\s+(?<houseNumber>\d{1,10}((\s)?\w{1,3})?)$/;
+                    // Match addresses where the house number comes first, e.g. 10 D John-Paul's Ave.
+                    let numberFirstRegex = /^(?<houseNumber>\d{1,10}((\s)?\w{1,3})?)\s+(?<streetName>[a-zA-Z.'\- ]+)/;
+
+                    let streetFirstAddress = addressString.match(streetFirstRegex);
+                    let numberFirstAddress = addressString.match(numberFirstRegex);
+
+                    if (streetFirstAddress) {
+                        return streetFirstAddress.groups;
+                    } else if (numberFirstAddress) {
+                        return numberFirstAddress.groups;
+                    }
+
+                    return {
+                        streetName: addressString,
+                        houseNumber: 'N/A'
+                    };
+                }
+
+                let street = getStreetAndHouseNumberFromAddress(
+                    address,
+                    adyenConfiguration.getHouseNumberStreetLine(),
+                    adyenConfiguration.getCustomerStreetLinesEnabled()
+                );
+
+                return {
+                    city: address.city,
+                    country: address.countryId,
+                    postalCode: address.postcode,
+                    street: street.streetName,
+                    houseNumber: street.houseNumber,
+                    firstName: address.firstname,
+                    lastName: address.lastname,
+                    telephone: address.telephone
+                };
+            }
         });
     },
 );


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Add the config based logic for formatting shopper address to the web component
Update regex to search for different address formats, e.g. 1A streetname, Streetname 1 A
**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

**Fixed issue**:  <!-- #-prefixed issue number -->