### PR TITLE
Release 7.3.2

### DIFF
--- a/Api/Data/AddressAdapterInterface.php
+++ b/Api/Data/AddressAdapterInterface.php
@@ -21,33 +21,21 @@
  * Author: Adyen <magento@adyen.com>
  */
 
-namespace Adyen\Payment\Gateway\Data\Order;
+namespace Adyen\Payment\Api\Data;
 
-use Adyen\Payment\Api\Data\AddressAdapterInterface;
-use Magento\Sales\Api\Data\OrderAddressInterface;
+use Magento\Payment\Gateway\Data\AddressAdapterInterface as CoreAddressAdapterInterface;
 
-class AddressAdapter extends \Magento\Payment\Gateway\Data\Order\AddressAdapter implements AddressAdapterInterface
+interface AddressAdapterInterface extends CoreAddressAdapterInterface
 {
     /**
-     * @var OrderAddressInterface
+     * Get street line 3
+     * @return string
      */
-    private $address;
+    public function getStreetLine3();
 
-    public function __construct(OrderAddressInterface $address)
-    {
-        $this->address = $address;
-        parent::__construct($address);
-    }
-
-    public function getStreetLine3()
-    {
-        $street = $this->address->getStreet();
-        return isset($street[2]) ? $street[2] : '';
-    }
-
-    public function getStreetLine4()
-    {
-        $street = $this->address->getStreet();
-        return isset($street[3]) ? $street[3] : '';
-    }
+    /**
+     * Get street line 4
+     * @return string
+     */
+    public function getStreetLine4();
 }

