### PR TITLE
POS Cloud HTML receipt is escaped

### DIFF
--- a/view/adminhtml/templates/info/adyen_pos_cloud.phtml
+++ b/view/adminhtml/templates/info/adyen_pos_cloud.phtml
@@ -90,4 +90,4 @@ $_isDemoMode = $block->isDemoMode();
         padding-bottom: 5px;
     }
 </style>
-<?= $block->escapeHtml($block->getMethod()->getInfoInstance()->getAdditionalInformation('receipt')); ?>
+<?= $block->getMethod()->getInfoInstance()->getAdditionalInformation('receipt'); ?>

--- a/view/frontend/templates/info/adyen_pos_cloud.phtml
+++ b/view/frontend/templates/info/adyen_pos_cloud.phtml
@@ -46,5 +46,5 @@
             padding-bottom: 5px;
         }
     </style>
-    <?= $block->escapeHtml($block->getMethod()->getInfoInstance()->getAdditionalInformation('receipt')); ?>
+    <?= $block->getMethod()->getInfoInstance()->getAdditionalInformation('receipt'); ?>
 </dl>


### PR DESCRIPTION
The receipt itself is HTML and should not be escaped, otherwise raw HTML will be disabled

**Description**
When using POS cloud Adyen will return a HTML receipt. This receipt is displayed in the backend and frontend as encoded HTML instead of HTML.

**Tested scenarios**
Create a POS payment, check frontend and backend.
