### PR TITLE
Restore config cache import for originKey webapi

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -33,6 +33,7 @@ use Magento\Directory\Model\Config\Source\Country;
 use Magento\Framework\App\CacheInterface;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\App\Helper\AbstractHelper;
+use Magento\Framework\App\Cache\Type\Config as ConfigCache;
 use Magento\Framework\App\Helper\Context;
 use Magento\Framework\App\ProductMetadataInterface;
 use Magento\Framework\Component\ComponentRegistrarInterface;


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
We restored [origin key endpoints](https://github.com/Adyen/adyen-magento2/pull/1185) in order to push that change with the next major release.
Restore the import of `Magento\Framework\App\Cache\Type\Config` which we removed in [#1178](https://github.com/Adyen/adyen-magento2/pull/1178/files#diff-d52e7365b52ebb360796c9734ab3a62d2bd9f6097e38c253892c3d22a36668b5L27)
