### PR TITLE
[PW-6134] Fix missing quote id on admin orders

### DIFF
--- a/Gateway/Request/CcBackendAuthorizationDataBuilder.php
+++ b/Gateway/Request/CcBackendAuthorizationDataBuilder.php
@@ -50,7 +50,8 @@ class CcBackendAuthorizationDataBuilder implements BuilderInterface
         /** @var PaymentDataObject $paymentDataObject */
         $paymentDataObject = SubjectReader::readPayment($buildSubject);
         $payment = $paymentDataObject->getPayment();
-        $requestBody = $this->stateData->getStateData($payment->getData('quote_id'));
+        $order = $paymentDataObject->getOrder();
+        $requestBody = $this->stateData->getStateData($order->getQuoteId());
 
         // if installments is set add it into the request
         $installments = $payment->getAdditionalInformation(AdyenCcDataAssignObserver::NUMBER_OF_INSTALLMENTS) ?: 0;


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->

The expression `$payment->getData('quote_id')` returns `null` causing an exception due to the lack of a required parameter. Fix it by using quote id from the order. 

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
Admin orders: 
* Pay by link
* Credit card