--- a/Block/Form/Cc.php
+++ b/Block/Form/Cc.php
@@ -202,12 +202,7 @@ class Cc extends \Magento\Payment\Block\Form\Cc
     public function getFormattedInstallments()
     {
         try {
-            $quote = $this->_appState->getAreaCode() == \Magento\Framework\App\Area::AREA_ADMINHTML ?
-                $this->backendCheckoutSession->getQuote() :
-                $this->checkoutSession->getQuote();
-
-            $quoteAmountCurrency = $this->chargedCurrency->getQuoteAmountCurrency($quote);
-
+            $quoteAmountCurrency = $this->getQuoteAmountCurrency();
             return $this->installmentsHelper->formatInstallmentsConfig(
                 $this->adyenHelper->getAdyenCcConfigData('installments',
                     $this->_storeManager->getStore()->getId()
@@ -261,5 +256,40 @@ class Cc extends \Magento\Payment\Block\Form\Cc
             // Suppress exception, assume that risk should be enabled
             return true;
         }
+    }
+
+    /**
+     * @return string
+     */
+    public function getAmount()
+    {
+        try {
+            $quoteAmountCurrency = $this->getQuoteAmountCurrency();
+            $value = $quoteAmountCurrency->getAmount();
+            $currency = $quoteAmountCurrency->getCurrencyCode();
+            $amount = array("value" => $value, "currency" => $currency);
+
+            return json_encode($amount);
+
+        } catch (\Throwable $e) {
+            $this->adyenLogger->error(
+                'There was an error fetching the amount for installments config: ' . $e->getMessage()
+            );
+            return '{}';
+        }
+    }
+
+    /**
+     * @return \Adyen\Payment\Model\AdyenAmountCurrency
+     * @throws LocalizedException
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     */
+    protected function getQuoteAmountCurrency(): \Adyen\Payment\Model\AdyenAmountCurrency
+    {
+        $quote = $this->_appState->getAreaCode() == \Magento\Framework\App\Area::AREA_ADMINHTML ?
+            $this->backendCheckoutSession->getQuote() :
+            $this->checkoutSession->getQuote();
+
+        return $this->chargedCurrency->getQuoteAmountCurrency($quote);
     }
 }

--- a/Gateway/Request/RefundDataBuilder.php
+++ b/Gateway/Request/RefundDataBuilder.php
@@ -78,13 +78,18 @@ class RefundDataBuilder implements BuilderInterface
     {
         /** @var \Magento\Payment\Gateway\Data\PaymentDataObject $paymentDataObject */
         $paymentDataObject = \Magento\Payment\Gateway\Helper\SubjectReader::readPayment($buildSubject);
-        $buildSubjectAmount = \Magento\Payment\Gateway\Helper\SubjectReader::readAmount($buildSubject);
+
         $order = $paymentDataObject->getOrder();
         $payment = $paymentDataObject->getPayment();
-        $pspReference = $payment->getCcTransId();
         $orderAmountCurrency = $this->chargedCurrency->getOrderAmountCurrency($payment->getOrder(), false);
-        $currency = $orderAmountCurrency->getCurrencyCode();
-        $amount = $buildSubjectAmount;
+
+        // Construct AdyenAmountCurrency from creditmemo
+        $creditMemo = $payment->getCreditMemo();
+        $creditMemoAmountCurrency = $this->chargedCurrency->getCreditMemoAmountCurrency($creditMemo, false);
+
+        $pspReference = $payment->getCcTransId();
+        $currency = $creditMemoAmountCurrency->getCurrencyCode();
+        $amount = $creditMemoAmountCurrency->getAmount();
         $storeId = $order->getStoreId();
         $method = $payment->getMethod();
         $merchantAccount = $this->adyenHelper->getAdyenMerchantAccount($method, $storeId);
@@ -110,7 +115,7 @@ class RefundDataBuilder implements BuilderInterface
                 $orderPaymentCollection->addPaymentFilterDescending($payment->getId());
             } elseif ($refundStrategy == "3") {
                 // refund based on ratio
-                $ratio = $buildSubjectAmount / $orderAmountCurrency->getAmount();
+                $ratio = $amount / $orderAmountCurrency->getAmount();
                 $orderPaymentCollection->addPaymentFilterAscending($payment->getId());
             }
 
@@ -194,10 +199,8 @@ class RefundDataBuilder implements BuilderInterface
     {
         $formFields = [];
         $count = 0;
-        $currency = $this->chargedCurrency
-            ->getOrderAmountCurrency($payment->getOrder(), false)
-            ->getCurrencyCode();
 
+        // Construct AdyenAmountCurrency from creditmemo
         /**
          * @var \Magento\Sales\Model\Order\Creditmemo $creditMemo
          */
@@ -217,7 +220,7 @@ class RefundDataBuilder implements BuilderInterface
                 $count,
                 $refundItem->getName(),
                 $itemAmountCurrency->getAmount(),
-                $currency,
+                $itemAmountCurrency->getCurrencyCode(),
                 $itemAmountCurrency->getTaxAmount(),
                 $itemAmountCurrency->getAmount() + $itemAmountCurrency->getTaxAmount(),
                 $refundItem->getOrderItem()->getTaxPercent(),
@@ -228,15 +231,34 @@ class RefundDataBuilder implements BuilderInterface
         }
 
         // Shipping cost
-        if ($creditMemo->getShippingAmount() > 0) {
+        $shippingAmountCurrency = $this->chargedCurrency->getCreditMemoShippingAmountCurrency($creditMemo);
+        if ($shippingAmountCurrency->getAmount() > 0) {
             ++$count;
             $formFields = $this->adyenHelper->createOpenInvoiceLineShipping(
                 $formFields,
                 $count,
                 $payment->getOrder(),
-                $creditMemo->getShippingAmount(),
-                $creditMemo->getShippingTaxAmount(),
-                $currency,
+                $shippingAmountCurrency->getAmount(),
+                $shippingAmountCurrency->getTaxAmount(),
+                $shippingAmountCurrency->getCurrencyCode(),
+                $payment
+            );
+        }
+
+        // Adjustment
+        $adjustmentAmountCurrency = $this->chargedCurrency->getCreditMemoAdjustmentAmountCurrency($creditMemo);
+        if ($adjustmentAmountCurrency->getAmount() != 0) {
+            $positive = $adjustmentAmountCurrency->getAmount() > 0 ? 'Positive' : '';
+            $negative = $adjustmentAmountCurrency->getAmount() < 0 ? 'Negative' : '';
+            $description = "Adjustment - " . implode(' | ', array_filter([$positive, $negative]));
+
+            ++$count;
+            $formFields = $this->adyenHelper->createOpenInvoiceLineAdjustment(
+                $formFields,
+                $count,
+                $description,
+                $adjustmentAmountCurrency->getAmount(),
+                $adjustmentAmountCurrency->getCurrencyCode(),
                 $payment
             );
         }

--- a/Gateway/Response/PaymentRefundDetailsHandler.php
+++ b/Gateway/Response/PaymentRefundDetailsHandler.php
@@ -39,6 +39,10 @@ class PaymentRefundDetailsHandler implements HandlerInterface
         $payment = $payment->getPayment();
 
         foreach ($response as $singleResponse) {
+            if (isset($singleResponse['error'])) {
+                throw new \Magento\Framework\Exception\LocalizedException("The refund failed. Please make sure the amount is not greater than the limit or negative. Otherwise, refer to the logs for details.");
+            }
+
             // set pspReference as lastTransId only!
             $payment->setLastTransId($singleResponse['pspReference']);
         }

--- a/Helper/Address.php
+++ b/Helper/Address.php
@@ -24,8 +24,9 @@
 
 namespace Adyen\Payment\Helper;
 
+use Adyen\Payment\Api\Data\AddressAdapterInterface;
 use Adyen\Payment\Logger\AdyenLogger;
-use Magento\Payment\Gateway\Data\AddressAdapterInterface;
+use Magento\Payment\Gateway\Data\AddressAdapterInterface as CoreAddressAdapterInterface;
 use Magento\Sales\Api\Data\OrderAddressInterface;
 
 class Address
@@ -64,6 +65,11 @@ class Address
                 $address->getStreetLine2(),
                 $address->getStreetLine3(),
                 $address->getStreetLine4()
+            ];
+        } elseif ($address instanceof CoreAddressAdapterInterface) {
+            $addressArray = [
+                $address->getStreetLine1(),
+                $address->getStreetLine2()
             ];
         } elseif ($address instanceof OrderAddressInterface) {
             $addressArray = $address->getStreet();

--- a/Helper/ChargedCurrency.php
+++ b/Helper/ChargedCurrency.php
@@ -192,7 +192,7 @@ class ChargedCurrency
     }
 
     /**
-     * @param \Magento\Sales\Model\Order\Invoice $invoice
+     * @param Invoice $invoice
      * @return AdyenAmountCurrency
      */
     public function getInvoiceShippingAmountCurrency(Invoice $invoice)
