### PR TITLE
Adding Adyen configs to GraphQL Store Config

### DIFF
--- a/etc/graphql/di.xml
+++ b/etc/graphql/di.xml
@@ -16,7 +16,7 @@
             <argument name="extendedConfigData" xsi:type="array">
                 <item name="adyen_client_key_test" xsi:type="string">payment/adyen_abstract/client_key_test</item>
                 <item name="adyen_client_key_live" xsi:type="string">payment/adyen_abstract/client_key_live</item>
-                <item name="adyen_environment" xsi:type="string">payment/adyen_abstract/demo_mode</item>
+                <item name="demo_mode" xsi:type="string">payment/adyen_abstract/demo_mode</item>
             </argument>
         </arguments>
     </type>

--- a/etc/graphql/di.xml
+++ b/etc/graphql/di.xml
@@ -11,4 +11,13 @@
             </argument>
         </arguments>
     </type>
+    <type name="Magento\StoreGraphQl\Model\Resolver\Store\StoreConfigDataProvider">
+        <arguments>
+            <argument name="extendedConfigData" xsi:type="array">
+                <item name="adyen_client_key_test" xsi:type="string">payment/adyen_abstract/client_key_test</item>
+                <item name="adyen_client_key_live" xsi:type="string">payment/adyen_abstract/client_key_live</item>
+                <item name="adyen_environment" xsi:type="string">payment/adyen_abstract/demo_mode</item>
+            </argument>
+        </arguments>
+    </type>
 </config>

--- a/etc/schema.graphqls
+++ b/etc/schema.graphqls
@@ -126,5 +126,5 @@ input AdyenAdditionalDataPosCloud {
 type StoreConfig @doc(description: "The type contains information about a store config") {
     adyen_client_key_test : String @doc(description: "Adyen client key for TEST environment.")
     adyen_client_key_live : String @doc(description: "Adyen client key for LIVE environment.")
-    adyen_environment : String @doc(description: "Adyen configured environment mode, LIVE or TEST.")
+    demo_mode : String @doc(description: "Adyen demo mode enabled (TEST).")
 }

--- a/etc/schema.graphqls
+++ b/etc/schema.graphqls
@@ -126,5 +126,5 @@ input AdyenAdditionalDataPosCloud {
 type StoreConfig @doc(description: "The type contains information about a store config") {
     adyen_client_key_test : String @doc(description: "Adyen client key for TEST environment.")
     adyen_client_key_live : String @doc(description: "Adyen client key for LIVE environment.")
-    demo_mode : String @doc(description: "Adyen demo mode enabled (TEST).")
+    adyen_demo_mode : String @doc(description: "Adyen demo mode enabled (TEST).")
 }

--- a/etc/schema.graphqls
+++ b/etc/schema.graphqls
@@ -122,3 +122,9 @@ input AdyenAdditionalDataPosCloud {
     number_of_installments: Int @doc(description: "Number of installments for the payment.")
     terminal_id: String @doc(description: "Terminal ID of selected terminal.")
 }
+
+type StoreConfig @doc(description: "The type contains information about a store config") {
+    adyen_client_key_test : String @doc(description: "Adyen client key for TEST environment.")
+    adyen_client_key_live : String @doc(description: "Adyen client key for LIVE environment.")
+    adyen_environment : String @doc(description: "Adyen configured environment mode, LIVE or TEST.")
+}


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
Extending GraphQL StoreConfig with Adyen config data.

**Tested scenarios**
StoreConfig query returning `adyen_client_key_test`, `adyen_client_key_live` and `demo_mode`

**Fixed issue**:  NA