### PR TITLE
[PW-5424] adyen giving web component

### DIFF
--- a/Api/Internal/InternalAdyenDonationsInterface.php
+++ b/Api/Internal/InternalAdyenDonationsInterface.php
@@ -29,7 +29,7 @@ interface InternalAdyenDonationsInterface
     /**
      * Build and send internal donation payment request
      * @param string $payload
-     * @param $formKey
+     * @param string $formKey
      * @return mixed
      */
     public function handleInternalRequest($payload, $formKey);

--- a/Block/Checkout/Multishipping/Success.php
+++ b/Block/Checkout/Multishipping/Success.php
@@ -28,7 +28,7 @@ use Adyen\Payment\Helper\Data;
 use Adyen\Payment\Helper\PaymentResponseHandler;
 use Adyen\Payment\Model\PaymentResponse;
 use Adyen\Payment\Model\ResourceModel\PaymentResponse\Collection;
-use Adyen\Payment\Model\Ui\AdyenMultishippingConfigProvider;
+use Adyen\Payment\Model\Ui\AdyenCheckoutSuccessConfigProvider;
 use Magento\Framework\Api\SearchCriteriaBuilder;
 use Magento\Framework\Serialize\SerializerInterface;
 use Magento\Framework\View\Element\Template\Context;
@@ -66,7 +66,7 @@ class Success extends \Magento\Multishipping\Block\Checkout\Success
     private $serializerInterface;
 
     /**
-     * @var AdyenMultishippingConfigProvider
+     * @var AdyenCheckoutSuccessConfigProvider
      */
     private $configProvider;
 
@@ -90,7 +90,7 @@ class Success extends \Magento\Multishipping\Block\Checkout\Success
         Data $adyenHelper,
         StoreManagerInterface $storeManager,
         SerializerInterface $serializerInterface,
-        AdyenMultishippingConfigProvider $configProvider,
+        AdyenCheckoutSuccessConfigProvider $configProvider,
         Context $context,
         Multishipping $multishipping,
         OrderRepositoryInterface $orderRepository,

--- a/Block/Checkout/Success.php
+++ b/Block/Checkout/Success.php
@@ -26,7 +26,7 @@ namespace Adyen\Payment\Block\Checkout;
 use Adyen\Payment\Helper\Config;
 use Adyen\Payment\Helper\Data;
 use Adyen\Payment\Helper\PaymentResponseHandler;
-use Adyen\Payment\Model\Ui\AdyenMultishippingConfigProvider;
+use Adyen\Payment\Model\Ui\AdyenCheckoutSuccessConfigProvider;
 use Magento\Checkout\Model\Session;
 use Magento\Framework\Serialize\SerializerInterface;
 use Magento\Framework\View\Element\Template;
@@ -75,7 +75,7 @@ class Success extends Template
     private $serializerInterface;
 
     /**
-     * @var AdyenMultishippingConfigProvider
+     * @var AdyenCheckoutSuccessConfigProvider
      */
     private $configProvider;
 
@@ -96,7 +96,7 @@ class Success extends Template
         OrderFactory $orderFactory,
         Data $adyenHelper,
         Config $configHelper,
-        AdyenMultishippingConfigProvider $configProvider,
+        AdyenCheckoutSuccessConfigProvider $configProvider,
         StoreManagerInterface $storeManager,
         SerializerInterface $serializerInterface,
         array $data = []

--- a/Block/Checkout/Success.php
+++ b/Block/Checkout/Success.php
@@ -26,7 +26,9 @@ namespace Adyen\Payment\Block\Checkout;
 use Adyen\Payment\Helper\Config;
 use Adyen\Payment\Helper\Data;
 use Adyen\Payment\Helper\PaymentResponseHandler;
+use Adyen\Payment\Model\Ui\AdyenMultishippingConfigProvider;
 use Magento\Checkout\Model\Session;
+use Magento\Framework\Serialize\SerializerInterface;
 use Magento\Framework\View\Element\Template;
 use Magento\Framework\View\Element\Template\Context;
 use Magento\Sales\Model\Order;
