### PR TITLE
AdyenMultishippingConfigProvider.php compilation fix

### DIFF
--- a/Model/Ui/AdyenCheckoutSuccessConfigProvider.php
+++ b/Model/Ui/AdyenCheckoutSuccessConfigProvider.php
@@ -23,7 +23,7 @@
 
 namespace Adyen\Payment\Model\Ui;
 
-use \Magento\Checkout\Model\ConfigProviderInterface;
+use Magento\Checkout\Model\ConfigProviderInterface;
 use Magento\Store\Model\StoreManagerInterface;
 
 class AdyenCheckoutSuccessConfigProvider implements ConfigProviderInterface

--- a/view/frontend/layout/multishipping_checkout_success.xml
+++ b/view/frontend/layout/multishipping_checkout_success.xml
@@ -30,8 +30,7 @@
         <referenceBlock class="Adyen\Payment\Block\Checkout\Multishipping\Success" name="checkout_success"
                         template="Adyen_Payment::checkout/multishipping/success.phtml">
             <arguments>
-                <argument name="checkout_data" xsi:type="object">Magento\Multishipping\Block\DataProviders\Success
-                </argument>
+                <argument name="checkout_data" xsi:type="object">Magento\Multishipping\Block\DataProviders\Success</argument>
                 <argument name="cacheable" xsi:type="boolean">false</argument>
             </arguments>
         </referenceBlock>


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Noticed an intermittent compilation error caused by the Success.pho block class, and here's a fix for it.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
Class compilation with no errors.

**Fixed issue**:  <!-- #-prefixed issue number --> NA