### PR TITLE
[PW-5815]Handle declined flow  

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/adyen-hpp-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-hpp-method.js
@@ -753,10 +753,7 @@ define(
                             var self = this;
                             await self.handleOnSubmit(state.data, amazonPayComponent);
                         } catch (error) {
-                            debugger;
                             amazonPayComponent.handleDeclineFlow();
-                            //go to failed page
-                            self.handleOnSubmit(state.data, amazonPayComponent);
                         }
                     };
                     if (formattedShippingAddress &&

--- a/view/frontend/web/js/view/payment/method-renderer/adyen-hpp-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-hpp-method.js
@@ -472,7 +472,7 @@ define(
                     }
 
                     data.additional_data = additionalData;
-                     this.placeRedirectOrder(data, component);
+                    this.placeRedirectOrder(data, component);
                 }
 
                 return false;
@@ -742,16 +742,20 @@ define(
                         configuration.totalPriceLabel = configuration.configuration.merchantName;
                     }
                 }
+
                 // Extra amazon pay configuration first call to amazon page
                 if (paymentMethod.methodIdentifier.includes('amazonpay')) {
                     configuration.productType = 'PayAndShip';
                     configuration.checkoutMode = 'ProcessOrder';
-                    configuration.returnUrl = location.href;
+                    var url = new URL(location.href);
+                    if (url.searchParams.has('amazonCheckoutSessionId')) {
+                        url.searchParams.delete('amazonCheckoutSessionId');
+                    }
+                    configuration.returnUrl = url.href;
                     configuration.onSubmit = (state, amazonPayComponent) => {
                         try {
                             self.handleOnSubmit(state.data, amazonPayComponent);
                         } catch (error) {
-                            //try this one first
                             amazonPayComponent.handleDeclineFlow();
                         }
                     };
@@ -792,16 +796,12 @@ define(
                                 currency: configuration.amount.currency,
                                 value: configuration.amount.value
                             },
-                            returnUrl: location.href,
                             showChangePaymentDetailsButton: false
                         }).mount(containerId);
                         amazonPayComponent.submit();
                         result.component = amazonPayComponent;
                     }
-                    if (url.searchParams.has(amazonSessionKey)) {
-                        url.searchParams.delete(amazonSessionKey);
-                        history.replaceState(null, '', '?' + url.searchParams + location.hash);
-                    }
+
                     const component = self.checkoutComponent.create(
                         paymentMethod.methodIdentifier, configuration);
                     if ('isAvailable' in component) {

--- a/view/frontend/web/js/view/payment/method-renderer/adyen-hpp-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-hpp-method.js
@@ -750,7 +750,6 @@ define(
                     configuration.returnUrl = location.href;
                     configuration.onSubmit = async(state, amazonPayComponent) => {
                         try {
-                            var self = this;
                             await self.handleOnSubmit(state.data, amazonPayComponent);
                         } catch (error) {
                             amazonPayComponent.handleDeclineFlow();


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
With this pr we are adding the `handleDeclineFlow` which redirects from checkout page back to the amazon pay page to choose another card. This response includes pspreference and others declined payment information. 
Testing using the amazon pay declined cards returns only an error message `AmazonPay internal error: Unknown issue has occured while processing. `  For this case the component is remount with the current return url and amazonsessionkey


**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

- [x] Happy flow
- [x] Choose a declined card
- [x] 3ds Declined - wrong password
- [x] 3DS Happy flow
- [x] From Declined to happy flow
- [x] CC
- [x] klarna