@@ -68,6 +70,16 @@ class Success extends Template
     private $configHelper;
 
     /**
+     * @var SerializerInterface
+     */
+    private $serializerInterface;
+
+    /**
+     * @var AdyenMultishippingConfigProvider
+     */
+    private $configProvider;
+
+    /**
      * Success constructor.
      *
      * @param Context $context
@@ -84,14 +96,18 @@ class Success extends Template
         OrderFactory $orderFactory,
         Data $adyenHelper,
         Config $configHelper,
+        AdyenMultishippingConfigProvider $configProvider,
         StoreManagerInterface $storeManager,
+        SerializerInterface $serializerInterface,
         array $data = []
     ) {
         $this->checkoutSession = $checkoutSession;
         $this->orderFactory = $orderFactory;
         $this->adyenHelper = $adyenHelper;
-        $this->storeManager = $storeManager;
         $this->configHelper = $configHelper;
+        $this->configProvider = $configProvider;
+        $this->storeManager = $storeManager;
+        $this->serializerInterface = $serializerInterface;
         parent::__construct($context, $data);
     }
 
@@ -158,6 +174,11 @@ class Success extends Template
             'website' => $this->configHelper->getAdyenGivingCharityWebsite($storeId),
             'donationAmounts' => $this->configHelper->getAdyenGivingDonationAmounts($storeId)
         ];
+    }
+
+    public function getSerializedCheckoutConfig()
+    {
+        return $this->serializerInterface->serialize($this->configProvider->getConfig());
     }
 
     public function getLocale()

--- a/Block/Checkout/Success.php
+++ b/Block/Checkout/Success.php
@@ -165,6 +165,10 @@ class Success extends Template
     {
         $storeId = $this->storeManager->getStore()->getId();
         $imageBaseUrl = $this->storeManager->getStore()->getBaseUrl(\Magento\Framework\UrlInterface::URL_TYPE_MEDIA).'adyen/';
+        $donationAmounts = explode(',', $this->configHelper->getAdyenGivingDonationAmounts($storeId));
+        $donationAmounts = array_map(function ($amount) {
+            return $this->adyenHelper->formatAmount($amount, 'EUR');
+        }, $donationAmounts);
 
         return [
             'name' => $this->configHelper->getAdyenGivingCharityName($storeId),
@@ -172,7 +176,7 @@ class Success extends Template
             'backgroundUrl' => $imageBaseUrl . $this->configHelper->getAdyenGivingBackgroundImage($storeId),
             'logoUrl' => $imageBaseUrl . $this->configHelper->getAdyenGivingCharityLogo($storeId),
             'website' => $this->configHelper->getAdyenGivingCharityWebsite($storeId),
-            'donationAmounts' => $this->configHelper->getAdyenGivingDonationAmounts($storeId)
+            'donationAmounts' => implode(',', $donationAmounts)
         ];
     }
 

--- a/Block/Checkout/Success.php
+++ b/Block/Checkout/Success.php
@@ -167,7 +167,7 @@ class Success extends Template
         $imageBaseUrl = $this->storeManager->getStore()->getBaseUrl(\Magento\Framework\UrlInterface::URL_TYPE_MEDIA).'adyen/';
         $donationAmounts = explode(',', $this->configHelper->getAdyenGivingDonationAmounts($storeId));
         $donationAmounts = array_map(function ($amount) {
-            return $this->adyenHelper->formatAmount($amount, 'EUR');
+            return $this->adyenHelper->formatAmount($amount, $this->getOrder()->getOrderCurrencyCode());
         }, $donationAmounts);
 
         return [

--- a/Controller/Process/Result.php
+++ b/Controller/Process/Result.php
@@ -247,6 +247,11 @@ class Result extends \Magento\Framework\App\Action\Action
             ]
         );
 
+        // Save PSP reference from the response
+        if (!empty($response['pspReference'])) {
+            $this->payment->setAdditionalInformation('pspReference', $response['pspReference']);
+        }
+
         // Save payment token if available in the response
         if (!empty($response['additionalData']['recurring.recurringDetailReference']) &&
             $this->payment->getMethodInstance()->getCode() !== \Adyen\Payment\Model\Ui\AdyenOneclickConfigProvider::CODE) {
@@ -257,6 +262,11 @@ class Result extends \Magento\Framework\App\Action\Action
                 $this->_adyenHelper->createAdyenBillingAgreement($order, $response['additionalData']);
             }
             $this->orderResourceModel->save($order);
+        }
+
+        // Save donation token if available in the response
+        if (!empty($response['donationToken'])) {
+            $this->payment->setAdditionalInformation('donationToken', $response['donationToken']);
         }
 
         // update the order

--- a/Gateway/Http/Client/TransactionDonate.php
+++ b/Gateway/Http/Client/TransactionDonate.php
@@ -58,7 +58,7 @@ class TransactionDonate implements ClientInterface
         try {
             $response = $service->donations($request);
         } catch (AdyenException $e) {
-            $response['error'] = $e->getMessage();
+            $response = ['error' => $e->getMessage()];
         }
 
         return $response;

--- a/Gateway/Request/DonationDataBuilder.php
+++ b/Gateway/Request/DonationDataBuilder.php
@@ -54,9 +54,11 @@ class DonationDataBuilder implements BuilderInterface
      */
     public function build(array $buildSubject)
     {
-        $request['body'] = $this->adyenRequestsHelper
-            ->buildDonationData($buildSubject['payment'], $this->storeManager->getStore()->getId());
-
-        return $request;
+        return [
+            'body' => $this->adyenRequestsHelper->buildDonationData(
+                    $buildSubject['payment'],
+                    $this->storeManager->getStore()->getId()
+                )
+        ];
     }
 }

