### PR TITLE
PW-5831 Fix multishipping for Magento payment methods

### DIFF
--- a/view/frontend/web/js/view/checkout/multishipping/payment-mixin.js
+++ b/view/frontend/web/js/view/checkout/multishipping/payment-mixin.js
@@ -30,7 +30,14 @@ define([
             widgetFullName,
             jQuery[originalWidget.prototype.namespace][originalWidget.prototype.widgetName], {
                 _validatePaymentMethod: function () {
-                    return !!$('#stateData').val() && this._super();
+                    let isValid;
+                    let selectedPaymentMethod = $('#payment-methods input[name="payment[method]"]:checked').val();
+                    if (selectedPaymentMethod.startsWith('adyen')) {
+                        isValid = !!$('#stateData').val();
+                    } else {
+                        isValid = true;
+                    }
+                    return isValid && this._super();
                 }
             });
     }

--- a/view/frontend/web/js/view/checkout/multishipping/payment-mixin.js
+++ b/view/frontend/web/js/view/checkout/multishipping/payment-mixin.js
@@ -32,7 +32,7 @@ define([
                 _validatePaymentMethod: function () {
                     let isValid;
                     let selectedPaymentMethod = $('#payment-methods input[name="payment[method]"]:checked').val();
-                    if (selectedPaymentMethod.startsWith('adyen')) {
+                    if (!!selectedPaymentMethod && selectedPaymentMethod.startsWith('adyen')) {
                         isValid = !!$('#stateData').val();
                     } else {
                         isValid = true;


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
When trying to use multishipping outside of Adyen's payment methods, Go to Review Your Order Button does not work. In addition, multishipping works without issues for Adyen payment methods.
This is caused by our `_validatePaymentMethod` mixin method which is used to disable the button.

Add update to `_validatePaymentMethod` to only check for valid stateData if selected Payment method is Adyen PM

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- Select non-Adyen PMs in multishipping billing step
- Select Adyen PM with rendered checkout component
- Select Adyen PM with no checkout component