### PR TITLE
[PW-6001] Use storePaymentMethodMode on Pay by Link v68

### DIFF
--- a/Gateway/Request/RecurringDataBuilder.php
+++ b/Gateway/Request/RecurringDataBuilder.php
@@ -62,11 +62,13 @@ class RecurringDataBuilder implements BuilderInterface
         $paymentDataObject = \Magento\Payment\Gateway\Helper\SubjectReader::readPayment($buildSubject);
         $payment = $paymentDataObject->getPayment();
         $storeId = $payment->getOrder()->getStoreId();
-        $request['body'] = $this->adyenRequestsHelper->buildRecurringData(
-            $storeId,
-            $payment,
-            []
-        );
+        $request = [
+            'body' => $this->adyenRequestsHelper->buildRecurringData(
+                $storeId,
+                $payment,
+                []
+            )
+        ];
         return $request;
     }
 }

--- a/Helper/Requests.php
+++ b/Helper/Requests.php
@@ -358,7 +358,7 @@ class Requests extends AbstractHelper
         $storedPaymentMethodsEnabled = $this->adyenHelper->getAdyenOneclickConfigData('active', $storeId);
         $stateData = $payment->getAdditionalInformation('stateData');
 
-        if ('adyen_pay_by_link' === $payment->getMethod()) {
+        if ($payment->getMethod() === AdyenPayByLinkConfigProvider::CODE) {
             $request['storePaymentMethodMode'] = 'askForConsent';
         } else {
             $request['storePaymentMethod'] = (bool)($stateData['storePaymentMethod'] ?? $storedPaymentMethodsEnabled);

--- a/Helper/Requests.php
+++ b/Helper/Requests.php
@@ -356,9 +356,13 @@ class Requests extends AbstractHelper
         $enableOneclick = $this->adyenHelper->getAdyenAbstractConfigData('enable_oneclick', $storeId);
         $enableVault = $this->adyenHelper->isCreditCardVaultEnabled();
         $storedPaymentMethodsEnabled = $this->adyenHelper->getAdyenOneclickConfigData('active', $storeId);
-
         $stateData = $payment->getAdditionalInformation('stateData');
-        $request['storePaymentMethod'] = (bool)($stateData['storePaymentMethod'] ?? $storedPaymentMethodsEnabled);
+
+        if ('adyen_pay_by_link' === $payment->getMethod()) {
+            $request['storePaymentMethodMode'] = 'askForConsent';
+        } else {
+            $request['storePaymentMethod'] = (bool)($stateData['storePaymentMethod'] ?? $storedPaymentMethodsEnabled);
+        }
 
         //recurring
         if ($storedPaymentMethodsEnabled) {


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->

In v68 the parameter `storePaymentMethod` was renamed to `storePaymentMethodMode`. 

https://docs.adyen.com/online-payments/release-notes#releaseNote=2021-10-06-checkout-api-68

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

* Admin PBL order
