### PR TITLE
[PW-5034]Add amount to checkout component for installments in admin

### DIFF
--- a/Block/Form/Cc.php
+++ b/Block/Form/Cc.php
@@ -202,12 +202,7 @@ class Cc extends \Magento\Payment\Block\Form\Cc
     public function getFormattedInstallments()
     {
         try {
-            $quote = $this->_appState->getAreaCode() == \Magento\Framework\App\Area::AREA_ADMINHTML ?
-                $this->backendCheckoutSession->getQuote() :
-                $this->checkoutSession->getQuote();
-
-            $quoteAmountCurrency = $this->chargedCurrency->getQuoteAmountCurrency($quote);
-
+            $quoteAmountCurrency = $this->getQuoteAmountCurrency();
             return $this->installmentsHelper->formatInstallmentsConfig(
                 $this->adyenHelper->getAdyenCcConfigData('installments',
                     $this->_storeManager->getStore()->getId()
@@ -261,5 +256,40 @@ class Cc extends \Magento\Payment\Block\Form\Cc
             // Suppress exception, assume that risk should be enabled
             return true;
         }
+    }
+
+    /**
+     * @return string
+     */
+    public function getAmount()
+    {
+        try {
+            $quoteAmountCurrency = $this->getQuoteAmountCurrency();
+            $value = $quoteAmountCurrency->getAmount();
+            $currency = $quoteAmountCurrency->getCurrencyCode();
+            $amount = array("value" => $value, "currency" => $currency);
+
+            return json_encode($amount);
+
+        } catch (\Throwable $e) {
+            $this->adyenLogger->error(
+                'There was an error fetching the amount for installments config: ' . $e->getMessage()
+            );
+            return '{}';
+        }
+    }
+
+    /**
+     * @return \Adyen\Payment\Model\AdyenAmountCurrency
+     * @throws LocalizedException
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     */
+    protected function getQuoteAmountCurrency(): \Adyen\Payment\Model\AdyenAmountCurrency
+    {
+        $quote = $this->_appState->getAreaCode() == \Magento\Framework\App\Area::AREA_ADMINHTML ?
+            $this->backendCheckoutSession->getQuote() :
+            $this->checkoutSession->getQuote();
+
+        return $this->chargedCurrency->getQuoteAmountCurrency($quote);
     }
 }

--- a/view/adminhtml/templates/form/cc.phtml
+++ b/view/adminhtml/templates/form/cc.phtml
@@ -92,6 +92,7 @@ $ccExpYear = $block->getInfoData('cc_exp_year');
                         hasHolderName: true,
                         installmentOptions: <?= /* @noEscape */ $block->getFormattedInstallments();?>,
                         showInstallmentAmounts: true,
+                        amount :<?= /* @noEscape */ $block->getAmount();?>,
                         onChange: function (state) {
                             if (state.isValid) {
                                 $('#adyen-cc-statedata').val(JSON.stringify(state.data));


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
When the merchant was creating an order from magento 2 admin panel the amount was not visible next to the number of installments. The issue is that we did not include the amount while we render the component.  
**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
Test with cc from the admin when creating an order
**Fixed issue**:  <!-- #-prefixed issue number -->