--- a/Gateway/Validator/CheckoutResponseValidator.php
+++ b/Gateway/Validator/CheckoutResponseValidator.php
@@ -93,6 +93,10 @@ class CheckoutResponseValidator extends AbstractValidator
                 $payment->setAdditionalInformation('details', $response['details']);
             }
 
+            if (!empty($response['donationToken'])) {
+                $payment->setAdditionalInformation('donationToken', $response['donationToken']);
+            }
+
             switch ($resultCode) {
                 case "Authorised":
                 case "Received":

--- a/Gateway/Validator/DonateResponseValidator.php
+++ b/Gateway/Validator/DonateResponseValidator.php
@@ -52,16 +52,14 @@ class DonateResponseValidator extends AbstractValidator
     {
         $response = SubjectReader::readResponse($validationSubject);
 
-        if (empty($response['resultCode'])) {
-            $errorMsg = __('An error occurred with the donation.');
-
+        if (empty($response['payment']['resultCode'])) {
             if (!empty($response['error'])) {
                 $this->adyenLogger->error($response['error']);
             }
 
-            throw new LocalizedException(__($errorMsg));
+            throw new LocalizedException(__('An error occurred with the donation.'));
         }
 
-        return $this->createResult(true);
+        return $this->createResult($response['payment']['resultCode'] === 'Authorised');
     }
 }

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -214,7 +214,7 @@ class Config
 
     public function adyenGivingEnabled($storeId)
     {
-        return $this->getConfigData('active', 'adyen_giving', $storeId);
+        return $this->getConfigData('active', self::XML_ADYEN_GIVING_PREFIX, $storeId);
     }
 
     public function getAdyenGivingConfigData($storeId)

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -211,6 +211,53 @@ class Config
         return $this->getConfigData(self::XML_PAYMENT_ORIGIN_URL, self::XML_ADYEN_ABSTRACT_PREFIX, $storeId);
     }
 
