### PR TITLE
[PW 5561] - Create fallback for 'getStreetLine functions' returning NULL 

### DIFF
--- a/Helper/Address.php
+++ b/Helper/Address.php
@@ -24,10 +24,24 @@
 
 namespace Adyen\Payment\Helper;
 
+use Adyen\Payment\Logger\AdyenLogger;
 use Magento\Payment\Gateway\Data\AddressAdapterInterface;
+use Magento\Sales\Api\Data\OrderAddressInterface;
 
 class Address
 {
+    /**
+     * @var AdyenLogger $logger
+     */
+    protected $logger;
+
+    /**
+     * Address constructor.
+     */
+    public function __construct(AdyenLogger $logger)
+    {
+        $this->logger = $logger;
+    }
 
     // Regex to extract the house number from the street line if needed (e.g. 'Street address 1 A' => '1 A')
     const HOUSE_NUMBER_REGEX = '/((\s\d{0,10})|(\s\d{0,10}\s?\w{1,3}))$/i';
@@ -43,12 +57,23 @@ class Address
         $houseNumberStreetLine,
         $customerStreetLinesEnabled
     ): array {
-        $addressArray = [
-            $address->getStreetLine1(),
-            $address->getStreetLine2(),
-            $address->getStreetLine3(),
-            $address->getStreetLine4()
-        ];
+        if ($address instanceof AddressAdapterInterface) {
+            $addressArray = [
+                $address->getStreetLine1(),
+                $address->getStreetLine2(),
+                $address->getStreetLine3(),
+                $address->getStreetLine4()
+            ];
+        } elseif ($address instanceof OrderAddressInterface) {
+            $addressArray = $address->getStreet();
+        } else {
+            $this->logger->warning(sprintf(
+                'Unknown address type %s passed to the getStreetAndHouseNumberFromAddress function',
+                get_class($address)
+            ));
+
+            $addressArray = [];
+        }
 
         // Cap the full street to the enabled street lines
         $street = array_slice($addressArray, 0, $customerStreetLinesEnabled);

--- a/Helper/Requests.php
+++ b/Helper/Requests.php
@@ -203,15 +203,6 @@ class Requests extends AbstractHelper
 
             $customerStreetLinesEnabled = $this->adyenHelper->getCustomerStreetLinesEnabled($storeId);
 
-            // If config is not found (will occur on Adobe Commerce), attempt to get the value from the adyen config instead.
-            if (!$customerStreetLinesEnabled) {
-                $customerStreetLinesEnabled = $this->adyenHelper->getConfigData(
-                    'override_magento_number_of_lines',
-                    'adyen_abstract',
-                    $storeId
-                );
-            }
-
             $address = $this->addressHelper->getStreetAndHouseNumberFromAddress(
                 $billingAddress,
                 $houseNumberStreetLine,

--- a/etc/adminhtml/system/adyen_checkout_experience.xml
+++ b/etc/adminhtml/system/adyen_checkout_experience.xml
@@ -48,13 +48,6 @@
             <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
             <tooltip><![CDATA[3DS1, 3DS2 and redirect failed payments can restore the previous quote or clone it for a retry.]]></tooltip>
         </field>
-        <field id="override_magento_number_of_lines" translate="label" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
-            <label>Override Magento 'Number of lines in a street address' config</label>
-            <config_path>payment/adyen_abstract/override_magento_number_of_lines</config_path>
-            <validate>validate-digits validate-not-negative-number validate-digits-range digits-range-1-4</validate>
-            <comment>Valid range: 1-4</comment>
-            <tooltip><![CDATA[This field will override the Magento 'Number of lines in a street address' config. It should only be used on Adobe Commerce, where the aforementioned field does not exist]]></tooltip>
-        </field>
         <field id="house_number_street_line" translate="label" type="select" sortOrder="50" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
             <label>Address street line used for the house number input</label>
             <config_path>payment/adyen_abstract/house_number_street_line</config_path>


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
Both streetAddress and number were being sent as 'N/A' because the address object passed to the `getStreetAndHouseNumberFromAddress` function is not of type `Gateway/Data/Order/AddressAdapter.php`. We knew this could happen based on #1086. However we didn't take into consideration that since a different type than this is passed, the `getStreetLine1` functions may not be present in the passed object.