### PR TITLE
[PW-5915]Add address regex for special characters for version 7

### DIFF
--- a/Helper/Address.php
+++ b/Helper/Address.php
@@ -45,8 +45,8 @@ class Address
     }
 
     // Regex to extract the house number from the street line if needed (e.g. 'Street address 1 A' => '1 A')
-    const STREET_FIRST_REGEX = "/(?<streetName>[a-zA-Z0-9.'\- ]+)\s+(?<houseNumber>\d{1,10}((\s)?\w{1,3})?)$/";
-    CONST NUMBER_FIRST_REGEX = "/^(?<houseNumber>\d{1,10}((\s)?\w{1,3})?)\s+(?<streetName>[a-zA-Z0-9.'\- ]+)/";
+    const STREET_FIRST_REGEX = "/(?<streetName>[A-Za-zÀ-ÖØ-öø-ÿ0-9.'\- ]+)\s+(?<houseNumber>\d{1,10}((\s)?\w{1,3})?)$/";
+    const NUMBER_FIRST_REGEX = "/^(?<houseNumber>\d{1,10}((\s)?\w{1,3})?)\s+(?<streetName>[a-zA-Z0-9.'\- ]+)/";
 
     /**
      * @param AddressAdapterInterface $address

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "adyen/module-payment",
   "description": "Official Magento2 Plugin to connect to Payment Service Provider Adyen.",
   "type": "magento2-module",
-  "version": "7.3.0",
+  "version": "7.3.1",
   "license": [
     "OSL-3.0",
     "AFL-3.0"

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "adyen/module-payment",
   "description": "Official Magento2 Plugin to connect to Payment Service Provider Adyen.",
   "type": "magento2-module",
-  "version": "7.3.1",
+  "version": "7.3.2",
   "license": [
     "OSL-3.0",
     "AFL-3.0"

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -24,7 +24,7 @@
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
 
-    <module name="Adyen_Payment" setup_version="7.3.1">
+    <module name="Adyen_Payment" setup_version="7.3.2">
         <sequence>
             <module name="Magento_Sales"/>
             <module name="Magento_Quote"/>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -24,7 +24,7 @@
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
 
-    <module name="Adyen_Payment" setup_version="7.3.0">
+    <module name="Adyen_Payment" setup_version="7.3.1">
         <sequence>
             <module name="Magento_Sales"/>
             <module name="Magento_Quote"/>


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Polish addresses are not parsed properly because of the special characters.
Improving the regex which extract the house number from the street line if needed fixes that issue
**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- Address without special characters
- Address with special characters
