### PR TITLE
[PW-4187] Remove AfterPay as an option for auto capture

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -1040,7 +1040,7 @@ class Data extends AbstractHelper
      */
     public function isPaymentMethodRatepayMethod($paymentMethod)
     {
-        if (strpos($paymentMethod, 'ratepay') !== false) {
+        if (strpos($paymentMethod, self::RATEPAY) !== false) {
             return true;
         }
 
@@ -1053,7 +1053,7 @@ class Data extends AbstractHelper
      */
     public function isPaymentMethodAfterpayTouchMethod($paymentMethod)
     {
-        if (strpos($paymentMethod, 'afterpaytouch') !== false) {
+        if (strpos($paymentMethod, self::AFTERPAY_TOUCH) !== false) {
             return true;
         }
 
@@ -1079,7 +1079,7 @@ class Data extends AbstractHelper
      */
     public function isPaymentMethodOneyMethod($paymentMethod)
     {
-        if (strpos($paymentMethod, 'facilypay_') !== false) {
+        if (strpos($paymentMethod, self::FACILYPAY) !== false) {
             return true;
         }
 
@@ -1115,7 +1115,7 @@ class Data extends AbstractHelper
      */
     public function isVatCategoryHigh($paymentMethod)
     {
-        if ($paymentMethod == "klarna" ||
+        if ($paymentMethod == self::KLARNA ||
             strlen($paymentMethod) >= 9 && substr($paymentMethod, 0, 9) == 'afterpay_'
         ) {
             return true;

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -61,6 +61,17 @@ class Data extends AbstractHelper
     const CHECKOUT_COMPONENT_JS_TEST = 'https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/4.5.0/adyen.js';
     const PSP_REFERENCE_REGEX = '/(?P<pspReference>[0-9.A-Z]{16})(?P<suffix>[a-z\-]*)/';
 
+    const AFTERPAY = 'afterpay';
+    const AFTERPAY_TOUCH = 'afterpaytouch';
+    const KLARNA = 'klarna';
+    const RATEPAY = 'ratepay';
+    const FACILYPAY = 'facilypay_';
+    const AFFIRM = 'affirm';
+    const CLEARPAY = 'clearpay';
+    const ZIP = 'zip';
+    const PAYBRIGHT = 'paybright';
+
+
     /**
      * @var EncryptorInterface
      */
@@ -986,14 +997,14 @@ class Data extends AbstractHelper
      */
     public function isPaymentMethodOpenInvoiceMethod($paymentMethod)
     {
-        if (strpos($paymentMethod, 'afterpay') !== false ||
-            strpos($paymentMethod, 'klarna') !== false ||
-            strpos($paymentMethod, 'ratepay') !== false ||
-            strpos($paymentMethod, 'facilypay_') !== false ||
-            strpos($paymentMethod, 'affirm') !== false ||
-            strpos($paymentMethod, 'clearpay') !== false ||
-            strpos($paymentMethod, 'zip') !== false ||
-            strpos($paymentMethod, 'paybright') !== false
+        if (strpos($paymentMethod, self::AFTERPAY) !== false ||
+            strpos($paymentMethod, self::KLARNA) !== false ||
+            strpos($paymentMethod, self::RATEPAY) !== false ||
+            strpos($paymentMethod, self::FACILYPAY) !== false ||
+            strpos($paymentMethod, self::AFFIRM) !== false ||
+            strpos($paymentMethod, self::CLEARPAY) !== false ||
+            strpos($paymentMethod, self::ZIP) !== false ||
+            strpos($paymentMethod, self::PAYBRIGHT) !== false
         ) {
             return true;
         }
@@ -1009,14 +1020,14 @@ class Data extends AbstractHelper
      */
     public function isPaymentMethodOpenInvoiceMethodValidForAutoCapture($paymentMethod)
     {
-        if (strpos($paymentMethod, 'afterpaytouch') !== false ||
-            strpos($paymentMethod, 'klarna') !== false ||
-            strpos($paymentMethod, 'ratepay') !== false ||
-            strpos($paymentMethod, 'facilypay_') !== false ||
-            strpos($paymentMethod, 'affirm') !== false ||
-            strpos($paymentMethod, 'clearpay') !== false ||
-            strpos($paymentMethod, 'zip') !== false ||
-            strpos($paymentMethod, 'paybright') !== false
+        if (strpos($paymentMethod, self::AFTERPAY_TOUCH) !== false ||
+            strpos($paymentMethod, self::KLARNA) !== false ||
+            strpos($paymentMethod, self::RATEPAY) !== false ||
+            strpos($paymentMethod, self::FACILYPAY) !== false ||
+            strpos($paymentMethod, self::AFFIRM) !== false ||
+            strpos($paymentMethod, self::CLEARPAY) !== false ||
+            strpos($paymentMethod, self::ZIP) !== false ||
+            strpos($paymentMethod, self::PAYBRIGHT) !== false
         ) {
             return true;
         }

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -1002,6 +1002,28 @@ class Data extends AbstractHelper
     }
 
     /**
+     * Excludes AfterPay (NL/BE) from the open invoice list.
+     * AfterPay variants should be excluded (not afterpaytouch)as an option for auto capture.
+     * @param $paymentMethod
+     * @return bool
+     */
+    public function isPaymentMethodOpenInvoiceMethodValidForAutoCapture($paymentMethod)
+    {
+        if (strpos($paymentMethod, 'afterpaytouch') !== false ||
+            strpos($paymentMethod, 'klarna') !== false ||
+            strpos($paymentMethod, 'ratepay') !== false ||
+            strpos($paymentMethod, 'facilypay_') !== false ||
+            strpos($paymentMethod, 'affirm') !== false ||
+            strpos($paymentMethod, 'clearpay') !== false ||
+            strpos($paymentMethod, 'zip') !== false ||
+            strpos($paymentMethod, 'paybright') !== false
+        ) {
+            return true;
+        }
+
+        return false;
+    }
+    /**
      * @param $paymentMethod
      * @return bool
      */

--- a/Model/Cron.php
+++ b/Model/Cron.php
@@ -1753,7 +1753,7 @@ class Cron
 
             // if auto capture mode for openinvoice is turned on then use auto capture
             if ($captureModeOpenInvoice == true &&
-                $this->_adyenHelper->isPaymentMethodOpenInvoiceMethod($this->_paymentMethod)
+                $this->_adyenHelper->isPaymentMethodOpenInvoiceMethodValidForAutoCapture($this->_paymentMethod)
             ) {
                 $this->_adyenLogger->addAdyenNotificationCronjob(
                     'This payment method is configured to be working as auto capture '

--- a/etc/adminhtml/system/adyen_advanced_order_processing.xml
+++ b/etc/adminhtml/system/adyen_advanced_order_processing.xml
@@ -40,7 +40,7 @@
         </field>
         <field id="auto_capture_openinvoice" translate="label" type="select" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
             <label>Use auto-capture for OpenInvoice payments</label>
-            <tooltip>Applicable for Klarna and AfterPay only. By default OpenInvoice is set to manual capture. If you want auto capture you need to contact magento@adyen.com. After approval has been given, then you can set this option to 'Yes'.</tooltip>
+            <tooltip>Applicable for Klarna, Afterpay touch, Ratepay, Facilypay, Affirm, ClearPay, Zip and PayBright. By default OpenInvoice is set to manual capture. If you want auto capture you need to contact magento@adyen.com. After approval has been given, then you can set this option to 'Yes'.</tooltip>
             <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
             <config_path>payment/adyen_abstract/auto_capture_openinvoice</config_path>
         </field>

--- a/etc/adminhtml/system/adyen_advanced_order_processing.xml
+++ b/etc/adminhtml/system/adyen_advanced_order_processing.xml
@@ -40,7 +40,7 @@
         </field>
         <field id="auto_capture_openinvoice" translate="label" type="select" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
             <label>Use auto-capture for OpenInvoice payments</label>
-            <tooltip>Applicable for Klarna, Afterpay touch, Ratepay, Facilypay, Affirm, Clearpay, Zip and Paybright. By default OpenInvoice is set to manual capture. If you want auto capture you need to contact magento@adyen.com. After approval has been given, then you can set this option to 'Yes'.</tooltip>
+            <tooltip>Applicable for Klarna, Afterpay Touch, Ratepay, FacilyPay/Oney, Affirm, Clearpay, Zip and PayBright. By default, Open Invoice methods are set to manual capture. If you want auto capture you need to contact magento@adyen.com. After approval has been given you can set this option to 'Yes'.</tooltip>
             <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
             <config_path>payment/adyen_abstract/auto_capture_openinvoice</config_path>
         </field>

--- a/etc/adminhtml/system/adyen_advanced_order_processing.xml
+++ b/etc/adminhtml/system/adyen_advanced_order_processing.xml
@@ -40,7 +40,7 @@
         </field>
         <field id="auto_capture_openinvoice" translate="label" type="select" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
             <label>Use auto-capture for OpenInvoice payments</label>
-            <tooltip>Applicable for Klarna, Afterpay touch, Ratepay, Facilypay, Affirm, ClearPay, Zip and PayBright. By default OpenInvoice is set to manual capture. If you want auto capture you need to contact magento@adyen.com. After approval has been given, then you can set this option to 'Yes'.</tooltip>
+            <tooltip>Applicable for Klarna, Afterpay touch, Ratepay, Facilypay, Affirm, Clearpay, Zip and Paybright. By default OpenInvoice is set to manual capture. If you want auto capture you need to contact magento@adyen.com. After approval has been given, then you can set this option to 'Yes'.</tooltip>
             <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
             <config_path>payment/adyen_abstract/auto_capture_openinvoice</config_path>
         </field>


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
We currently allow the merchant to set AfterPay (NL/BE) to immediate capture, although we do not support the AUTH flow for AfterPay. For this reason the variant should be removed from options to configure the capture settings.
The related setting is "Use auto-capture for OpenInvoice payments", which is configurable to yes/no. It includes ALL Afterpay options, Klarna and RatePay.
We need to remove AfterPay (NL/BE), but keep Afterpay Touch, which does allow for both flows.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

**Fixed issue**:  <!-- #-prefixed issue number -->