### PR TITLE
[PW-5344] Change the UI of the overview of Magento2 config

### DIFF
--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -33,19 +33,8 @@
                 <frontend_model>Magento\Paypal\Block\Adminhtml\System\Config\Fieldset\Group</frontend_model>
                 <include path="Adyen_Payment::system/adyen_getting_started.xml"/>
                 <include path="Adyen_Payment::system/adyen_required_settings.xml"/>
-                <include path="Adyen_Payment::system/adyen_advanced_order_processing.xml"/>
-                <include path="Adyen_Payment::system/adyen_advanced_notifications.xml"/>
-                <include path="Adyen_Payment::system/adyen_checkout_experience.xml"/>
-                <include path="Adyen_Payment::system/adyen_manual_review.xml"/>
-                <include path="Adyen_Payment::system/adyen_partial_payment.xml"/>
-                <include path="Adyen_Payment::system/adyen_security.xml"/>
-                <include path="Adyen_Payment::system/adyen_cc.xml"/>
-                <include path="Adyen_Payment::system/adyen_oneclick.xml"/>
-                <include path="Adyen_Payment::system/adyen_hpp.xml"/>
-                <include path="Adyen_Payment::system/adyen_pos_cloud.xml"/>
-                <include path="Adyen_Payment::system/adyen_pay_by_link.xml"/>
-                <include path="Adyen_Payment::system/adyen_boleto.xml"/>
-                <include path="Adyen_Payment::system/adyen_pwa.xml"/>
+                <include path="Adyen_Payment::system/adyen_configure_payment_methods.xml"/>
+                <include path="Adyen_Payment::system/adyen_advanced_settings.xml"/>
             </group>
         </section>
     </system>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -26,8 +26,8 @@
     <system>
         <section id="payment" translate="label" type="text" sortOrder="400" showInDefault="1" showInWebsite="1" showInStore="1">
             <group id="adyen_group_all_in_one" translate="label" type="text" sortOrder="5" showInDefault="1" showInWebsite="1" showInStore="1">
-                <label>Adyen All-in-One Payment Solutions</label>
-                <comment><![CDATA[Adyen All-in-One Payment Solutions]]></comment>
+                <label>Adyen Payments</label>
+                <comment><![CDATA[Adyen Payments]]></comment>
                 <attribute type="expanded">1</attribute>
                 <fieldset_css>complex</fieldset_css>
                 <frontend_model>Magento\Paypal\Block\Adminhtml\System\Config\Fieldset\Group</frontend_model>

