### PR TITLE
Revert "[PW-5070] Fix coupon counted as 'used' on canceled order in 3DS2 and rerouted 3DS1 flow (#1305)

### DIFF
--- a/Controller/Process/Result.php
+++ b/Controller/Process/Result.php
@@ -26,7 +26,6 @@ namespace Adyen\Payment\Controller\Process;
 use Adyen\Payment\Helper\StateData;
 use \Adyen\Payment\Model\Notification;
 use Adyen\Service\Validator\DataArrayValidator;
-use Adyen\Payment\Helper\PaymentResponseHandler;
 use Magento\Framework\App\Request\Http as Http;
 use Magento\Sales\Model\Order;
 
@@ -110,11 +109,6 @@ class Result extends \Magento\Framework\App\Action\Action
     private $stateDataHelper;
 
     /**
-     * @var PaymentResponseHandler
-     */
-    private $paymentResponseHandler;
-
-    /**
      * Result constructor.
      *
      * @param \Magento\Framework\App\Action\Context $context
@@ -125,10 +119,6 @@ class Result extends \Magento\Framework\App\Action\Action
      * @param \Adyen\Payment\Logger\AdyenLogger $adyenLogger
      * @param \Magento\Store\Model\StoreManagerInterface $storeManager
      * @param \Adyen\Payment\Helper\Quote $quoteHelper
-     * @param \Adyen\Payment\Helper\Vault $vaultHelper
-     * @param \Magento\Sales\Model\ResourceModel\Order $orderResourceModel
-     * @param StateData $stateDataHelper
-     * @param PaymentResponseHandler $paymentResponseHandler
      */
     public function __construct(
         \Magento\Framework\App\Action\Context $context,
@@ -141,8 +131,7 @@ class Result extends \Magento\Framework\App\Action\Action
         \Adyen\Payment\Helper\Quote $quoteHelper,
         \Adyen\Payment\Helper\Vault $vaultHelper,
         \Magento\Sales\Model\ResourceModel\Order $orderResourceModel,
-        StateData $stateDataHelper,
-        PaymentResponseHandler $paymentResponseHandler
+        StateData $stateDataHelper
     ) {
         $this->_adyenHelper = $adyenHelper;
         $this->_orderFactory = $orderFactory;
@@ -154,7 +143,6 @@ class Result extends \Magento\Framework\App\Action\Action
         $this->vaultHelper = $vaultHelper;
         $this->orderResourceModel = $orderResourceModel;
         $this->stateDataHelper = $stateDataHelper;
-        $this->paymentResponseHandler = $paymentResponseHandler;
         parent::__construct($context);
     }
 
@@ -527,7 +515,6 @@ class Result extends \Magento\Framework\App\Action\Action
 
         try {
             $response = $service->paymentsDetails($request);
-            $this->paymentResponseHandler->handlePaymentResponse($response, $this->payment, $order);
             $responseMerchantReference = !empty($response['merchantReference']) ? $response['merchantReference'] : null;
             $resultMerchantReference = !empty($result['merchantReference']) ? $result['merchantReference'] : null;
             $merchantReference = $responseMerchantReference ?: $resultMerchantReference;


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->

This reverts commit e83eb5775618c4b4065f971343ea1fff6fd02026.

The fix for PW-5070 is throwing an error during refusal of a multi shipping payment: 
```
Exception #0 (Zend_Db_Statement_Exception): SQLSTATE[23000]: Integrity constraint violation: 1452 Cannot add or update a child row: a foreign key constraint fails (`magento`.`salesrule_customer`, CONSTRAINT `SALESRULE_CUSTOMER_RULE_ID_SALESRULE_RULE_ID` FOREIGN KEY (`rule_id`) REFERENCES `salesrule` (`rule_id`) ON DELETE CASCADE), query was: INSERT INTO `salesrule_customer` () VALUES ()
Exception #1 (PDOException): SQLSTATE[23000]: Integrity constraint violation: 1452 Cannot add or update a child row: a foreign key constraint fails (`magento`.`salesrule_customer`, CONSTRAINT `SALESRULE_CUSTOMER_RULE_ID_SALESRULE_RULE_ID` FOREIGN KEY (`rule_id`) REFERENCES `salesrule` (`rule_id`) ON DELETE CASCADE)
```

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
* Regular flow works
* Multi-shipping success/failure