### PR TITLE
[PW-5924] fix check for unrendered LPMs in multishipping (v7)

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/multishipping/adyen-hpp-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/multishipping/adyen-hpp-method.js
@@ -249,9 +249,10 @@ define([
         selectPaymentMethodType: function() {
             var self = this;
             $('#stateData').val('');
+            let paymentMethod = self.paymentMethod;
             let stateData;
-            if (!('component' in self)) {
-                let paymentMethod = self.paymentMethod;
+            if ($.trim($('#adyen-alternative-payment-container-' +
+                paymentMethod.methodIdentifier).html())==='') {
                 stateData = {
                     paymentMethod: {
                         type: paymentMethod.type

--- a/view/frontend/web/js/view/payment/method-renderer/multishipping/adyen-hpp-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/multishipping/adyen-hpp-method.js
@@ -250,10 +250,9 @@ define([
             var self = this;
             $('#stateData').val('');
             let paymentMethod = self.paymentMethod;
-            let stateData;
-            if ($.trim($('#adyen-alternative-payment-container-' +
-                paymentMethod.methodIdentifier).html())==='') {
-                stateData = {
+            const isEmptyContainer = $('#adyen-alternative-payment-container-' + paymentMethod.methodIdentifier).children().size() === 0;
+            if (isEmptyContainer) {
+                let stateData = {
                     paymentMethod: {
                         type: paymentMethod.type
                     }


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Fix how we set the state data for LPMs that do not have a rendered component.
[Currently](https://github.com/Adyen/adyen-magento2/blob/712da7349a0bc9f28ff09d07a03d24fda36072b3/view/frontend/web/js/view/payment/method-renderer/multishipping/adyen-hpp-method.js#L253) we check for the existence of a `component` in the LPM .
But this only works for LPMs which failed to render, because we [try to set](https://github.com/Adyen/adyen-magento2/blob/fbdbfad10b5a80b7c2798d061ec624d2f4560b95/view/frontend/web/js/view/payment/method-renderer/adyen-hpp-method.js#L774) the `component` property for every LPM.
This means that we are unable to click 'Proceed' in multishipping when we select for example Klarna or Bank Transfer.

***Fix:*** Updated the logic in `view/frontend/web/js/view/payment/method-renderer/multishipping/adyen-hpp-method.js` to check whether component is rendered in the page and set the stateData if it isn't rendered.
**Tested scenarios**
<!-- Description of tested scenarios -->
- Proceed with banktransfer, stateData is set manually
- Proceed with giftcard, stateData is set manually
- Proceed with Klarna, stateData is set manually
- Proceed with ideal, Sepa direct debit, stateData is generated from component and set
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

