### PR TITLE
PW-4710 Fix manual review status for immediate capture

### DIFF
--- a/Model/Cron.php
+++ b/Model/Cron.php
@@ -2122,6 +2122,10 @@ class Cron
                 if ($fraudManualReviewStatus != "") {
                     $status = $fraudManualReviewStatus;
                     $comment = "Adyen Payment is in Manual Review check the Adyen platform";
+                    //if the order requires the manual review, it is not possible to set the order in process because the
+                    //$fraudManualReviewStatus is a status assigned to NEW state.
+                    //see https://github.com/Adyen/adyen-magento2/issues/1236
+                    $this->_order->setIsInProcess(false);
                 }
             }
 


### PR DESCRIPTION
**Description**
With this PR I would like to fix the bug on the Manual review not usable when Adyen is configured with immediate capture.

**Tested scenarios**

1. Set the Adyen Magento module and your Adyen Merchant account to use the `immediate` capture
2. Configure the Manual Review Status and the Manual Review Accepted Status configuration on Magento
3. Configure the risk management to require the manual review on the transactions
4. Create an order on Magento
5. Wait for the Adyen notification to be processed
6. Check the state of the order to be NEW and the status in the one configured in step 2 for Manual Review Status 
7. If it is ok, accept the risk on Adyen and wait the notification
8. After the notification is processed, you can see the order in state PROCESSING and status configured in step 2 for Manual Review Accepted Status

**Fixed issue**: https://github.com/Adyen/adyen-magento2/issues/1236
