### PR TITLE
Feature/magento coding standards

### DIFF
--- a/Controller/Process/Result.php
+++ b/Controller/Process/Result.php
@@ -178,7 +178,6 @@ class Result extends \Magento\Framework\App\Action\Action
             $session = $this->_session;
             $session->getQuote()->setIsActive($setQuoteAsActive)->save();
             $this->_redirect($successPath, ['_query' => ['utm_nooverride' => '1']]);
-
         } else {
             $this->_adyenLogger->addAdyenResult(
                 sprintf(

--- a/Gateway/Http/Client/TransactionPayment.php
+++ b/Gateway/Http/Client/TransactionPayment.php
@@ -99,7 +99,6 @@ class TransactionPayment implements ClientInterface
             $paymentResponse->setMerchantReference($request["reference"]);
 
             $this->paymentResponseResourceModel->save($paymentResponse);
-
         } catch (\Adyen\AdyenException $e) {
             $response['error'] = $e->getMessage();
         }

--- a/Helper/Installments.php
+++ b/Helper/Installments.php
@@ -56,7 +56,6 @@ class Installments
 
         $formattedConfig = $values = array();
         foreach ($installmentsArray as $card => $cardInstallments) {
-
             $values[] = 1; // Always allow payment in full amount if installments are available
 
             foreach ($cardInstallments as $minimumAmount => $installment) {

--- a/Model/Cron.php
+++ b/Model/Cron.php
@@ -2109,7 +2109,6 @@ class Cron
         }
 
         if ($fullAmountFinalized) {
-
             $comment = "Adyen Payment Successfully completed";
 
             // If manual review is true AND manual review status is set

--- a/etc/adminhtml/menu.xml
+++ b/etc/adminhtml/menu.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../Magento/Backend/etc/menu.xsd">
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Backend:etc/menu.xsd">
     <menu>
         <add id="Adyen_Payment::adyen" title="Adyen" module="Adyen_Payment" sortOrder="100" parent="Magento_Backend::system" resource="Adyen_Payment::adyen"/>
         <add id="Adyen_Payment::notifications_overview" title="Notifications Overview" module="Adyen_Payment" sortOrder="10" parent="Adyen_Payment::adyen" action="adyen/notifications/overview" resource="Adyen_Payment::notifications_overview"/>


### PR DESCRIPTION
**Description**
- I know it's a small PR but I saw the old style XSD namespace location and updated it to the newer version (https://devdocs.magento.com/guides/v2.4/extension-dev-guide/build/XSD-XML-validation.html),
- I have also updated the module to pass the PHPCS ruleset in the repo,
- I did start fixing more until I saw the ruleset in the repo only checks for Errors not warnings 😓 but I have reverted my changes. While going through them I did notice some things like `@deprecated` classes and think it might be worth updating to specify why the are deprecated but I am not sure of the reason so I left that alone.

**Tested scenarios**
- The only testable change is seeing that in an IDE that supports auto-completion of XML files with an associated XSD file that the auto-completion works,
- PHPCS scanner now completes with a full pass. 😀 

