### PR TITLE
[PW-5530] Remove google pay filtering as it is not part of the response

### DIFF
--- a/Helper/Vault.php
+++ b/Helper/Vault.php
@@ -145,14 +145,7 @@ class Vault
             $paymentToken = $this->paymentTokenFactory->create(
                 PaymentTokenFactoryInterface::TOKEN_TYPE_CREDIT_CARD
             );
-
             $paymentToken->setGatewayToken($additionalData[self::RECURRING_DETAIL_REFERENCE]);
-
-            if (strpos($additionalData[self::PAYMENT_METHOD], "paywithgoogle") !== false
-                && !empty($additionalData['paymentMethodVariant'])) {
-                $additionalData[self::PAYMENT_METHOD] = $additionalData['paymentMethodVariant'];
-                $paymentToken->setIsVisible(false);
-            }
         } else {
             $paymentTokenSaveRequired = true;
         }

--- a/Model/Billing/Agreement.php
+++ b/Model/Billing/Agreement.php
@@ -110,9 +110,6 @@ class Agreement extends \Magento\Paypal\Model\Billing\Agreement
         // Billing agreement is CC
         if (isset($data['card']['number'])) {
             $ccType = $data['variant'];
-            if (strpos($ccType, "paywithgoogle") !== false && !empty($data['paymentMethodVariant'])) {
-                $ccType = $data['paymentMethodVariant'];
-            }
             $ccTypes = $this->adyenHelper->getCcTypesAltData();
 
             if (isset($ccTypes[$ccType])) {
@@ -199,11 +196,7 @@ class Agreement extends \Magento\Paypal\Model\Billing\Agreement
             return $this;
         }
         // Billing agreement is CC
-
         $ccType = $variant = $contractDetail['paymentMethod'];
-        if (strpos($ccType, "paywithgoogle") !== false && !empty($contractDetail['paymentMethodVariant'])) {
-            $ccType = $variant = $contractDetail['paymentMethodVariant'];
-        }
         $ccTypes = $this->adyenHelper->getCcTypesAltData();
 
         if (isset($ccTypes[$ccType])) {

--- a/view/frontend/web/js/view/payment/method-renderer/adyen-hpp-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-hpp-method.js
@@ -81,6 +81,7 @@ define(
                 'paypal',
                 'applepay',
                 'paywithgoogle',
+                'googlepay',
                 'amazonpay'
             ],
             initObservable: function() {


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
The reason to remove the `googlepay` or `paywithgoogle` is that the for google pay and apple pay we don't return anything related to google or apple since the actual payment is done with card. These variants are not included in the payments response or in the notification. The returned payment method is the cc type for example `visa` or `mc`

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

Tested with :
- paywithgoogle
- inspect the notification
- inspect the response
- Google pay token is set as visible false

**Fixed issue**:  <!-- #-prefixed issue number -->