### PR TITLE
[PW-5815] Handle declined flow

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/adyen-hpp-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-hpp-method.js
@@ -310,7 +310,7 @@ define(
 
                 return result;
             },
-            placeRedirectOrder: function(data, component) {
+            placeRedirectOrder: async function(data, component) {
                 var self = this;
 
                 // Place Order but use our own redirect url after
@@ -318,14 +318,11 @@ define(
                 $('.hpp-message').slideUp();
                 self.isPlaceOrderActionAllowed(false);
 
-                $.when(
+               await $.when(
                     placeOrderAction(data,
                         self.currentMessageContainer),
                 ).fail(
                     function(response) {
-                        if (component && component.props.methodIdentifier === 'amazonpay') {
-                            component.handleDeclineFlow();
-                        }
                         self.isPlaceOrderActionAllowed(true);
                         fullScreenLoader.stopLoader();
                         self.showErrorMessage(response);
@@ -460,7 +457,7 @@ define(
                     mount(actionNode);
                 }
             },
-            handleOnSubmit: function(state, component) {
+            handleOnSubmit: async function(state, component) {
                 if (this.validate()) {
                     var data = {};
                     data.method = this.getCode();
@@ -477,7 +474,7 @@ define(
                     }
 
                     data.additional_data = additionalData;
-                    this.placeRedirectOrder(data, component);
+                    await this.placeRedirectOrder(data, component);
                 }
 
                 return false;
@@ -750,7 +747,18 @@ define(
                 if (paymentMethod.methodIdentifier.includes('amazonpay')) {
                     configuration.productType = 'PayAndShip';
                     configuration.checkoutMode = 'ProcessOrder';
-                    configuration.returnUrl = location.href;
+                    var url = new URL(location.href);
+                    if (url.searchParams.has('amazonCheckoutSessionId')) {
+                        url.searchParams.delete('amazonCheckoutSessionId');
+                    }
+                    configuration.returnUrl = url.href;
+                    configuration.onSubmit = async (state, amazonPayComponent) => {
+                        try {
+                           await self.handleOnSubmit(state.data, amazonPayComponent);
+                        } catch (error) {
+                            amazonPayComponent.handleDeclineFlow();
+                        }
+                    };
 
                     if (formattedShippingAddress &&
                         formattedShippingAddress.telephone) {
@@ -789,25 +797,24 @@ define(
                                 currency: configuration.amount.currency,
                                 value: configuration.amount.value
                             },
-                            returnUrl: location.href,
                             showChangePaymentDetailsButton: false
                         }).mount(containerId);
                         amazonPayComponent.submit();
                         result.component = amazonPayComponent;
-                    } else {
-                        const component = self.checkoutComponent.create(
-                            paymentMethod.methodIdentifier, configuration);
-                        if ('isAvailable' in component) {
-                            component.isAvailable().then(() => {
-                                component.mount(containerId);
-                            }).catch(e => {
-                                result.isAvailable(false);
-                            });
-                        } else {
-                            component.mount(containerId);
-                        }
-                        result.component = component;
                     }
+                    const component = self.checkoutComponent.create(
+                        paymentMethod.methodIdentifier, configuration);
+                    if ('isAvailable' in component) {
+                        component.isAvailable().then(() => {
+                            component.mount(containerId);
+                        }).catch(e => {
+                            result.isAvailable(false);
+                        });
+                    } else {
+                        component.mount(containerId);
+                    }
+                    result.component = component;
+
                 } catch (err) {
                     // The component does not exist yet
                     if ('test' === adyenConfiguration.getCheckoutEnvironment()) {

--- a/view/frontend/web/js/view/payment/method-renderer/adyen-hpp-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-hpp-method.js
@@ -748,9 +748,7 @@ define(
                     configuration.productType = 'PayAndShip';
                     configuration.checkoutMode = 'ProcessOrder';
                     var url = new URL(location.href);
-                    if (url.searchParams.has('amazonCheckoutSessionId')) {
-                        url.searchParams.delete('amazonCheckoutSessionId');
-                    }
+                    url.searchParams.delete('amazonCheckoutSessionId');
                     configuration.returnUrl = url.href;
                     configuration.onSubmit = async (state, amazonPayComponent) => {
                         try {


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
With this pr we are adding the `handleDeclineFlow` which redirects from checkout page back to the amazon pay page to choose another card. For this case the response includes the declined payment information. 
Testing using the amazon pay declined cards returns only an error message `AmazonPay internal error: Unknown issue has occurred while processing. `  For this case the component is remounted with the current return url using the url `amazonsessionkey` 

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

- [x] Amazon pay Happy flow 
- [x] Choose a declined card
- [x] Decline from Adyen with test code 
- [x] 3DS Declined - wrong password
- [x] 3DS Happy flow Amazon pay
- [x] From Declined to happy flow
- [x] CC 3DS2
- [x] CC

