### PR TITLE
[PW-6047] - Verify that component is defined when handling decline flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,9 @@ Inside Adyen toggle the following settings on inside the API and Responses secti
 * Variant
 
 ## Requirements
-This plugin supports Magento2 version 
-* 2.2.9 and higher
-* 2.3.1 and higher
-* 2.4 
+This plugin supports Magento2 version
+* 2.3.7 and higher
+* 2.4 and higher
 
 ## Contributing
 We strongly encourage you to join us in contributing to this repository so everyone can benefit from:

--- a/view/frontend/web/js/view/payment/method-renderer/adyen-hpp-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-hpp-method.js
@@ -323,7 +323,7 @@ define(
                         self.currentMessageContainer),
                 ).fail(
                     function(response) {
-                        if (component.props.methodIdentifier == 'amazonpay') {
+                        if (component && component.props.methodIdentifier === 'amazonpay') {
                             component.handleDeclineFlow();
                         }
                         self.isPlaceOrderActionAllowed(true);


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
Currently, when a redirect payment method fails, the `component.handleDeclineFlow()` function is called. However there is a case (giftcard) where the component will not be mounted which implies that this will be called on an undefined variable.

This PR will add a check to mitigate this edge case.

**Tested scenarios**
* Successful giftcard flow
* Failed giftcard flow