### PR TITLE
[PW-5400] Move the order status config fields from required settings to magento order processing

### DIFF
--- a/etc/adminhtml/system/adyen_advanced_order_processing.xml
+++ b/etc/adminhtml/system/adyen_advanced_order_processing.xml
@@ -44,29 +44,59 @@
             <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
             <config_path>payment/adyen_abstract/auto_capture_openinvoice</config_path>
         </field>
-        <field id="payment_authorized_virtual" translate="label" type="select" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
-            <label>Order status: payment capture (virtual products)</label>
-            <tooltip>(optional) Select only status assigned to state complete. Leave empty to use the same as normal products</tooltip>
-            <source_model>Adyen\Payment\Model\Config\Source\Complete</source_model>
-            <config_path>payment/adyen_abstract/payment_authorized_virtual</config_path>
-        </field>
-        <field id="pending_status" translate="label" type="select" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1">
-            <label>Order status: pending Bank Transfer/SEPA orders</label>
-            <tooltip>By default, Adyen does not inform your Magento store about pending payments. If you want these notifications to be received, Go to Adyen Customer Area => Server Communication and add BankTransfer Pending Notification and Direct-Debit Pending Notification.</tooltip>
-            <source_model>Magento\Sales\Model\Config\Source\Order\Status\NewStatus</source_model>
-            <config_path>payment/adyen_abstract/pending_status</config_path>
-        </field>
-        <field id="send_email_bank_sepa_on_pending" translate="label" type="select" sortOrder="50" showInDefault="1" showInWebsite="1" showInStore="1">
+        <field id="send_email_bank_sepa_on_pending" translate="label" type="select" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
             <label>Send order confirmation email for Bank Transfer/SEPA</label>
             <tooltip>Send a confirmation mail after Bank Tranfer/SEPA is placed (not yet paid). If you want these notifications to be received, Go to Adyen Customer Area => Server Communication and add BankTransfer Pending Notification and Direct-Debit Pending Notification.</tooltip>
             <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
             <config_path>payment/adyen_abstract/send_email_bank_sepa_on_pending</config_path>
         </field>
-        <field id="sepa_flow" translate="label" type="select" sortOrder="60" showInDefault="1" showInWebsite="1" showInStore="1">
+        <field id="sepa_flow" translate="label" type="select" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1">
             <label>Sepa Payment flow</label>
             <tooltip>If you are not sure just leave it at 'Sale’. Sale means it is always immediate capture with auth/cap it will follow the Capture Delay. If you want to enable 'Auth/Capt' for SEPA Direct Debit, please contact support@adyen.com</tooltip>
             <source_model>Adyen\Payment\Model\Config\Source\SepaFlow</source_model>
             <config_path>payment/adyen_abstract/sepa_flow</config_path>
+        </field>
+        <field id="capture_mode" translate="label" type="select" sortOrder="50" showInDefault="1" showInWebsite="1" showInStore="1">
+            <label>Capture Delay</label>
+            <tooltip>Immediate is the default. Set to manual if you want to perform the capture of funds manually later (only affects credit cards and a few alternative payment methods). You need to change this setting as well in Adyen Customer Area => Settings => Merchant Settings => Capture Delay. If you have selected a capture delay of a couple of days in Adyen keep it here on immediate</tooltip>
+            <source_model>Adyen\Payment\Model\Config\Source\CaptureMode</source_model>
+            <config_path>payment/adyen_abstract/capture_mode</config_path>
+        </field>
+        <field id="order_status" translate="label" type="select" sortOrder="60" showInDefault="1" showInWebsite="1" showInStore="0">
+            <label>Order status: order creation</label>
+            <tooltip>Status given to newly created orders before payment result confirmation via server notifications from Adyen.</tooltip>
+            <source_model>Magento\Sales\Model\Config\Source\Order\Status\NewStatus</source_model>
+            <config_path>payment/adyen_abstract/order_status</config_path>
+        </field>
+        <field id="payment_pre_authorized" translate="label" type="select" sortOrder="61" showInDefault="1" showInWebsite="1" showInStore="0">
+            <label>Order status: payment authorisation</label>
+            <tooltip>Status given to orders after authorisation confirmed by an AUTHORISATION notification from Adyen. Note: an authorisation status via the result URL does not yet trigger this status.</tooltip>
+            <source_model>Magento\Sales\Model\Config\Source\Order\Status\Newprocessing</source_model>
+            <config_path>payment/adyen_abstract/payment_pre_authorized</config_path>
+        </field>
+        <field id="payment_authorized" translate="label" type="select" sortOrder="62" showInDefault="1" showInWebsite="1" showInStore="0">
+            <label>Order status: payment confirmed</label>
+            <tooltip>Status given to orders after capture result is confirmed by an AUTHORISATION notification (if capture mode = immediate) or a CAPTURE notification (if capture mode = manual capture) from Adyen.</tooltip>
+            <source_model>Magento\Sales\Model\Config\Source\Order\Status\Processing</source_model>
+            <config_path>payment/adyen_abstract/payment_authorized</config_path>
+        </field>
+        <field id="payment_cancelled" translate="label" type="select" sortOrder="63" showInDefault="1" showInWebsite="1" showInStore="0">
+            <label>Order status: order cancellation</label>
+            <tooltip>Status given to orders after order cancellation is confirmed by a CANCEL_OR_REFUND notification from Adyen. If orders are already invoiced, they cannot be cancelled, but will be refunded instead.</tooltip>
+            <source_model>Adyen\Payment\Model\Config\Source\Cancelled</source_model>
+            <config_path>payment/adyen_abstract/payment_cancelled</config_path>
+        </field>
+        <field id="payment_authorized_virtual" translate="label" type="select" sortOrder="64" showInDefault="1" showInWebsite="1" showInStore="1">
+            <label>Order status: payment capture (virtual products)</label>
+            <tooltip>(optional) Select only status assigned to state complete. Leave empty to use the same as normal products</tooltip>
+            <source_model>Adyen\Payment\Model\Config\Source\Complete</source_model>
+            <config_path>payment/adyen_abstract/payment_authorized_virtual</config_path>
+        </field>
+        <field id="pending_status" translate="label" type="select" sortOrder="65" showInDefault="1" showInWebsite="1" showInStore="1">
+            <label>Order status: pending Bank Transfer/SEPA orders</label>
+            <tooltip>By default, Adyen does not inform your Magento store about pending payments. If you want these notifications to be received, Go to Adyen Customer Area => Server Communication and add BankTransfer Pending Notification and Direct-Debit Pending Notification.</tooltip>
+            <source_model>Magento\Sales\Model\Config\Source\Order\Status\NewStatus</source_model>
+            <config_path>payment/adyen_abstract/pending_status</config_path>
         </field>
     </group>
 </include>

