### PR TITLE
Added productUrl and imageUrl to openInvoice fields (for Klarna)

### DIFF
--- a/Gateway/Request/CheckoutDataBuilder.php
+++ b/Gateway/Request/CheckoutDataBuilder.php
@@ -56,6 +56,11 @@ class CheckoutDataBuilder implements BuilderInterface
      */
     private $chargedCurrency;
 
+    /**
+     * @var \Magento\Catalog\Helper\Image
+     */
+    private $imageHelper;
+
 
     /**
      * CheckoutDataBuilder constructor.
@@ -67,11 +72,13 @@ class CheckoutDataBuilder implements BuilderInterface
     public function __construct(
         Data $adyenHelper,
         CartRepositoryInterface $cartRepository,
-        ChargedCurrency $chargedCurrency
+        ChargedCurrency $chargedCurrency,
+        \Magento\Catalog\Helper\Image $imageHelper
     ) {
         $this->adyenHelper = $adyenHelper;
         $this->cartRepository = $cartRepository;
         $this->chargedCurrency = $chargedCurrency;
+        $this->imageHelper = $imageHelper;
     }
 
     /**
@@ -211,6 +218,24 @@ class CheckoutDataBuilder implements BuilderInterface
     }
 
     /**
+     * @param string $item
+     * @return string
+     */
+    protected function getImageUrl($item): string
+    {
+        $product = $item->getProduct();
+        $imageUrl = "";
+
+        if ($image = $product->getSmallImage()) {
+            $imageUrl = $this->imageHelper->init($product, 'product_page_image_small')
+                ->setImageFile($image)
+                ->getUrl();
+        }
+
+        return $imageUrl;
+    }
+
+    /**
      * @param \Magento\Sales\Model\Order $order
      *
      * @return array
@@ -262,7 +287,9 @@ class CheckoutDataBuilder implements BuilderInterface
                 'description' => $item->getName(),
                 'quantity' => $numberOfItems,
                 'taxCategory' => $item->getProduct()->getAttributeText('tax_class_id'),
-                'taxPercentage' => $formattedTaxPercentage
+                'taxPercentage' => $formattedTaxPercentage,
+                'productUrl'=> $item->getProduct()->getUrlModel()->getUrl($item->getProduct()),
+                'imageUrl'=> $this->getImageUrl($item)
             ];
         }
 

--- a/Gateway/Request/CheckoutDataBuilder.php
+++ b/Gateway/Request/CheckoutDataBuilder.php
@@ -32,6 +32,7 @@ use Adyen\Payment\Observer\AdyenCcDataAssignObserver;
 use Magento\Payment\Gateway\Request\BuilderInterface;
 use Adyen\Payment\Observer\AdyenHppDataAssignObserver;
 use Magento\Quote\Api\CartRepositoryInterface;
+use Magento\Catalog\Helper\Image;
 
 class CheckoutDataBuilder implements BuilderInterface
 {
@@ -57,7 +58,7 @@ class CheckoutDataBuilder implements BuilderInterface
     private $chargedCurrency;
 
     /**
-     * @var \Magento\Catalog\Helper\Image
+     * @var Image
      */
     private $imageHelper;
 
@@ -68,12 +69,13 @@ class CheckoutDataBuilder implements BuilderInterface
      * @param Data $adyenHelper
      * @param CartRepositoryInterface $cartRepository
      * @param ChargedCurrency $chargedCurrency
+     * @param Image $imageHelper
      */
     public function __construct(
         Data $adyenHelper,
         CartRepositoryInterface $cartRepository,
         ChargedCurrency $chargedCurrency,
-        \Magento\Catalog\Helper\Image $imageHelper
+        Image $imageHelper
     ) {
         $this->adyenHelper = $adyenHelper;
         $this->cartRepository = $cartRepository;


### PR DESCRIPTION
**Description**
The new checkout API supports `productUrl` and `imageUrl` for Klarna. These will then be shown on the Klarna page after redirect. I've added a method to retrieve the imageUrl, which sends an empty string if no image was found. Additionally included both values in the lineItems.

**Tested scenarios**
- Klarna pay later payment
- Afterpay payment (does not support it but values are ignored by API)
- Default unit tests
- Multi store view setup (with different URL).
    - As can be seen, productUrl is still correct and Images are cached from the same URL.