### PR TITLE
[PW-6138] Restore cart on back button

### DIFF
--- a/Controller/Process/Result.php
+++ b/Controller/Process/Result.php
@@ -169,6 +169,9 @@ class Result extends \Magento\Framework\App\Action\Action
             }
         }
 
+        // Customer returned, clear the pending payment flag
+        $this->_session->unsPendingPayment();
+
         if ($response) {
             $result = $this->validateResponse($response);
 

--- a/Model/Api/AdyenPaymentDetails.php
+++ b/Model/Api/AdyenPaymentDetails.php
@@ -114,6 +114,9 @@ class AdyenPaymentDetails implements AdyenPaymentDetailsInterface
             unset($payload['orderId']);
         }
 
+        // Got a payment response, clear the pending payment flag
+        $this->checkoutSession->unsPendingPayment();
+
         $payment = $order->getPayment();
         $apiPayload = DataArrayValidator::getArrayOnlyWithApprovedKeys($payload, self::PAYMENTS_DETAILS_KEYS);
         // cancellation request without `state.data`

--- a/Observer/AdyenCcDataAssignObserver.php
+++ b/Observer/AdyenCcDataAssignObserver.php
@@ -25,6 +25,7 @@ namespace Adyen\Payment\Observer;
 
 use Adyen\Payment\Helper\StateData;
 use Adyen\Payment\Model\ResourceModel\StateData\Collection;
+use Magento\Checkout\Model\Session;
 use Magento\Framework\Event\Observer;
 use Magento\Payment\Observer\AbstractDataAssignObserver;
 use Magento\Quote\Api\Data\PaymentInterface;
@@ -70,6 +71,11 @@ class AdyenCcDataAssignObserver extends AbstractDataAssignObserver
     private $stateData;
 
     /**
+     * @var Session
+     */
+    private $checkoutSession;
+
+    /**
      * AdyenCcDataAssignObserver constructor.
      * @param CheckoutStateDataValidator $checkoutStateDataValidator
      * @param Collection $stateDataCollection
@@ -78,11 +84,13 @@ class AdyenCcDataAssignObserver extends AbstractDataAssignObserver
     public function __construct(
         CheckoutStateDataValidator $checkoutStateDataValidator,
         Collection $stateDataCollection,
-        StateData $stateData
+        StateData $stateData,
+        Session $checkoutSession
     ) {
         $this->checkoutStateDataValidator = $checkoutStateDataValidator;
         $this->stateDataCollection = $stateDataCollection;
         $this->stateData = $stateData;
+        $this->checkoutSession = $checkoutSession;
     }
 
     /**
@@ -135,5 +143,8 @@ class AdyenCcDataAssignObserver extends AbstractDataAssignObserver
         if (!empty($stateData[self::STORE_PAYMENT_METHOD])) {
             $paymentInfo->setAdditionalInformation(self::STORE_CC, $stateData[self::STORE_PAYMENT_METHOD]);
         }
+
+        // Customer is about to leave the shop
+        $this->checkoutSession->setPendingPayment(true);
     }
 }

--- a/Observer/AdyenHppDataAssignObserver.php
+++ b/Observer/AdyenHppDataAssignObserver.php
@@ -27,6 +27,7 @@ use Adyen\Payment\Helper\StateData;
 use Adyen\Payment\Model\ResourceModel\StateData\Collection;
 use Adyen\Service\Validator\CheckoutStateDataValidator;
 use Adyen\Service\Validator\DataArrayValidator;
+use Magento\Checkout\Model\Session;
 use Magento\Framework\Event\Observer;
 use Magento\Payment\Observer\AbstractDataAssignObserver;
 use Magento\Quote\Api\Data\PaymentInterface;
@@ -63,6 +64,10 @@ class AdyenHppDataAssignObserver extends AbstractDataAssignObserver
      * @var StateData
      */
     private $stateData;
+    /**
+     * @var Session
+     */
+    private $checkoutSession;
 
     /**
      * AdyenHppDataAssignObserver constructor.
@@ -72,11 +77,13 @@ class AdyenHppDataAssignObserver extends AbstractDataAssignObserver
     public function __construct(
         CheckoutStateDataValidator $checkoutStateDataValidator,
         Collection $stateDataCollection,
-        StateData $stateData
+        StateData $stateData,
+        Session $checkoutSession
     ) {
         $this->checkoutStateDataValidator = $checkoutStateDataValidator;
         $this->stateDataCollection = $stateDataCollection;
         $this->stateData = $stateData;
+        $this->checkoutSession = $checkoutSession;
     }
 
     /**
@@ -124,5 +131,8 @@ class AdyenHppDataAssignObserver extends AbstractDataAssignObserver
         if (!empty($additionalData[self::BRAND_CODE])) {
             $paymentInfo->setCcType($additionalData[self::BRAND_CODE]);
         }
+
+        // Customer is about to leave the shop
+        $this->checkoutSession->setPendingPayment(true);
     }
 }

--- a/Observer/CustomQuoteProcessObserver.php
+++ b/Observer/CustomQuoteProcessObserver.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2022 Adyen N.V (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\Payment\Observer;
+
+use Magento\Checkout\Model\Session;
+use Magento\Framework\App\Request\Http;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+
+class CustomQuoteProcessObserver implements ObserverInterface
+{
+    private $request;
+
+    public function __construct(Http $request)
+    {
+        $this->request = $request;
+    }
+
+    public function execute(Observer $observer)
+    {
+        /** @var $checkoutSession Session */
+        $checkoutSession = $observer->getEvent()->getData('checkout_session');
+        if ($checkoutSession && $checkoutSession->hasQuote()) {
+            return;
+        }
+
+        $moduleName = $this->request->getModuleName();
+        $controller = $this->request->getControllerName();
+        $action = $this->request->getActionName();
+        $route = $moduleName . '_' . $controller . '_' . $action;
+
+        // If there's still a pending payment, the customer didn't return through the normal flow
+        if ($route === 'checkout_index_index' && $checkoutSession->hasPendingPayment()) {
+            $checkoutSession->restoreQuote();
+            $checkoutSession->unsPendingPayment();
+        }
+    }
+}

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -47,4 +47,7 @@
     <event name="sales_order_invoice_save_after">
         <observer name="adyen_invoice_save_after" instance="Adyen\Payment\Observer\InvoiceObserver" />
     </event>
+    <event name="custom_quote_process">
+        <observer name="adyen_custom_quote_process" instance="Adyen\Payment\Observer\CustomQuoteProcessObserver" />
+    </event>
 </config>


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->

When a customer leaves the shop to make a payment on an external payment method. They can change their mind and press the back button on their browser. Currently, this action will bring them back but their shopping basket is gone.

This change will detect the situation, and try to restore the cart so that customers can make another attempt without losing their cart.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
* iDeal
* AliPay 
* Credit Cards (3DS1, 3DS2, non-3DS)