--- a/etc/adminhtml/system/adyen_required_settings.xml
+++ b/etc/adminhtml/system/adyen_required_settings.xml
@@ -85,37 +85,7 @@
             <source_model>Adyen\Payment\Model\Config\Source\ChargedCurrency</source_model>
             <config_path>payment/adyen_abstract/charged_currency</config_path>
         </field>
-        <field id="capture_mode" translate="label" type="select" sortOrder="110" showInDefault="1" showInWebsite="1" showInStore="1">
-            <label>Capture Delay</label>
-            <tooltip>Immediate is the default. Set to manual if you want to perform the capture of funds manually later (only affects credit cards and a few alternative payment methods). You need to change this setting as well in Adyen Customer Area => Settings => Merchant Settings => Capture Delay. If you have selected a capture delay of a couple of days in Adyen keep it here on immediate</tooltip>
-            <source_model>Adyen\Payment\Model\Config\Source\CaptureMode</source_model>
-            <config_path>payment/adyen_abstract/capture_mode</config_path>
-        </field>
-        <field id="order_status" translate="label" type="select" sortOrder="120" showInDefault="1" showInWebsite="1" showInStore="0">
-            <label>Order status: order creation</label>
-            <tooltip>Status given to newly created orders before payment result confirmation via server notifications from Adyen.</tooltip>
-            <source_model>Magento\Sales\Model\Config\Source\Order\Status\NewStatus</source_model>
-            <config_path>payment/adyen_abstract/order_status</config_path>
-        </field>
-        <field id="payment_pre_authorized" translate="label" type="select" sortOrder="130" showInDefault="1" showInWebsite="1" showInStore="0">
-            <label>Order status: payment authorisation</label>
-            <tooltip>Status given to orders after authorisation confirmed by an AUTHORISATION notification from Adyen. Note: an authorisation status via the result URL does not yet trigger this status.</tooltip>
-            <source_model>Magento\Sales\Model\Config\Source\Order\Status\Newprocessing</source_model>
-            <config_path>payment/adyen_abstract/payment_pre_authorized</config_path>
-        </field>
-        <field id="payment_authorized" translate="label" type="select" sortOrder="140" showInDefault="1" showInWebsite="1" showInStore="0">
-            <label>Order status: payment confirmed</label>
-            <tooltip>Status given to orders after capture result is confirmed by an AUTHORISATION notification (if capture mode = immediate) or a CAPTURE notification (if capture mode = manual capture) from Adyen.</tooltip>
-            <source_model>Magento\Sales\Model\Config\Source\Order\Status\Processing</source_model>
-            <config_path>payment/adyen_abstract/payment_authorized</config_path>
-        </field>
-        <field id="payment_cancelled" translate="label" type="select" sortOrder="150" showInDefault="1" showInWebsite="1" showInStore="0">
-            <label>Order status: order cancellation</label>
-            <tooltip>Status given to orders after order cancellation is confirmed by a CANCEL_OR_REFUND notification from Adyen. If orders are already invoiced, they cannot be cancelled, but will be refunded instead.</tooltip>
-            <source_model>Adyen\Payment\Model\Config\Source\Cancelled</source_model>
-            <config_path>payment/adyen_abstract/payment_cancelled</config_path>
-        </field>
-        <field id="debug" translate="label" type="select" sortOrder="160" showInDefault="1" showInWebsite="1" showInStore="0">
+        <field id="debug" translate="label" type="select" sortOrder="110" showInDefault="1" showInWebsite="1" showInStore="0">
             <label>Enable debug logging</label>
             <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
             <config_path>payment/adyen_abstract/debug</config_path>


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->

This change move and reorders existing settings.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
* Save settings before change
* Moving settings to another file did not affect previously saved values 