+    public function adyenGivingEnabled($storeId)
+    {
+        return $this->getConfigData('active', 'adyen_giving', $storeId);
+    }
+
+    public function getAdyenGivingConfigData($storeId)
+    {
+        return [
+            'name' => $this->getAdyenGivingCharityName($storeId),
+            'description' => $this->getAdyenGivingCharityDescription($storeId),
+            'backgroundUrl' => $this->getAdyenGivingBackgroundImage($storeId),
+            'logoUrl' => $this->getAdyenGivingCharityLogo($storeId),
+            'website' => $this->getAdyenGivingCharityWebsite($storeId),
+            'donationAmounts' => $this->getAdyenGivingDonationAmounts($storeId)
+        ];
+    }
+
+    public function getAdyenGivingCharityName($storeId)
+    {
+        return $this->getConfigData('charity_name', 'adyen_giving', $storeId);
+    }
+
+    public function getAdyenGivingCharityDescription($storeId)
+    {
+        return $this->getConfigData('charity_description', 'adyen_giving', $storeId);
+    }
+
+    public function getAdyenGivingBackgroundImage($storeId)
+    {
+        return $this->getConfigData('background_image', 'adyen_giving', $storeId);
+    }
+
+    public function getAdyenGivingCharityLogo($storeId)
+    {
+        return $this->getConfigData('charity_logo', 'adyen_giving', $storeId);
+    }
+
+    public function getAdyenGivingCharityWebsite($storeId)
+    {
+        return $this->getConfigData('charity_website', 'adyen_giving', $storeId);
+    }
+
+    public function getAdyenGivingDonationAmounts($storeId)
+    {
+        return $this->getConfigData('donation_amounts', 'adyen_giving', $storeId);
+    }
+
     /**
      * Retrieve information from payment configuration
      *

--- a/Helper/PaymentResponseHandler.php
+++ b/Helper/PaymentResponseHandler.php
@@ -204,7 +204,7 @@ class PaymentResponseHandler
                 if (!empty($paymentsResponse['donationToken'])) {
                     $payment->setAdditionalInformation('donationToken', $paymentsResponse['donationToken']);
                 }
-                
+
                 $this->orderResourceModel->save($order);
                 break;
             case self::REFUSED:

--- a/Helper/PaymentResponseHandler.php
+++ b/Helper/PaymentResponseHandler.php
@@ -200,6 +200,11 @@ class PaymentResponseHandler
                         $this->adyenHelper->createAdyenBillingAgreement($order, $paymentsResponse['additionalData']);
                     }
                 }
+
+                if (!empty($paymentsResponse['donationToken'])) {
+                    $payment->setAdditionalInformation('donationToken', $paymentsResponse['donationToken']);
+                }
+                
                 $this->orderResourceModel->save($order);
                 break;
             case self::REFUSED:

--- a/Helper/Requests.php
+++ b/Helper/Requests.php
@@ -381,6 +381,7 @@ class Requests extends AbstractHelper
         return [
             "amount"=> $buildSubject['amount'],
             "reference"=> Uuid::generateV4(),
+            'shopperReference' => $buildSubject['shopperReference'],
             "paymentMethod"=> $buildSubject['paymentMethod'],
             "donationToken"=> $buildSubject['donationToken'],
             "donationOriginalPspReference"=> $buildSubject['donationOriginalPspReference'],

--- a/Model/Api/AdyenDonations.php
+++ b/Model/Api/AdyenDonations.php
@@ -47,11 +47,6 @@ class AdyenDonations implements AdyenDonationsInterface
     private $checkoutSession;
 
     /**
-     * @var Order
-     */
-    private $order;
-
-    /**
      * @var OrderFactory
      */
     private $orderFactory;
@@ -67,7 +62,7 @@ class AdyenDonations implements AdyenDonationsInterface
      * @inheritDoc
      *
      * @throws CommandException
-     * @throws NotFoundException
+     * @throws NotFoundException|LocalizedException
      */
     public function donate($payload)
     {

--- a/Model/Api/AdyenDonations.php
+++ b/Model/Api/AdyenDonations.php
@@ -97,7 +97,7 @@ class AdyenDonations implements AdyenDonationsInterface
             $payload['paymentMethod'] = ['type' => 'scheme'];
         }
 