--- a/etc/adminhtml/system/adyen_advanced_settings.xml
+++ b/etc/adminhtml/system/adyen_advanced_settings.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<!--
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2021 Adyen BV (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+-->
+<include xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_include.xsd">
+    <group id="adyen_advanced_settings" translate="label" type="text" sortOrder="120" showInDefault="1"
+           showInWebsite="1"
+           showInStore="1">
+        <label><![CDATA[Advanced settings]]></label>
+        <frontend_model>Magento\Config\Block\System\Config\Form\Fieldset</frontend_model>
+        <include path="Adyen_Payment::system/adyen_advanced_order_processing.xml"/>
+        <include path="Adyen_Payment::system/adyen_advanced_notifications.xml"/>
+        <include path="Adyen_Payment::system/adyen_checkout_experience.xml"/>
+        <include path="Adyen_Payment::system/adyen_manual_review.xml"/>
+        <include path="Adyen_Payment::system/adyen_partial_payment.xml"/>
+        <include path="Adyen_Payment::system/adyen_security.xml"/>
+
+        <include path="Adyen_Payment::system/adyen_pos_cloud.xml"/>
+        <include path="Adyen_Payment::system/adyen_pay_by_link.xml"/>
+        <include path="Adyen_Payment::system/adyen_boleto.xml"/>
+        <include path="Adyen_Payment::system/adyen_pwa.xml"/>
+    </group>
+</include>

--- a/etc/adminhtml/system/adyen_boleto.xml
+++ b/etc/adminhtml/system/adyen_boleto.xml
@@ -25,7 +25,7 @@
 <include xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_include.xsd">
     <group id="adyen_boleto" translate="label" type="text" sortOrder="450" showInDefault="1" showInWebsite="1" showInStore="1">
         <label><![CDATA[Boleto integration]]></label>
-        <frontend_model>Magento\Paypal\Block\Adminhtml\System\Config\Fieldset\Payment</frontend_model>
+        <frontend_model>Magento\Config\Block\System\Config\Form\Fieldset</frontend_model>
         <fieldset_css>adyen-method-adyen-cc</fieldset_css>
         <comment>Process Boleto transactions</comment>
         <field id="active" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">

--- a/etc/adminhtml/system/adyen_cc.xml
+++ b/etc/adminhtml/system/adyen_cc.xml
@@ -22,14 +22,16 @@
  * Author: Adyen <magento@adyen.com>
  */
 -->
-<include xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_include.xsd">
+<include xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_include.xsd">
     <group id="adyen_cc" translate="label" type="text" sortOrder="100" showInDefault="1" showInWebsite="1"
            showInStore="1">
         <label><![CDATA[CreditCard API integration]]></label>
-        <frontend_model>Magento\Paypal\Block\Adminhtml\System\Config\Fieldset\Payment</frontend_model>
-        <fieldset_css>adyen-method-adyen-cc</fieldset_css>
-        <comment>Process creditcard payments inside your checkout.</comment>
+        <frontend_model>Magento\Config\Block\System\Config\Form\Fieldset</frontend_model>
+        <comment> <![CDATA[
+                <p>Process creditcard payments inside your checkout.
+                    </p>
+            ]]>
+        </comment>
         <field id="active" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="1"
                showInStore="1">
             <label>Enabled</label>
@@ -80,7 +82,6 @@
                 <config_path>payment/adyen_cc/installments</config_path>
             </field>
         </group>
-
         <group id="adyen_cc_country_specific" translate="label" showInDefault="1" showInWebsite="1" sortOrder="70">
             <label>Country Specific Settings</label>
             <frontend_model>Magento\Config\Block\System\Config\Form\Fieldset</frontend_model>

--- a/etc/adminhtml/system/adyen_configure_payment_methods.xml
+++ b/etc/adminhtml/system/adyen_configure_payment_methods.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<!--
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2021 Adyen BV (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+-->
+<include xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_include.xsd">
+    <group id="adyen_configure_payment_methods" translate="label" type="text" sortOrder="120" showInDefault="1"
+           showInWebsite="1"
+           showInStore="1">
+        <label><![CDATA[Configure payment methods]]></label>
+        <frontend_model>Magento\Config\Block\System\Config\Form\Fieldset</frontend_model>
+        <include path="Adyen_Payment::system/adyen_cc.xml"/>
+        <include path="Adyen_Payment::system/adyen_oneclick.xml"/>
+        <include path="Adyen_Payment::system/adyen_hpp.xml"/>
+    </group>
+</include>

--- a/etc/adminhtml/system/adyen_hpp.xml
+++ b/etc/adminhtml/system/adyen_hpp.xml
@@ -25,7 +25,7 @@
 <include xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_include.xsd">
     <group id="adyen_hpp" translate="label" type="text" sortOrder="200" showInDefault="1" showInWebsite="1" showInStore="1">
         <label><![CDATA[Alternative payment methods]]></label>
-        <frontend_model>Magento\Paypal\Block\Adminhtml\System\Config\Fieldset\Payment</frontend_model>
+        <frontend_model>Magento\Config\Block\System\Config\Form\Fieldset</frontend_model>
         <fieldset_css>adyen-method-adyen-cc</fieldset_css>
         <comment>Process alternative payments methods</comment>
         <field id="active" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">

--- a/etc/adminhtml/system/adyen_oneclick.xml
+++ b/etc/adminhtml/system/adyen_oneclick.xml
@@ -25,7 +25,7 @@
 <include xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_include.xsd">
     <group id="adyen_oneclick" translate="label" type="text" sortOrder="150" showInDefault="1" showInWebsite="1" showInStore="1">
         <label><![CDATA[Stored Payment Methods - Requires Adyen Credit Card]]></label>
-        <frontend_model>Magento\Paypal\Block\Adminhtml\System\Config\Fieldset\Payment</frontend_model>
+        <frontend_model>Magento\Config\Block\System\Config\Form\Fieldset</frontend_model>
         <fieldset_css>adyen-method-adyen-cc</fieldset_css>
         <comment><![CDATA[During checkout shoppers can choose to have their payment details remembered and stored for trusted websites in Adyen’s highly secure platform. Adyen takes care of this process for its customers. Shoppers can then select the stored payment method in the checkout.]]></comment>
 

--- a/etc/adminhtml/system/adyen_pay_by_link.xml
+++ b/etc/adminhtml/system/adyen_pay_by_link.xml
@@ -25,7 +25,7 @@
 <include xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_include.xsd">
     <group id="adyen_pay_by_link" translate="label" type="text" sortOrder="400" showInDefault="1" showInWebsite="1" showInStore="1">
         <label><![CDATA[Adyen Pay by Link]]></label>
-        <frontend_model>Magento\Paypal\Block\Adminhtml\System\Config\Fieldset\Payment</frontend_model>
+        <frontend_model>Magento\Config\Block\System\Config\Form\Fieldset</frontend_model>
         <fieldset_css>adyen-method-adyen-cc</fieldset_css>
         <comment>Generate payment links for admin orders</comment>
         <field id="active" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">

--- a/etc/adminhtml/system/adyen_pos_cloud.xml
+++ b/etc/adminhtml/system/adyen_pos_cloud.xml
@@ -24,7 +24,7 @@
 <include xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_include.xsd">
     <group id="adyen_pos_cloud" translate="label" type="text" sortOrder="350" showInDefault="1" showInWebsite="1" showInStore="1">
         <label><![CDATA[Point of Sale (POS) integration with Cloud API]]></label>
-        <frontend_model>Magento\Paypal\Block\Adminhtml\System\Config\Fieldset\Payment</frontend_model>
+        <frontend_model>Magento\Config\Block\System\Config\Form\Fieldset</frontend_model>
         <fieldset_css>adyen-method-adyen-cc</fieldset_css>
         <comment>Process Point of Sales transactions</comment>
         <field id="active" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">

--- a/etc/adminhtml/system/adyen_required_settings.xml
+++ b/etc/adminhtml/system/adyen_required_settings.xml
@@ -22,70 +22,103 @@
  * Author: Adyen <magento@adyen.com>
  */
 -->
-<include xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_include.xsd">
-    <group id="adyen_required_settings" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
+<include xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_include.xsd">
+    <group id="adyen_required_settings" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="1"
+           showInStore="1">
         <label><![CDATA[Required Settings]]></label>
         <frontend_model>Magento\Config\Block\System\Config\Form\Fieldset</frontend_model>
-        <field id="merchant_account" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
+        <field id="merchant_account" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="1"
+               showInStore="1">
             <label>Merchant Account</label>
             <config_path>payment/adyen_abstract/merchant_account</config_path>
-            <tooltip><![CDATA[The merchant account identifier you want to process the (transaction) request with. Find this at the top of the screen in the Adyen Customer Area, where you will see [YourCompanyAccount] > [YourMerchantAccount] . Please note that the merchant account is different from the company account; a company account can have one or more merchant accounts.]]></tooltip>
-            <comment><![CDATA[<a target="_blank" href="https://docs.adyen.com/developers/plugins/magento-2/set-up-the-plugin-in-magento#step3configuretheplugininmagento">Click here for explanation.</a>]]></comment>
+            <tooltip>
+                <![CDATA[The merchant account identifier you want to process the (transaction) request with. Find this at the top of the screen in the Adyen Customer Area, where you will see [YourCompanyAccount] > [YourMerchantAccount] . Please note that the merchant account is different from the company account; a company account can have one or more merchant accounts.]]></tooltip>
+            <comment>
+                <![CDATA[<a target="_blank" href="https://docs.adyen.com/developers/plugins/magento-2/set-up-the-plugin-in-magento#step3configuretheplugininmagento">Click here for explanation.</a>]]></comment>
         </field>
-        <field id="demo_mode" translate="label" type="select" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
+        <field id="demo_mode" translate="label" type="select" sortOrder="20" showInDefault="1" showInWebsite="1"
+               showInStore="1">
             <label>Test/Production Mode</label>
             <source_model>Adyen\Payment\Model\Config\Source\DemoMode</source_model>
             <config_path>payment/adyen_abstract/demo_mode</config_path>
-            <tooltip><![CDATA[ In the test mode you must use test cards. See section Documentation & Support for the link to the test cards]]></tooltip>
+            <tooltip>
+                <![CDATA[ In the test mode you must use test cards. See section Documentation & Support for the link to the test cards]]></tooltip>
         </field>
-        <field id="notification_username" translate="label" type="text" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
+        <field id="notification_username" translate="label" type="text" sortOrder="30" showInDefault="1"
+               showInWebsite="1" showInStore="1">
             <label>Notification User Name</label>
             <config_path>payment/adyen_abstract/notification_username</config_path>
-            <tooltip>Set a user name of your choice here and copy it over to Adyen Customer Area => Developers => Webhooks => Standard Notification => User Name.</tooltip>
+            <tooltip>Set a user name of your choice here and copy it over to Adyen Customer Area => Developers =>
+                Webhooks => Standard Notification => User Name.
+            </tooltip>
         </field>
-        <field id="notification_password" translate="label" type="obscure" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1">
+        <field id="notification_password" translate="label" type="obscure" sortOrder="40" showInDefault="1"
+               showInWebsite="1" showInStore="1">
             <label>Notification Password</label>
             <backend_model>Magento\Config\Model\Config\Backend\Encrypted</backend_model>
             <config_path>payment/adyen_abstract/notification_password</config_path>
-            <tooltip>Set a password of your choice and copy it over to Adyen Customer Area => Developers => Webhooks => Standard Notification => Password.</tooltip>
+            <tooltip>Set a password of your choice and copy it over to Adyen Customer Area => Developers => Webhooks =>
+                Standard Notification => Password.
+            </tooltip>
         </field>
-        <field id="api_key_test" translate="label" type="obscure" sortOrder="50" showInDefault="1" showInWebsite="1" showInStore="0">
+        <field id="api_key_test" translate="label" type="obscure" sortOrder="50" showInDefault="1" showInWebsite="1"
+               showInStore="0">
             <label>API key for Test</label>
-            <tooltip>If you don't know your Api-Key, log in to your Test Customer Area. Navigate to Developers => API Credentials and click on your webservice user. Find your API Key in the "Authentication" section.</tooltip>
+            <tooltip>If you don't know your Api-Key, log in to your Test Customer Area. Navigate to Developers => API
+                Credentials and click on your webservice user. Find your API Key in the "Authentication" section.
+            </tooltip>
             <backend_model>Magento\Config\Model\Config\Backend\Encrypted</backend_model>
             <config_path>payment/adyen_abstract/api_key_test</config_path>
-            <comment model="Adyen\Payment\Model\Comment\ApiKeyEnding" />
+            <comment model="Adyen\Payment\Model\Comment\ApiKeyEnding"/>
         </field>
-        <field id="api_key_live" translate="label" type="obscure" sortOrder="60" showInDefault="1" showInWebsite="1" showInStore="0">
+        <field id="api_key_live" translate="label" type="obscure" sortOrder="60" showInDefault="1" showInWebsite="1"
+               showInStore="0">
             <label>API key for Live</label>
-            <tooltip>If you don't know your Api-Key, you can find it in your Live Customer Area. Navigate to Developers => API Credentials and click on your webservice user. Find your API Key in the "Authentication" section.</tooltip>
+            <tooltip>If you don't know your Api-Key, you can find it in your Live Customer Area. Navigate to Developers
+                => API Credentials and click on your webservice user. Find your API Key in the "Authentication" section.
+            </tooltip>
             <backend_model>Magento\Config\Model\Config\Backend\Encrypted</backend_model>
             <config_path>payment/adyen_abstract/api_key_live</config_path>
-            <comment model="Adyen\Payment\Model\Comment\ApiKeyEnding" />
+            <comment model="Adyen\Payment\Model\Comment\ApiKeyEnding"/>
         </field>
-        <field id="client_key_test" translate="label" type="text" sortOrder="70" showInDefault="1" showInWebsite="1" showInStore="0">
+        <field id="client_key_test" translate="label" type="text" sortOrder="70" showInDefault="1" showInWebsite="1"
+               showInStore="0">
             <label>Client key for Test</label>
-            <tooltip>If you don't know your Client Key, you can find it in your Test Customer Area. Navigate to Developers => API Credentials and click on your webservice user. Find your Client Key in the "Authentication" section.</tooltip>
+            <tooltip>If you don't know your Client Key, you can find it in your Test Customer Area. Navigate to
+                Developers => API Credentials and click on your webservice user. Find your Client Key in the
+                "Authentication" section.
+            </tooltip>
             <config_path>payment/adyen_abstract/client_key_test</config_path>
         </field>
-        <field id="client_key_live" translate="label" type="text" sortOrder="80" showInDefault="1" showInWebsite="1" showInStore="0">
+        <field id="client_key_live" translate="label" type="text" sortOrder="80" showInDefault="1" showInWebsite="1"
+               showInStore="0">
             <label>Client key for Live</label>
-            <tooltip>If you don't know your Client Key, you can find it in your Live Customer Area. Navigate to Developers => API Credentials and click on your webservice user. Find your Client Key in the "Authentication" section.</tooltip>
+            <tooltip>If you don't know your Client Key, you can find it in your Live Customer Area. Navigate to
+                Developers => API Credentials and click on your webservice user. Find your Client Key in the
+                "Authentication" section.
+            </tooltip>
             <config_path>payment/adyen_abstract/client_key_live</config_path>
         </field>
-        <field id="live_endpoint_url_prefix" translate="label" type="text" sortOrder="90" showInDefault="1" showInWebsite="1" showInStore="0">
+        <field id="live_endpoint_url_prefix" translate="label" type="text" sortOrder="90" showInDefault="1"
+               showInWebsite="1" showInStore="0">
             <label>Live endpoint prefix</label>
-            <tooltip><![CDATA[e.g. if your live endpoint is: <br/> <i>https://1234a567bcd89ef0-MagentoCompany-checkout-live.adyenpayments.com</i> <br/> please type:  <strong>1234a567bcd89ef0-MagentoCompany</strong> in this field.]]></tooltip>
-            <comment><![CDATA[Provide the unique live url prefix: <strong>[random]-[company name]</strong> from the Developers => API URLs menu in the Adyen Customer Area. For more information, please check <a href="https://docs.adyen.com/developers/development-resources/live-endpoints#checkoutendpoints">  our documentation</a>.]]></comment>
+            <tooltip>
+                <![CDATA[e.g. if your live endpoint is: <br/> <i>https://1234a567bcd89ef0-MagentoCompany-checkout-live.adyenpayments.com</i> <br/> please type:  <strong>1234a567bcd89ef0-MagentoCompany</strong> in this field.]]></tooltip>
+            <comment>
+                <![CDATA[Provide the unique live url prefix: <strong>[random]-[company name]</strong> from the Developers => API URLs menu in the Adyen Customer Area. For more information, please check <a href="https://docs.adyen.com/developers/development-resources/live-endpoints#checkoutendpoints">  our documentation</a>.]]></comment>
             <config_path>payment/adyen_abstract/live_endpoint_url_prefix</config_path>
         </field>
-        <field id="charged_currency" translate="label" type="hidden" sortOrder="100" showInDefault="1" showInWebsite="1" showInStore="1">
+        <field id="charged_currency" translate="label" type="hidden" sortOrder="100" showInDefault="1" showInWebsite="1"
+               showInStore="1">
             <label>Charged currency</label>
-            <comment><![CDATA[Currency used for Adyen payment processing. This setting is hidden to ensure processing of payments in the expected currency (Display by default), see <a target="_blank" href="https://docs.adyen.com/developers/plugins/magento-2/set-up-the-plugin-in-magento#selecting-charged-currency">Adyen docs</a> for more information.]]></comment>
+            <comment>
+                <![CDATA[Currency used for Adyen payment processing. This setting is hidden to ensure processing of payments in the expected currency (Display by default), see <a target="_blank" href="https://docs.adyen.com/developers/plugins/magento-2/set-up-the-plugin-in-magento#selecting-charged-currency">Adyen docs</a> for more information.]]></comment>
             <source_model>Adyen\Payment\Model\Config\Source\ChargedCurrency</source_model>
             <config_path>payment/adyen_abstract/charged_currency</config_path>
         </field>
-        <field id="debug" translate="label" type="select" sortOrder="110" showInDefault="1" showInWebsite="1" showInStore="0">
+        <field id="debug" translate="label" type="select" sortOrder="110" showInDefault="1" showInWebsite="1"
+               showInStore="0">
             <label>Enable debug logging</label>
             <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
             <config_path>payment/adyen_abstract/debug</config_path>


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
1. Remove different UI (Adyen logos and configure button) for the payment method sections. Keep same header UI.
2. Add new section under Required Settings called "Configure payment methods"
3. Move the credit card, stored payment methods and alternative payment method sections to the new section "Configure payment methods".
4. Change "Adyen all in one payment solution" header to "Adyen Payments"
5. Split the config into 3 sections: Required Settings, Configure payment methods, Advanced Settings (regroup the different advanced settings under this).


**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

**Fixed issue**:  <!-- #-prefixed issue number -->