@@ -212,5 +212,25 @@ class ChargedCurrency
             null,
             $invoice->getShippingTaxAmount()
         );
+    }
+
+    /**
+     * @param Invoice $invoice
+     * @return AdyenAmountCurrency
+     */
+    public function getInvoiceAmountCurrency(Invoice $invoice)
+    {
+        $chargedCurrency = $invoice->getOrder()->getAdyenChargedCurrency();
+        if ($chargedCurrency == self::BASE) {
+            return new AdyenAmountCurrency(
+                $invoice->getBaseGrandTotal(),
+                $invoice->getBaseCurrencyCode()
+            );
+        }
+        return new AdyenAmountCurrency(
+            $invoice->getGrandTotal(),
+            $invoice->getOrderCurrencyCode()
+        );
+
     }
 }

--- a/Helper/ChargedCurrency.php
+++ b/Helper/ChargedCurrency.php
@@ -25,6 +25,7 @@ namespace Adyen\Payment\Helper;
 
 use Adyen\Payment\Model\AdyenAmountCurrency;
 use Magento\Quote\Model\Quote;
+use Magento\Sales\Api\Data\CreditmemoInterface;
 use Magento\Sales\Model\Order;
 use Magento\Sales\Model\Order\Invoice;
 use Magento\Sales\Api\Data\CreditmemoItemInterface;
@@ -142,27 +143,94 @@ class ChargedCurrency
     }
 
     /**
+     * @param CreditmemoInterface $creditMemo
+     * @return AdyenAmountCurrency
+     */
+    public function getCreditMemoAmountCurrency(CreditmemoInterface $creditMemo)
+    {
+        $chargedCurrency = $creditMemo->getOrder()->getAdyenChargedCurrency();
+        if ($chargedCurrency == self::BASE) {
+            return new AdyenAmountCurrency(
+                $creditMemo->getBaseGrandTotal(),
+                $creditMemo->getBaseCurrencyCode(),
+                null,
+                $creditMemo->getBaseTaxAmount()
+            );
+        }
+        return new AdyenAmountCurrency(
+            $creditMemo->getGrandTotal(),
+            $creditMemo->getOrderCurrencyCode(),
+            null,
+            $creditMemo->getTaxAmount()
+        );
+    }
+
+
+    /**
+     * @param CreditmemoInterface $creditMemo
+     * @return AdyenAmountCurrency
+     */
+    public function getCreditMemoAdjustmentAmountCurrency(CreditmemoInterface $creditMemo)
+    {
+        $chargedCurrency = $creditMemo->getOrder()->getAdyenChargedCurrency();
+        if ($chargedCurrency == self::BASE) {
+            return new AdyenAmountCurrency(
+                $creditMemo->getBaseAdjustment(),
+                $creditMemo->getBaseCurrencyCode()
+            );
+        }
+        return new AdyenAmountCurrency(
+            $creditMemo->getAdjustment(),
+            $creditMemo->getOrderCurrencyCode()
+        );
+    }
+
+    /**
+     * @param CreditmemoInterface $creditMemo
+     * @return AdyenAmountCurrency
+     */
+    public function getCreditMemoShippingAmountCurrency(CreditmemoInterface $creditMemo)
+    {
+        $chargedCurrency = $creditMemo->getOrder()->getAdyenChargedCurrency();
+        if ($chargedCurrency == self::BASE) {
+            return new AdyenAmountCurrency(
+                $creditMemo->getBaseShippingAmount(),
+                $creditMemo->getBaseCurrencyCode(),
+                null,
+                $creditMemo->getBaseShippingTaxAmount()
+            );
+        }
+        return new AdyenAmountCurrency(
+            $creditMemo->getShippingAmount(),
+            $creditMemo->getOrderCurrencyCode(),
+            null,
+            $creditMemo->getShippingTaxAmount()
+        );
+    }
+
+    /**
      * @param CreditmemoItemInterface $item
      * @return AdyenAmountCurrency
      */
     public function getCreditMemoItemAmountCurrency(CreditmemoItemInterface $item)
     {
-        $chargedCurrency = $item->getCreditMemo()->getInvoice()->getOrder()->getAdyenChargedCurrency();
+        $chargedCurrency = $item->getCreditMemo()->getOrder()->getAdyenChargedCurrency();
         if ($chargedCurrency == self::BASE) {
             return new AdyenAmountCurrency(
                 $item->getBasePrice(),
-                $item->getCreditMemo()->getInvoice()->getBaseCurrencyCode(),
+                $item->getCreditMemo()->getBaseCurrencyCode(),
                 null,
                 $item->getBaseTaxAmount() / $item->getQty()
             );
         }
         return new AdyenAmountCurrency(
             $item->getPrice(),
-            $item->getCreditMemo()->getInvoice()->getOrderCurrencyCode(),
+            $item->getCreditMemo()->getOrderCurrencyCode(),
             null,
             $item->getTaxAmount() / $item->getQty()
         );
     }
