### PR TITLE
Update PaymentMethods.php

### DIFF
--- a/Helper/PaymentMethods.php
+++ b/Helper/PaymentMethods.php
@@ -291,6 +291,12 @@ class PaymentMethods extends AbstractHelper
             // return empty result
             return [];
         }
+        catch (\Adyen\ConnectionException $e) {
+            $this->adyenLogger->error(
+                "Curl request to the end point failed. Check the live-endpoint configuration"
+            );
+            return [];
+        }
 
         return $responseData;
     }

--- a/Helper/PaymentMethods.php
+++ b/Helper/PaymentMethods.php
@@ -293,7 +293,7 @@ class PaymentMethods extends AbstractHelper
         }
         catch (\Adyen\ConnectionException $e) {
             $this->adyenLogger->error(
-                "Curl request to the end point failed. Check the live-endpoint configuration"
+                "Connection to the endpoint failed. Check the Adyen Live endpoint prefix configuration."
             );
             return [];
         }


### PR DESCRIPTION
Add an \Adyen\ConnectionException catch in case the curl request failed (if the live endPoint is misconfigured)


**Description**
If the Live endPoint is misconfigured in the Magento2 module Backoffice, on the checkout page the CURL request to retrieve Adyen Payment raise an \Adyen\ConnectionException, but the getPaymentMethodsResponse in Helper/PaymentMethods.php is only catching \Adyen\AdyenException => so the Ajax call never return response and the checkout freeze when getting payment method.

**Tested scenarios**
- Add a wrong live Endpoint in the Magento2 Adyen module back office
- Clean the cache
- On the frontend, add some product to your cart and go to the checkout page
- Magento doesn't show the payment methods because the Adyen Ajax call failed 


**Fixed issue**:  add an \Adyen\ConnectionException catch to handle failed CURL request