### PR TITLE
[PW-5712] - Check address issue on plugin v6

### DIFF
--- a/Helper/Address.php
+++ b/Helper/Address.php
@@ -43,8 +43,10 @@ class Address
         $this->logger = $logger;
     }
 
+
     // Regex to extract the house number from the street line if needed (e.g. 'Street address 1 A' => '1 A')
-    const HOUSE_NUMBER_REGEX = '/((\s\d{0,10})|(\s\d{0,10}\s?\w{1,3}))$/i';
+    const STREET_FIRST_REGEX = "/(?<streetName>[a-zA-Z0-9.'\- ]+)\s+(?<houseNumber>\d{1,10}((\s)?\w{1,3})?)$/";
+    CONST NUMBER_FIRST_REGEX = "/^(?<houseNumber>\d{1,10}((\s)?\w{1,3})?)\s+(?<streetName>[a-zA-Z0-9.'\- ]+)/";
 
     /**
      * @param $address
@@ -102,19 +104,17 @@ class Address
     {
         $addressString = implode(' ', $addressArray);
 
-        preg_match(
-            self::HOUSE_NUMBER_REGEX,
-            trim($addressString),
-            $houseNumber,
-            PREG_OFFSET_CAPTURE
-        );
+        // Match addresses where the street name comes first, e.g. John-Paul's Ave. 1 B
+        preg_match(self::STREET_FIRST_REGEX, trim($addressString), $streetFirstAddress);
+        // Match addresses where the house number comes first, e.g. 10 D John-Paul's Ave.
+        preg_match(self::NUMBER_FIRST_REGEX, trim($addressString), $numberFirstAddress);
 
-        if (!empty($houseNumber['0'])) {
-            $_houseNumber = trim($houseNumber['0']['0']);
-            $position = $houseNumber['0']['1'];
-            $streetName = trim(substr($addressString, 0, $position));
-            return $this->formatAddressArray($streetName, $_houseNumber);
+        if (!empty($streetFirstAddress)) {
+            return $this->formatAddressArray($streetFirstAddress['streetName'], $streetFirstAddress['houseNumber']);
+        } elseif (!empty($numberFirstAddress)) {
+            return $this->formatAddressArray($numberFirstAddress['streetName'], $numberFirstAddress['houseNumber']);
         }
+
         return $this->formatAddressArray($addressString, 'N/A');
     }
 

--- a/Helper/Invoice.php
+++ b/Helper/Invoice.php
@@ -118,7 +118,7 @@ class Invoice extends AbstractHelper
         foreach ($invoiceCollection as $invoice) {
             $parsedTransId = $this->adyenDataHelper->parseTransactionId($invoice->getTransactionId());
             // Loose comparison based on how Magento does the comparison in entity
-            if ($invoice->getState() == InvoiceModel::STATE_OPEN) {
+            if ($invoice->getState() == InvoiceModel::STATE_OPEN || !$invoice->wasPayCalled()) {
                 // If all invoices should be updated, or this is the single invoice that should be updated
                 if ($fullAmountCaptured || $parsedTransId['pspReference'] === $originalReference) {
                     $invoice->pay();


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
This PR updates the regex used to identify the house number when it is entered in the same line as the street. Currently the houseNumber will be correctly sent to Adyen only if it is entered after the street. This PR will cater for the case where the number is also entered before the street.

Also when finalizing an invoice, check if the pay() method was called.

**Tested scenarios**
* House number entered before street
* House number entered after street