### PR TITLE
Pw 5723: Use webhook module to receive notifications 

### DIFF
--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -30,6 +30,9 @@ class Config
 {
     const XML_PAYMENT_PREFIX = "payment";
     const XML_ADYEN_ABSTRACT_PREFIX = "adyen_abstract";
+    const XML_MERCHANT_ACCOUNT = "merchant_account";
+    const XML_NOTIFICATIONS_USERNAME = "notification_username";
+    const XML_NOTIFICATIONS_PASSWORD = "notification_password";
     const XML_NOTIFICATIONS_CAN_CANCEL_FIELD = "notifications_can_cancel";
     const XML_NOTIFICATIONS_HMAC_CHECK = "notifications_hmac_check";
     const XML_NOTIFICATIONS_IP_CHECK = "notifications_ip_check";
@@ -64,6 +67,46 @@ class Config
     ) {
         $this->scopeConfig = $scopeConfig;
         $this->encryptor = $encryptor;
+    }
+
+    /**
+     * @param int|null $storeId
+     * @return string
+     */
+    public function getMerchantAccount($storeId = null)
+    {
+        return $this->getConfigData(
+            self::XML_MERCHANT_ACCOUNT,
+            self::XML_ADYEN_ABSTRACT_PREFIX,
+            $storeId
+        );
+    }
+
+    /**
+     * @param int|null $storeId
+     * @return string
+     */
+    public function getNotificationsUsername($storeId = null)
+    {
+        return $this->getConfigData(
+            self::XML_NOTIFICATIONS_USERNAME,
+            self::XML_ADYEN_ABSTRACT_PREFIX,
+            $storeId
+        );
+    }
+
+    /**
+     * @param int|null $storeId
+     * @return string
+     */
+    public function getNotificationsPassword($storeId = null)
+    {
+        $key = $this->getConfigData(
+            self::XML_NOTIFICATIONS_PASSWORD,
+            self::XML_ADYEN_ABSTRACT_PREFIX,
+            $storeId
+        );
+        return $this->encryptor->decrypt(trim($key));
     }
 
     /**

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -660,16 +660,6 @@ class Data extends AbstractHelper
     }
 
     /**
-     * Retrieve the decrypted notification password
-     *
-     * @return string
-     */
-    public function getNotificationPassword()
-    {
-        return $this->_encryptor->decrypt(trim($this->getAdyenAbstractConfigData('notification_password')));
-    }
-
-    /**
      * Retrieve the API key
      *
      * @param null|int|string $storeId

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
   ],
   "require": {
     "adyen/php-api-library": "^10",
+    "adyen/php-webhook-module": "^0.3.0",
     "magento/framework": ">=101.0.8 <102 || >=102.0.1",
     "magento/module-vault": "101.*",
     "magento/module-paypal": ">=100.2.6",


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
Currently, we use logic from Adyen PHP library (`adyen/php-api-library`) to validate notifications. This logic is migrating to it's own library `adyen/php-webhook-module`. 

This PR migrates the plugin to the new library and cleans up a bit of the controller.      
 
**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
* Correct username/password
* Invalid username/password
* Correct HMAC signature
* Invalid HMAC signature
* Notification mode
* Webhook notification is successfully saved to database
* Duplicated notification is saved only once