### PR TITLE
Set valid tax percentage for shipment

### DIFF
--- a/Gateway/Request/CheckoutDataBuilder.php
+++ b/Gateway/Request/CheckoutDataBuilder.php
@@ -338,6 +338,11 @@ class CheckoutDataBuilder implements BuilderInterface
                 $currency
             );
 
+            $formattedTaxPercentage = $this->adyenHelper->formatAmount(
+                (($formattedPriceIncludingTax - $formattedPriceExcludingTax) / $formattedPriceExcludingTax) * 100,
+                $currency
+            );
+
             $formFields['lineItems'][] = [
                 'id' => 'shippingCost',
                 'amountExcludingTax' => $formattedPriceExcludingTax,
@@ -345,7 +350,7 @@ class CheckoutDataBuilder implements BuilderInterface
                 'taxAmount' => $formattedTaxAmount,
                 'description' => $order->getShippingDescription(),
                 'quantity' => 1,
-                'taxPercentage' => ($formattedTaxAmount / $formattedPriceExcludingTax) * 100 * 100
+                'taxPercentage' => $formattedTaxPercentage
             ];
         }
 


### PR DESCRIPTION
**Description**
`taxPercentage` for shipment might be impossible to parse when requesting a payment link (`\Adyen\Payment\Gateway\Http\Client\TransactionPaymentLinks::placeRequest()`):
```
The 'taxPercentage' field is invalid. Failed to parse [2093.4959349593] as Long
```

**Tested scenarios**
```php
$formFields['lineItems'][] = [
    'id' => 'shippingCost',
    'amountExcludingTax' => 492,
    'amountIncludingTax' => 595,
    'taxAmount' => 103,
    'taxPercentage' => (103 / 492) * 100 * 100
];
```

(103 / 492) * 100 * 100 = 2093.4959349593

With this change it will format 20.93% to `2093` as taxPercentage.