### PR TITLE
Set amount authorized in sales_order_payment for hpp payment methods

### DIFF
--- a/Model/Cron.php
+++ b/Model/Cron.php
@@ -1521,6 +1521,8 @@ class Cron
         if ($isFullAmountAuthorized) {
             $this->_setPrePaymentAuthorized();
             $this->_prepareInvoice();
+            //set authorized amount in sales_order_payment
+            $this->_order->getPayment()->setAmountAuthorized($this->orderAmount);
         } else {
             $this->addProcessedStatusHistoryComment();
         }


### PR DESCRIPTION

<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
`amount_authorized` field in `sales_order_payment` table was not getting populated for Adyen HPP 
but the credit cards are already initialized in magento `Payment.php` so the table is updating properly
With this PR when receiving a `AUTHORISATION` notification and the amount is full authorised then the amount is updated in the `sales_order_payment` table

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
Tested for CC and IDeal 