### PR TITLE
[PW-5668] Patch for OFFER_CLOSED flow with cc

### DIFF
--- a/Model/Cron.php
+++ b/Model/Cron.php
@@ -1212,12 +1212,18 @@ class Cron
                  * Returns if the payment method is wallet like wechatpayWeb, amazonpay, applepay, paywithgoogle
                  */
                 $isWalletPaymentMethod = $this->paymentMethodsHelper->isWalletPaymentMethod($orderPaymentMethod);
+
+                /*
+                 * Return if payment method is cc like VI, MI
+                 */
+                $isCCPaymentMethod = $this->_order->getPayment()->getMethod() === 'adyen_cc';
+
                 /*
                 * If the order was made with an Alternative payment method,
                 *  continue with the cancellation only if the payment method of
                 * the notification matches the payment method of the order.
                 */
-                if ( !$isWalletPaymentMethod && strcmp($notificationPaymentMethod, $orderPaymentMethod) !== 0) {
+                if ( !$isWalletPaymentMethod && !$isCCPaymentMethod && strcmp($notificationPaymentMethod, $orderPaymentMethod) !== 0) {
                     $this->_adyenLogger->addAdyenNotificationCronjob(
                         "The notification does not match the payment method of the order,
                     skipping OFFER_CLOSED"


### PR DESCRIPTION
**Description**
When checking whether an OFFER_CLOSED notification should trigger a state change, alternative payment method names from the notification are compared with the original payment method name from the order, these should match. This also happened when the payment method was a type of cc, as these strings do not match with the notification strings (e.g. 'VI' vs 'visa') the OFFER_CLOSED notification did not trigger a state change. This PR fixes this.

To think about: should these cc strings be compared anyway or should this step be skipped as a whole (like it is now)?

**Tested scenarios**
- Sending an OFFER_CLOSED notification before the authorisation.
- OFFER_CLOSED for adyen_hpp closes the order.
- OFFER_CLOSED for adyen_cc closes the order.
- OFFER_CLOSED for wallet methods closes the order.

**Fixed issue**: 
Closes #1193