-        $payload['pspReference'] = $order->getPayment()->getAdditionalInformation('pspReference');
+        $payload['donationOriginalPspReference'] = $order->getPayment()->getAdditionalInformation('pspReference');
 
         $customerId = $order->getCustomerId();
         if ($customerId) {

--- a/Model/Api/Internal/InternalAdyenDonations.php
+++ b/Model/Api/Internal/InternalAdyenDonations.php
@@ -22,11 +22,11 @@
  * Author: Adyen <magento@adyen.com>
  */
 
-namespace Adyen\Payment\Model\Api;
+namespace Adyen\Payment\Model\Api\Internal;
 
 use Adyen\AdyenException;
 use Adyen\Payment\Api\Internal\InternalAdyenDonationsInterface;
-use Adyen\Payment\Model\Api\Internal\AbstractInternalApiController;
+use Adyen\Payment\Model\Api\AdyenDonations;
 use Magento\Framework\App\Request\Http;
 use Magento\Framework\Data\Form\FormKey\Validator;
 use Magento\Framework\Exception\NotFoundException;

--- a/Model/Ui/AdyenCheckoutSuccessConfigProvider.php
+++ b/Model/Ui/AdyenCheckoutSuccessConfigProvider.php
@@ -26,7 +26,7 @@ namespace Adyen\Payment\Model\Ui;
 use \Magento\Checkout\Model\ConfigProviderInterface;
 use Magento\Store\Model\StoreManagerInterface;
 
-class AdyenMultishippingConfigProvider implements ConfigProviderInterface
+class AdyenCheckoutSuccessConfigProvider implements ConfigProviderInterface
 {
     /**
      * @var StoreManagerInterface

--- a/etc/adminhtml/system/adyen_giving.xml
+++ b/etc/adminhtml/system/adyen_giving.xml
@@ -57,7 +57,7 @@
         <field id="charity_logo" translate="label" type="image" sortOrder="90" showInDefault="1" showInWebsite="1" >
             <label>Charity logo</label>
             <config_path>payment/adyen_giving/charity_logo</config_path>
-            <backend_model>Magento\Config\Model\Config\Backend\Image</backend_model>
+            <backend_model>Magento\Config\Model\Config\Backend\Image\Logo</backend_model>
             <upload_dir config="system" scope_info="1">adyen</upload_dir>
             <base_url type="media" scope_info="1">sales/store/logo</base_url>
             <comment><![CDATA[Logo displayed on the Adyen Giving form.]]></comment>
@@ -66,7 +66,7 @@
             <label>Suggested donation amounts</label>
             <backend_model>Adyen\Payment\Model\Config\Backend\DonationAmounts</backend_model>
             <config_path>payment/adyen_giving/donation_amounts</config_path>
-            <tooltip><![CDATA[Suggested amounts that the shopper can choose to donate. The minimum amount is 1 EUR.]]></tooltip>
+            <tooltip><![CDATA[Suggested amounts that the shopper can choose to donate. Amount should be specified in minor units, e.g 100 = 1 EUR. The minimum amount is 1 EUR.]]></tooltip>
         </field>
         <field id="background_image" translate="label" type="image" sortOrder="80" showInDefault="1" showInWebsite="1" >
             <label>Background image</label>

--- a/etc/adminhtml/system/adyen_giving.xml
+++ b/etc/adminhtml/system/adyen_giving.xml
@@ -66,7 +66,7 @@
             <label>Suggested donation amounts</label>
             <backend_model>Adyen\Payment\Model\Config\Backend\DonationAmounts</backend_model>
             <config_path>payment/adyen_giving/donation_amounts</config_path>
-            <tooltip><![CDATA[Suggested amounts that the shopper can choose to donate. Amount should be specified in minor units, e.g 100 = 1 EUR. The minimum amount is 1 EUR.]]></tooltip>
+            <tooltip><![CDATA[Suggested amounts that the shopper can choose to donate. The minimum amount is 1 EUR.]]></tooltip>
         </field>
         <field id="background_image" translate="label" type="image" sortOrder="80" showInDefault="1" showInWebsite="1" >
             <label>Background image</label>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -979,6 +979,8 @@
                 type="Adyen\Payment\Model\Api\Internal\InternalAdyenOrderPaymentStatus"/>
     <preference for="Adyen\Payment\Api\AdyenStateDataInterface"
                 type="Adyen\Payment\Model\Api\AdyenStateData"/>
+    <preference for="Adyen\Payment\Api\Internal\InternalAdyenDonationsInterface"
+                type="Adyen\Payment\Model\Api\Internal\InternalAdyenDonations"/>
     <preference for="Adyen\Payment\Api\AdyenDonationsInterface"
                 type="Adyen\Payment\Model\Api\AdyenDonations"/>
     <type name="Magento\Vault\Api\PaymentTokenRepositoryInterface">

--- a/view/frontend/templates/checkout/success.phtml
+++ b/view/frontend/templates/checkout/success.phtml
@@ -46,24 +46,37 @@
     </script>
     <div id="ActionContainer"></div>
 <?php endif; ?>
-<?php if ($block->showAdyenGiving()): ?>
+<?php if ($block->showAdyenGiving()):
+    $checkoutConfig = /* @noEscape */
+    $block->getSerializedCheckoutConfig();
+    $scriptString = <<<script
+    window.checkoutConfig = {$checkoutConfig};
+script;
+?>
 <script>
+    <?=$scriptString?>
     require([
         'jquery',
-        'Adyen_Payment/js/bundle'
-    ], function ($, adyenComponent) {
+        'Adyen_Payment/js/bundle',
+        'Adyen_Payment/js/model/adyen-payment-service'
+    ], function ($, adyenComponent, adyenPaymentService) {
+        debugger;
         function handleOnDonate(state, component) {
             debugger;
             state.isValid // True or false. Specifies whether the shopper has selected a donation amount.
             if (state.isValid) {
-                const payload = state.data;
+                adyenPaymentService.donate(state.data).done(function (response) {
+                    debugger;
+                });
+            } else {
+
             }
-            state.data // Provides the data that you need to pass in the `/donate` call.
-            component // Provides the active component instance that called this event.
+            // state.data // Provides the data that you need to pass in the `/donate` call.
+            // component // Provides the active component instance that called this event.
         }
 
         function handleOnCancel(state, component) {
-            debugger
+            debugger;
             // Show a message, unmount the component, or redirect to another page.
         }
         const donationConfig = {
@@ -95,3 +108,4 @@
 </script>
 <div id='donation-container'></div>
 <?php endif; ?>
+

--- a/view/frontend/templates/checkout/success.phtml
+++ b/view/frontend/templates/checkout/success.phtml
@@ -76,8 +76,8 @@ script;
                 component.setStatus('ready');
             }
         }
-
         function handleOnCancel(state, component) {
+            // Redirect to default 'Continue Shopping' action
             let continueActionUrl = $('.primary.action.continue')[0].href;
             window.location = continueActionUrl;
         }

--- a/view/frontend/templates/checkout/success.phtml
+++ b/view/frontend/templates/checkout/success.phtml
@@ -60,24 +60,26 @@ script;
         'Adyen_Payment/js/bundle',
         'Adyen_Payment/js/model/adyen-payment-service'
     ], function ($, adyenComponent, adyenPaymentService) {
-        debugger;
         function handleOnDonate(state, component) {
-            debugger;
             state.isValid // True or false. Specifies whether the shopper has selected a donation amount.
             if (state.isValid) {
-                adyenPaymentService.donate(state.data).done(function (response) {
-                    debugger;
-                });
+                let payload = state.data;
+                payload.returnUrl = window.location.href;
+                adyenPaymentService.donate(payload)
+                    .done(function (response) {
+                        component.setStatus("success");
+                    })
+                    .fail(function (response) {
+                        component.setStatus('error');
+                    });
             } else {
-
+                component.setStatus('ready');
             }
-            // state.data // Provides the data that you need to pass in the `/donate` call.
-            // component // Provides the active component instance that called this event.
         }
 
         function handleOnCancel(state, component) {
-            debugger;
-            // Show a message, unmount the component, or redirect to another page.
+            let continueActionUrl = $('.primary.action.continue')[0].href;
+            window.location = continueActionUrl;
         }
         const donationConfig = {
             amounts: {

--- a/view/frontend/templates/checkout/success.phtml
+++ b/view/frontend/templates/checkout/success.phtml
@@ -46,3 +46,52 @@
     </script>
     <div id="ActionContainer"></div>
 <?php endif; ?>
+<?php if ($block->showAdyenGiving()): ?>
+<script>
+    require([
+        'jquery',
+        'Adyen_Payment/js/bundle'
+    ], function ($, adyenComponent) {
+        function handleOnDonate(state, component) {
+            debugger;
+            state.isValid // True or false. Specifies whether the shopper has selected a donation amount.
+            if (state.isValid) {
+                const payload = state.data;
+            }
+            state.data // Provides the data that you need to pass in the `/donate` call.
+            component // Provides the active component instance that called this event.
+        }
+
+        function handleOnCancel(state, component) {
+            debugger
+            // Show a message, unmount the component, or redirect to another page.
+        }
+        const donationConfig = {
+            amounts: {
+                currency: "EUR",
+                values: [<?=$block->getDonationComponentConfiguration()['donationAmounts'];?>]
+            },
+            backgroundUrl: "<?=$block->getDonationComponentConfiguration()['backgroundUrl'];?>",
+            description: "<?=$block->getDonationComponentConfiguration()['description'];?>",
+            logoUrl: "<?=$block->getDonationComponentConfiguration()['logoUrl'];?>",
+            name: "<?=$block->getDonationComponentConfiguration()['name'];?>",
+            url: "<?=$block->getDonationComponentConfiguration()['website'];?>",
+            showCancelButton: true,
+            onDonate: handleOnDonate,
+            onCancel: handleOnCancel
+        };
+        var checkoutComponent = new AdyenCheckout({
+            locale: '<?= $block->escapeHtml($block->getLocale()); ?>',
+            environment: '<?= $block->escapeHtml($block->getEnvironment()); ?>',
+            clientKey: '<?= $block->escapeHtml($block->getClientKey()); ?>'
+        });
+        try {
+            const donation = checkoutComponent.create('donation', donationConfig).mount('#donation-container');
+        } catch(err) {
+            // Action component cannot be created
+            console.log(err);
+        }
+    });
+</script>
+<div id='donation-container'></div>
+<?php endif; ?>

--- a/view/frontend/templates/checkout/success.phtml
+++ b/view/frontend/templates/checkout/success.phtml
@@ -61,7 +61,6 @@ script;
         'Adyen_Payment/js/model/adyen-payment-service'
     ], function ($, adyenComponent, adyenPaymentService) {
         function handleOnDonate(state, component) {
-            state.isValid // True or false. Specifies whether the shopper has selected a donation amount.
             if (state.isValid) {
                 let payload = state.data;
                 payload.returnUrl = window.location.href;

--- a/view/frontend/templates/checkout/success.phtml
+++ b/view/frontend/templates/checkout/success.phtml
@@ -82,7 +82,7 @@ script;
         }
         const donationConfig = {
             amounts: {
-                currency: "EUR",
+                currency: "<?=$block->getOrder()->getOrderCurrencyCode()?>",
                 values: [<?=$block->getDonationComponentConfiguration()['donationAmounts'];?>]
             },
             backgroundUrl: "<?=$block->getDonationComponentConfiguration()['backgroundUrl'];?>",

--- a/view/frontend/web/js/model/adyen-payment-service.js
+++ b/view/frontend/web/js/model/adyen-payment-service.js
@@ -90,6 +90,22 @@ define(
                     JSON.stringify(payload),
                     true
                 );
+            },
+
+            donate: function (data) {
+                debugger;
+                let request = {
+                    payload: JSON.stringify(data),
+                    formKey: $.mage.cookies.get('form_key')
+                };
+
+                const serviceUrl = urlBuilder.createUrl('/internal/adyen/donations', {});
+ 
+                return storage.post(
+                    serviceUrl,
+                    JSON.stringify(request),
+                    true
+                );
             }
         };
     }

--- a/view/frontend/web/js/model/adyen-payment-service.js
+++ b/view/frontend/web/js/model/adyen-payment-service.js
@@ -93,7 +93,6 @@ define(
             },
 
             donate: function (data) {
-                debugger;
                 let request = {
                     payload: JSON.stringify(data),
                     formKey: $.mage.cookies.get('form_key')


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Add adyen giving component to regular checkout page for supported payment methods.
- Save `donationToken` from adyen payments response 
- render giving component if enabled and donation token exists
- handle response from onDonate event and show result to shopper

Before giving
![Screen Shot 2021-11-02 at 5 31 05 PM](https://user-images.githubusercontent.com/5240725/139907991-357fd0b3-74da-4a9d-bee4-2bad1b57d73e.png)
After giving
![Screen Shot 2021-11-02 at 5 36 17 PM](https://user-images.githubusercontent.com/5240725/139908022-2a9d27d2-1cfb-4458-9966-7609cb4a2677.png)

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- CC, 3DS1 & 2 success and cancel flows
- Giving component is not rendered if disabled in administration
- Giving component is not rendered for non-supported PMs