+
 
     /**
      * @param Quote $quote

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -61,6 +61,17 @@ class Data extends AbstractHelper
     const CHECKOUT_COMPONENT_JS_TEST = 'https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/4.5.0/adyen.js';
     const PSP_REFERENCE_REGEX = '/(?P<pspReference>[0-9.A-Z]{16})(?P<suffix>[a-z\-]*)/';
 
+    const AFTERPAY = 'afterpay';
+    const AFTERPAY_TOUCH = 'afterpaytouch';
+    const KLARNA = 'klarna';
+    const RATEPAY = 'ratepay';
+    const FACILYPAY = 'facilypay_';
+    const AFFIRM = 'affirm';
+    const CLEARPAY = 'clearpay';
+    const ZIP = 'zip';
+    const PAYBRIGHT = 'paybright';
+
+
     /**
      * @var EncryptorInterface
      */
@@ -986,14 +997,14 @@ class Data extends AbstractHelper
      */
     public function isPaymentMethodOpenInvoiceMethod($paymentMethod)
     {
-        if (strpos($paymentMethod, 'afterpay') !== false ||
-            strpos($paymentMethod, 'klarna') !== false ||
-            strpos($paymentMethod, 'ratepay') !== false ||
-            strpos($paymentMethod, 'facilypay_') !== false ||
-            strpos($paymentMethod, 'affirm') !== false ||
-            strpos($paymentMethod, 'clearpay') !== false ||
-            strpos($paymentMethod, 'zip') !== false ||
-            strpos($paymentMethod, 'paybright') !== false
+        if (strpos($paymentMethod, self::AFTERPAY) !== false ||
+            strpos($paymentMethod, self::KLARNA) !== false ||
+            strpos($paymentMethod, self::RATEPAY) !== false ||
+            strpos($paymentMethod, self::FACILYPAY) !== false ||
+            strpos($paymentMethod, self::AFFIRM) !== false ||
+            strpos($paymentMethod, self::CLEARPAY) !== false ||
+            strpos($paymentMethod, self::ZIP) !== false ||
+            strpos($paymentMethod, self::PAYBRIGHT) !== false
         ) {
             return true;
         }
@@ -1002,12 +1013,34 @@ class Data extends AbstractHelper
     }
 
     /**
+     * Excludes AfterPay (NL/BE) from the open invoice list.
+     * AfterPay variants should be excluded (not afterpaytouch)as an option for auto capture.
+     * @param $paymentMethod
+     * @return bool
+     */
+    public function isPaymentMethodOpenInvoiceMethodValidForAutoCapture($paymentMethod)
+    {
+        if (strpos($paymentMethod, self::AFTERPAY_TOUCH) !== false ||
+            strpos($paymentMethod, self::KLARNA) !== false ||
+            strpos($paymentMethod, self::RATEPAY) !== false ||
+            strpos($paymentMethod, self::FACILYPAY) !== false ||
+            strpos($paymentMethod, self::AFFIRM) !== false ||
+            strpos($paymentMethod, self::CLEARPAY) !== false ||
+            strpos($paymentMethod, self::ZIP) !== false ||
+            strpos($paymentMethod, self::PAYBRIGHT) !== false
+        ) {
+            return true;
+        }
+
+        return false;
+    }
+    /**
      * @param $paymentMethod
      * @return bool
      */
     public function isPaymentMethodRatepayMethod($paymentMethod)
     {
-        if (strpos($paymentMethod, 'ratepay') !== false) {
+        if (strpos($paymentMethod, self::RATEPAY) !== false) {
             return true;
         }
 
@@ -1020,7 +1053,7 @@ class Data extends AbstractHelper
      */
     public function isPaymentMethodAfterpayTouchMethod($paymentMethod)
     {
-        if (strpos($paymentMethod, 'afterpaytouch') !== false) {
+        if (strpos($paymentMethod, self::AFTERPAY_TOUCH) !== false) {
             return true;
         }
 
@@ -1046,7 +1079,7 @@ class Data extends AbstractHelper
      */
     public function isPaymentMethodOneyMethod($paymentMethod)
     {
-        if (strpos($paymentMethod, 'facilypay_') !== false) {
+        if (strpos($paymentMethod, self::FACILYPAY) !== false) {
             return true;
         }
 
@@ -1082,7 +1115,7 @@ class Data extends AbstractHelper
      */
     public function isVatCategoryHigh($paymentMethod)
     {
-        if ($paymentMethod == "klarna" ||
+        if ($paymentMethod == self::KLARNA ||
             strlen($paymentMethod) >= 9 && substr($paymentMethod, 0, 9) == 'afterpay_'
         ) {
             return true;

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -1253,6 +1253,44 @@ class Data extends AbstractHelper
     }
 
     /**
+     * Add a line to the openinvoice data containing the details regarding an adjustment in the refund
+     *
+     * @param $formFields
+     * @param $count
+     * @param $description
+     * @param $adjustmentAmount
+     * @param $currency
+     * @param $payment
+     * @return mixed
+     */
+    public function createOpenInvoiceLineAdjustment(
+        $formFields,
+        $count,
+        $description,
+        $adjustmentAmount,
+        $currency,
+        $payment
+    ) {
+        $itemAmount = $this->formatAmount($adjustmentAmount, $currency);
+        $itemVatAmount = 0;
+        $itemVatPercentage = 0;
+        $numberOfItems = 1;
+
+        return $this->getOpenInvoiceLineData(
+            $formFields,
+            $count,
+            $currency,
+            $description,
+            $itemAmount,
+            $itemVatAmount,
+            $itemVatPercentage,
+            $numberOfItems,
+            $payment,
+            "adjustment"
+        );
+    }
+
+    /**
      * @param $taxAmount
      * @param $priceInclTax
      * @param $price

--- a/Helper/Invoice.php
+++ b/Helper/Invoice.php
@@ -137,7 +137,7 @@ class Invoice extends AbstractHelper
                 $pspReference,
                 $order->getIncrementId(),
                 $originalReference,
-                $order->getIncrementId(),
+                $order->getIncrementId()
             ));
         }
 

--- a/Model/Cron.php
+++ b/Model/Cron.php
@@ -1857,6 +1857,7 @@ class Cron
             case 'svs':
             case 'givex':
             case 'valuelink':
+            case 'twint':
                 $manualCaptureAllowed = true;
                 break;
             default:

--- a/Model/Cron.php
+++ b/Model/Cron.php
@@ -1212,12 +1212,18 @@ class Cron
                  * Returns if the payment method is wallet like wechatpayWeb, amazonpay, applepay, paywithgoogle
                  */
                 $isWalletPaymentMethod = $this->paymentMethodsHelper->isWalletPaymentMethod($orderPaymentMethod);
+
+                /*
+                 * Return if payment method is cc like VI, MI
+                 */
+                $isCCPaymentMethod = $this->_order->getPayment()->getMethod() === 'adyen_cc';
+
                 /*
                 * If the order was made with an Alternative payment method,
                 *  continue with the cancellation only if the payment method of
                 * the notification matches the payment method of the order.
                 */
-                if ( !$isWalletPaymentMethod && strcmp($notificationPaymentMethod, $orderPaymentMethod) !== 0) {
+                if ( !$isWalletPaymentMethod && !$isCCPaymentMethod && strcmp($notificationPaymentMethod, $orderPaymentMethod) !== 0) {
                     $this->_adyenLogger->addAdyenNotificationCronjob(
                         "The notification does not match the payment method of the order,
                     skipping OFFER_CLOSED"

--- a/Model/Cron.php
+++ b/Model/Cron.php
@@ -1759,7 +1759,7 @@ class Cron
 
             // if auto capture mode for openinvoice is turned on then use auto capture
             if ($captureModeOpenInvoice == true &&
-                $this->_adyenHelper->isPaymentMethodOpenInvoiceMethod($this->_paymentMethod)
+                $this->_adyenHelper->isPaymentMethodOpenInvoiceMethodValidForAutoCapture($this->_paymentMethod)
             ) {
                 $this->_adyenLogger->addAdyenNotificationCronjob(
                     'This payment method is configured to be working as auto capture '

--- a/Model/Gender.php
+++ b/Model/Gender.php
@@ -27,8 +27,10 @@ class Gender
 {
     const MALE = '1';
     const FEMALE = '2';
+    const OTHER = '3';
     const MALE_VALUE = 'MALE';
     const FEMALE_VALUE = 'FEMALE';
+    const OTHER_VALUE = 'OTHER';
 
     /**
      * @return array
@@ -37,7 +39,8 @@ class Gender
     {
         return [
             self::MALE_VALUE => __('Male'),
-            self::FEMALE_VALUE => __('Female')
+            self::FEMALE_VALUE => __('Female'),
+            self::OTHER_VALUE => __('Not specified')
         ];
     }
 
@@ -54,6 +57,8 @@ class Gender
             $gender = self::MALE;
         } elseif ($genderValue == self::FEMALE_VALUE) {
             $gender = self::FEMALE;
+        } elseif ($genderValue == self::OTHER_VALUE) {
+            $gender = self::OTHER;
         }
         return $gender;
     }
@@ -69,6 +74,8 @@ class Gender
             $gender = self::MALE_VALUE;
         } elseif ($genderValue == self::FEMALE) {
             $gender = self::FEMALE_VALUE;
+        } elseif ($genderValue == self::OTHER) {
+            $gender = self::OTHER_VALUE;
         }
         return $gender;
     }

--- a/Plugin/GuestPaymentInformationResetOrderId.php
+++ b/Plugin/GuestPaymentInformationResetOrderId.php
@@ -72,7 +72,10 @@ class GuestPaymentInformationResetOrderId
         try {
             $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
             $quoteId = $quoteIdMask->getQuoteId();
-            $this->quoteRepository->get($quoteId)->setReservedOrderId(null);
+            $quote = $this->quoteRepository->get($quoteId);
+            if ($quote->getPayment()->getMethod() !== 'adyen_pos_cloud') {
+                $quote->setReservedOrderId(null);
+            }
         } catch (\Exception $e) {
             $this->adyenLogger->error("Failed to reset reservedOrderId for guest shopper" . $e->getMessage());
         }

--- a/Plugin/PaymentInformationResetOrderId.php
+++ b/Plugin/PaymentInformationResetOrderId.php
@@ -61,7 +61,10 @@ class PaymentInformationResetOrderId
         $cartId
     ) {
         try {
-            $this->quoteRepository->get($cartId)->setReservedOrderId(null);
+            $quote = $this->quoteRepository->get($cartId);
+            if ($quote->getPayment()->getMethod() !== 'adyen_pos_cloud') {
+                $quote->setReservedOrderId(null);
+            }
         } catch (\Exception $e) {
             $this->adyenLogger->error("Failed to reset reservedOrderId " . $e->getMessage());
         }

--- a/Test/Unit/Helper/ChargedCurrencyTest.php
+++ b/Test/Unit/Helper/ChargedCurrencyTest.php
@@ -220,7 +220,9 @@ class ChargedCurrencyTest extends TestCase
                 'getBaseShippingTaxAmount',
                 'getBaseCurrencyCode',
                 'getOrderCurrencyCode',
-                'getOrder'
+                'getOrder',
+                'getGrandTotal',
+                'getBaseGrandTotal'
             ])
             ->getMock();
         $this->mockMethods($this->invoice,
@@ -231,7 +233,9 @@ class ChargedCurrencyTest extends TestCase
                 'getBaseShippingAmount' => self::AMOUNT_CURRENCY['base']['amount'],
                 'getBaseShippingTaxAmount' => self::AMOUNT_CURRENCY['base']['taxAmount'],
                 'getShippingAmount' => self::AMOUNT_CURRENCY['display']['amount'],
-                'getShippingTaxAmount' => self::AMOUNT_CURRENCY['display']['taxAmount']
+                'getShippingTaxAmount' => self::AMOUNT_CURRENCY['display']['taxAmount'],
+                'getGrandTotal' => self::AMOUNT_CURRENCY['display']['amount'],
+                'getBaseGrandTotal' => self::AMOUNT_CURRENCY['base']['amount']
             ]
         );
 
@@ -517,6 +521,34 @@ class ChargedCurrencyTest extends TestCase
                 $result->getAmount(),
                 $result->getCurrencyCode(),
                 $result->getTaxAmount()
+            ]
+        );
+    }
+
+    /**
+     * @dataProvider amountCurrencyProvider
+     * @param $configValue
+     * @param $expectedResult
+     * @param $orderPlacement
+     * @param $getAdyenChargedCurrency
+     */
+    public function testGetInvoiceAmountCurrency(
+        $configValue,
+        AdyenAmountCurrency $expectedResult,
+        $orderPlacement,
+        $getAdyenChargedCurrency
+    ) {
+        $this->order->method('getAdyenChargedCurrency')->willReturn($getAdyenChargedCurrency);
+        $this->chargedCurrencyHelper = new ChargedCurrency($this->configHelper);
+        $result = $this->chargedCurrencyHelper->getInvoiceAmountCurrency($this->invoice);
+        $this->assertEquals(
+            [
+                $expectedResult->getAmount(),
+                $expectedResult->getCurrencyCode()
+            ],
+            [
+                $result->getAmount(),
+                $result->getCurrencyCode()
             ]
         );
     }

--- a/Test/Unit/Helper/ChargedCurrencyTest.php
+++ b/Test/Unit/Helper/ChargedCurrencyTest.php
@@ -27,6 +27,7 @@ use Adyen\Payment\Helper\ChargedCurrency;
 use Adyen\Payment\Helper\Config;
 use Adyen\Payment\Model\AdyenAmountCurrency;
 use Magento\Quote\Model\Quote;
+use Magento\Sales\Api\Data\CreditmemoInterface;
 use Magento\Sales\Api\Data\CreditmemoItemInterface;
 use Magento\Sales\Model\Order;
 use Magento\Sales\Model\Order\Creditmemo\Item;
@@ -96,6 +97,11 @@ class ChargedCurrencyTest extends TestCase
      * @var CreditmemoItemInterface
      */
     private $creditMemoItem;
+
+    /**
+     * @var CreditmemoInterface
+     */
+    private $creditMemo;
 
     protected function setUp(): void
     {
@@ -261,22 +267,51 @@ class ChargedCurrencyTest extends TestCase
             ]
         );
 
-
-        $creditMemo = $this->getMockBuilder(Order\Creditmemo::class)
+        $this->creditMemo = $this->getMockBuilder(Order\Creditmemo::class)
             ->disableOriginalConstructor()
             ->setMethods([
-                'getInvoice'
+                'getBaseGrandTotal',
+                'getBaseCurrencyCode',
+                'getBaseTaxAmount',
+                'getBaseAdjustment',
+                'getBaseShippingAmount',
+                'getBaseShippingTaxAmount',
+                'getGrandTotal',
+                'getOrderCurrencyCode',
+                'getTaxAmount',
+                'getAdjustment',
+                'getShippingAmount',
+                'getShippingTaxAmount',
+                'getInvoice',
+                'getOrder'
             ])
             ->getMock();
-        $creditMemo->method('getInvoice')->willReturn($this->invoice);
+        $this->mockMethods($this->creditMemo,
+            [
+                'getBaseGrandTotal' => self::AMOUNT_CURRENCY['base']['amount'],
+                'getBaseCurrencyCode' => self::AMOUNT_CURRENCY['base']['currencyCode'],
+                'getBaseTaxAmount' => self::AMOUNT_CURRENCY['base']['taxAmount'],
+                'getBaseAdjustment' => self::AMOUNT_CURRENCY['base']['amount'],
+                'getBaseShippingAmount' => self::AMOUNT_CURRENCY['base']['amount'],
+                'getBaseShippingTaxAmount' => self::AMOUNT_CURRENCY['base']['taxAmount'],
+                'getGrandTotal' => self::AMOUNT_CURRENCY['display']['amount'],
+                'getOrderCurrencyCode' => self::AMOUNT_CURRENCY['display']['currencyCode'],
+                'getTaxAmount' => self::AMOUNT_CURRENCY['display']['taxAmount'],
+                'getAdjustment' => self::AMOUNT_CURRENCY['display']['amount'],
+                'getShippingAmount' => self::AMOUNT_CURRENCY['display']['amount'],
+                'getShippingTaxAmount' => self::AMOUNT_CURRENCY['display']['taxAmount'],
+                'getInvoice' => $this->invoice,
+                'getOrder' => $this->order
+            ]
+        );
 
         $this->creditMemoItem = $this->getMockBuilder(Item::class)
             ->disableOriginalConstructor()
             ->setMethods([
                 'getBasePrice',
                 'getPrice',
-                'getInvoice',
                 'getCreditMemo',
+                'getOrder',
                 'getBaseTaxAmount',
                 'getTaxAmount',
                 'getQty'
@@ -285,8 +320,8 @@ class ChargedCurrencyTest extends TestCase
         $this->mockMethods($this->creditMemoItem,
             [
                 'getBasePrice' => self::AMOUNT_CURRENCY['base']['amount'],
-                'getInvoice' => $this->invoice,
-                'getCreditMemo' => $creditMemo,
+                'getCreditMemo' => $this->creditMemo,
+                'getOrder' => $this->order,
                 'getBaseTaxAmount' => self::AMOUNT_CURRENCY['base']['taxAmount'],
                 'getPrice' => self::AMOUNT_CURRENCY['display']['amount'],
                 'getTaxAmount' => self::AMOUNT_CURRENCY['display']['taxAmount'],
@@ -436,13 +471,104 @@ class ChargedCurrencyTest extends TestCase
      * @param $orderPlacement
      * @param $getAdyenChargedCurrency
      */
+    public function testGetCreditMemoAmountCurrency(
+        $configValue,
+        AdyenAmountCurrency $expectedResult,
+        $orderPlacement,
+        $getAdyenChargedCurrency
+    ) {
+        $this->order->method('getAdyenChargedCurrency')->willReturn($getAdyenChargedCurrency);
+        $this->chargedCurrencyHelper = new ChargedCurrency($this->configHelper);
+        $result = $this->chargedCurrencyHelper->getCreditMemoAmountCurrency($this->creditMemo);
+
+        $this->assertEquals(
+            [
+                $expectedResult->getAmount(),
+                $expectedResult->getCurrencyCode(),
+                $expectedResult->getTaxAmount()
+            ],
+            [
+                $result->getAmount(),
+                $result->getCurrencyCode(),
+                $result->getTaxAmount()
+            ]
+        );
+    }
+
+    /**
+     * @dataProvider amountCurrencyProvider
+     * @param $configValue
+     * @param $expectedResult
+     * @param $orderPlacement
+     * @param $getAdyenChargedCurrency
+     */
+    public function testGetCreditMemoAdjustmentAmountCurrency(
+        $configValue,
+        AdyenAmountCurrency $expectedResult,
+        $orderPlacement,
+        $getAdyenChargedCurrency
+    ) {
+        $this->order->method('getAdyenChargedCurrency')->willReturn($getAdyenChargedCurrency);
+        $this->chargedCurrencyHelper = new ChargedCurrency($this->configHelper);
+        $result = $this->chargedCurrencyHelper->getCreditMemoAdjustmentAmountCurrency($this->creditMemo);
+
+        $this->assertEquals(
+            [
+                $expectedResult->getAmount(),
+                $expectedResult->getCurrencyCode()
+            ],
+            [
+                $result->getAmount(),
+                $result->getCurrencyCode()
+            ]
+        );
+    }
+
+    /**
+     * @dataProvider amountCurrencyProvider
+     * @param $configValue
+     * @param $expectedResult
+     * @param $orderPlacement
+     * @param $getAdyenChargedCurrency
+     */
+    public function testGetCreditMemoShippingAmountCurrency(
+        $configValue,
+        AdyenAmountCurrency $expectedResult,
+        $orderPlacement,
+        $getAdyenChargedCurrency
+    ) {
+        $this->order->method('getAdyenChargedCurrency')->willReturn($getAdyenChargedCurrency);
+        $this->chargedCurrencyHelper = new ChargedCurrency($this->configHelper);
+        $result = $this->chargedCurrencyHelper->getCreditMemoShippingAmountCurrency($this->creditMemo);
+
+        $this->assertEquals(
+            [
+                $expectedResult->getAmount(),
+                $expectedResult->getCurrencyCode(),
+                $expectedResult->getTaxAmount()
+            ],
+            [
+                $result->getAmount(),
+                $result->getCurrencyCode(),
+                $result->getTaxAmount()
+            ]
+        );
+    }
+
+    /**
+     * @dataProvider amountCurrencyProvider
+     * @param $configValue
+     * @param $expectedResult
+     * @param $orderPlacement
+     * @param $getAdyenChargedCurrency
+     */
     public function testGetCreditMemoItemAmountCurrency(
         $configValue,
         AdyenAmountCurrency $expectedResult,
         $orderPlacement,
         $getAdyenChargedCurrency
     ) {
-        $this->order->method('getAdyenChargedCurrency')->willReturn($orderPlacement ? $configValue : $getAdyenChargedCurrency);
+        $this->order->method('getAdyenChargedCurrency')->willReturn($getAdyenChargedCurrency);
         $this->chargedCurrencyHelper = new ChargedCurrency($this->configHelper);
         $result = $this->chargedCurrencyHelper->getCreditMemoItemAmountCurrency($this->creditMemoItem);
 

--- a/etc/adminhtml/system/adyen_advanced_order_processing.xml
+++ b/etc/adminhtml/system/adyen_advanced_order_processing.xml
@@ -40,7 +40,7 @@
         </field>
         <field id="auto_capture_openinvoice" translate="label" type="select" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
             <label>Use auto-capture for OpenInvoice payments</label>
-            <tooltip>Applicable for Klarna and AfterPay only. By default OpenInvoice is set to manual capture. If you want auto capture you need to contact magento@adyen.com. After approval has been given, then you can set this option to 'Yes'.</tooltip>
+            <tooltip>Applicable for Klarna, Afterpay Touch, Ratepay, FacilyPay/Oney, Affirm, Clearpay, Zip and PayBright. By default, Open Invoice methods are set to manual capture. If you want auto capture you need to contact magento@adyen.com. After approval has been given you can set this option to 'Yes'.</tooltip>
             <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
             <config_path>payment/adyen_abstract/auto_capture_openinvoice</config_path>
         </field>

--- a/view/adminhtml/templates/form/cc.phtml
+++ b/view/adminhtml/templates/form/cc.phtml
@@ -92,6 +92,7 @@ $ccExpYear = $block->getInfoData('cc_exp_year');
                         hasHolderName: true,
                         installmentOptions: <?= /* @noEscape */ $block->getFormattedInstallments();?>,
                         showInstallmentAmounts: true,
+                        amount :<?= /* @noEscape */ $block->getAmount();?>,
                         onChange: function (state) {
                             if (state.isValid) {
                                 $('#adyen-cc-statedata').val(JSON.stringify(state.data));

--- a/view/adminhtml/templates/info/adyen_pos_cloud.phtml
+++ b/view/adminhtml/templates/info/adyen_pos_cloud.phtml
@@ -90,4 +90,4 @@ $_isDemoMode = $block->isDemoMode();
         padding-bottom: 5px;
     }
 </style>
-<?= $block->escapeHtml($block->getMethod()->getInfoInstance()->getAdditionalInformation('receipt')); ?>
+<?= $block->getMethod()->getInfoInstance()->getAdditionalInformation('receipt'); ?>

--- a/view/frontend/templates/info/adyen_pos_cloud.phtml
+++ b/view/frontend/templates/info/adyen_pos_cloud.phtml
@@ -46,5 +46,5 @@
             padding-bottom: 5px;
         }
     </style>
-    <?= $block->escapeHtml($block->getMethod()->getInfoInstance()->getAdditionalInformation('receipt')); ?>
+    <?= $block->getMethod()->getInfoInstance()->getAdditionalInformation('receipt'); ?>
 </dl>

--- a/view/frontend/web/js/view/payment/method-renderer/adyen-cc-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-cc-method.js
@@ -148,7 +148,7 @@ define(
                                 if (creditCardType in allInstallments) {
                                     // get for the creditcard the installments
                                     var installmentCreditcard = allInstallments[creditCardType];
-                                    var grandTotal = quote.totals().grand_total;
+                                    var grandTotal = self.grandTotal();
                                     var precision = quote.getPriceFormat().precision;
                                     var currencyCode = quote.totals().quote_currency_code;
 
@@ -455,6 +455,14 @@ define(
             },
             getPlaceOrderUrl: function() {
                 return window.checkoutConfig.payment.iframe.placeOrderUrl[this.getCode()];
+            },
+            grandTotal: function () {
+                for (const totalsegment of quote.getTotals()()['total_segments']) {
+                    if (totalsegment.code === 'grand_total') {
+                        return totalsegment.value;
+                    }
+                }
+                return quote.totals().grand_total;
             },
         });
     }


### PR DESCRIPTION
**Description**
The release for 7.3.2 containing all the patches. (Original 7.3.2 release apparently contained the changes from v8)

Fixes
[PW-5446] Now capturing amount in correct currency when setting a different display currency #1197
[PW-5668] Patch for OFFER_CLOSED flow with cc #1215
Removed trailing comma #1237
Patch for terminal API error #1247
[PW-5682] Added refund adjustment functionality for openinvoice data #1213
[PW-5812] CAPTURE_FAILED notification sent after order captured #1234
Fix for AddressAdapterInterface incompatibility #1240
POS Cloud HTML receipt is escaped #1252
Add extra gender option #1241
[PW-4187] Remove AfterPay as an option for auto capture #1203
[PW-5319] Filter parameters sent in paymentDetails call #1206
[PW-5660] Installments adding to grand total the taxes #1214 
[PW-5034]Add amount to checkout component for installments in admin #1221

