### PR TITLE
Klarna product and image url

### DIFF
--- a/Gateway/Request/CheckoutDataBuilder.php
+++ b/Gateway/Request/CheckoutDataBuilder.php
@@ -222,9 +222,9 @@ class CheckoutDataBuilder implements BuilderInterface
 
         $imageUrl = "";
 
-        if ($product->getSmallImage()) {
+        if ($image = $product->getSmallImage()) {
             $imageUrl = $helperImport->init($product, 'product_page_image_small')
-                ->setImageFile($product->getSmallImage())
+                ->setImageFile($image)
                 ->getUrl();
         }
 

--- a/Gateway/Request/CheckoutDataBuilder.php
+++ b/Gateway/Request/CheckoutDataBuilder.php
@@ -211,6 +211,27 @@ class CheckoutDataBuilder implements BuilderInterface
     }
 
     /**
+     * @param string $item
+     * @return string
+     */
+    protected function retrieveImageUrl($item): string
+    {
+        $objectManager =\Magento\Framework\App\ObjectManager::getInstance();
+        $helperImport = $objectManager->get('\Magento\Catalog\Helper\Image');
+        $product = $item->getProduct();
+
+        $imageUrl = "";
+
+        if ($product->getSmallImage()) {
+            $imageUrl = $helperImport->init($product, 'product_page_image_small')
+                ->setImageFile($product->getSmallImage())
+                ->getUrl();
+        }
+
+        return $imageUrl;
+    }
+
+    /**
      * @param \Magento\Sales\Model\Order $order
      *
      * @return array
@@ -253,7 +274,6 @@ class CheckoutDataBuilder implements BuilderInterface
             );
 
             $formattedTaxPercentage = $this->adyenHelper->formatAmount($item->getTaxPercent(), $currency);
-
             $formFields['lineItems'][] = [
                 'id' => $item->getId(),
                 'amountExcludingTax' => $formattedPriceExcludingTax,
@@ -262,7 +282,9 @@ class CheckoutDataBuilder implements BuilderInterface
                 'description' => $item->getName(),
                 'quantity' => $numberOfItems,
                 'taxCategory' => $item->getProduct()->getAttributeText('tax_class_id'),
-                'taxPercentage' => $formattedTaxPercentage
+                'taxPercentage' => $formattedTaxPercentage,
+                'productUrl'=> $item->getProduct()->getUrlModel()->getUrl($item->getProduct()),
+                'imageUrl'=> $this->retrieveImageUrl($item)
             ];
         }
 

--- a/Helper/Invoice.php
+++ b/Helper/Invoice.php
@@ -137,7 +137,7 @@ class Invoice extends AbstractHelper
                 $pspReference,
                 $order->getIncrementId(),
                 $originalReference,
-                $order->getIncrementId(),
+                $order->getIncrementId()
             ));
         }
 


### PR DESCRIPTION
**Description**
The new API supports `productUrl` and `imageUrl` for Klarna. These will then be shown on the Klarna page after redirect. I've added a method to retrieve the imageUrl, which sends an empty string if no image was found. Additionally included both values in the lineItems.

**Tested scenarios**
- Klarna pay later payment
- Afterpay payment (does not support it but is ignored by API)
- Default unit tests