### PR TITLE
[PW-5915]Add address regex for special characters for version 6

### DIFF
--- a/Helper/Address.php
+++ b/Helper/Address.php
@@ -45,9 +45,8 @@ class Address
 
 
     // Regex to extract the house number from the street line if needed (e.g. 'Street address 1 A' => '1 A')
-    const STREET_FIRST_REGEX = "/(?<streetName>[a-zA-Z0-9.'\- ]+)\s+(?<houseNumber>\d{1,10}((\s)?\w{1,3})?)$/";
-    CONST NUMBER_FIRST_REGEX = "/^(?<houseNumber>\d{1,10}((\s)?\w{1,3})?)\s+(?<streetName>[a-zA-Z0-9.'\- ]+)/";
-
+    const STREET_FIRST_REGEX = "/(?<streetName>[A-Za-zÀ-ÖØ-öø-ÿ0-9.'\- ]+)\s+(?<houseNumber>\d{1,10}((\s)?\w{1,3})?)$/";
+    const NUMBER_FIRST_REGEX = "/^(?<houseNumber>\d{1,10}((\s)?\w{1,3})?)\s+(?<streetName>[A-Za-zÀ-ÖØ-öø-ÿ0-9.'\- ]+)/";
     /**
      * @param $address
      * @param $houseNumberStreetLine


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Polish addresses are not parsed properly because of the special characters.
Improving the regex which extract the house number from the street line if needed fixes that issue
**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- Address without special characters
- Address with special characters
**Fixed issue**:  <!-- #-prefixed issue number -->