### PR TITLE
Removed trailing comma

### DIFF
--- a/Helper/Invoice.php
+++ b/Helper/Invoice.php
@@ -137,7 +137,7 @@ class Invoice extends AbstractHelper
                 $pspReference,
                 $order->getIncrementId(),
                 $originalReference,
-                $order->getIncrementId(),
+                $order->getIncrementId()
             ));
         }
 


### PR DESCRIPTION

**Description**
Trailing comma in Invoice.php causes compile errors

**Fixed issue**
Should fix #1235 