### PR TITLE
fix for capture offline issue

### DIFF
--- a/Helper/Invoice.php
+++ b/Helper/Invoice.php
@@ -206,7 +206,7 @@ class Invoice extends AbstractHelper
 
         foreach ($invoiceCollection as $invoice) {
             $parsedTransId = $this->adyenDataHelper->parseTransactionId($invoice->getTransactionId());
-            if ($parsedTransId['pspReference'] === $originalReference) {
+            if (isset($parsedTransId['pspReference']) && $parsedTransId['pspReference'] === $originalReference) {
                 $returnInvoice = $invoice;
             }
         }


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
There is a possibility to create an invoice with capture offline in Magento. 
![image](https://user-images.githubusercontent.com/60093690/146159164-5330d87f-c57e-4e53-8762-71a3dc9db792.png)

This capture does not trigger any request to Adyen, so for that invoice, there is no PSP reference. When that invoice is the partial one and the second invoice is created with capture online, then an unexpected error is shown in the order history comments section:
![image](https://user-images.githubusercontent.com/60093690/146159221-84075258-d475-478d-b466-99b933d04958.png)

It is fixed by adding an additional check if the PSP reference exists before comparing its value.

**Tested scenarios**
1. Create a partial invoice with capture offline.
2. Create a second partial invoice with capture online.
3. An error is displayed in the order history comments section: "The order failed to update. Notice: Undefined index: pspReference in /app/vendor/adyen/module-payment/Helper/Invoice.php on line 211"

**Fixed issue**:  <!-- #-prefixed issue number -->