### PR TITLE
[PW-6260] - Get the full table name when doing join

### DIFF
--- a/Model/ResourceModel/Invoice/Invoice.php
+++ b/Model/ResourceModel/Invoice/Invoice.php
@@ -68,10 +68,11 @@ class Invoice extends AbstractDb
      */
     public function getAdyenInvoiceByCaptureWebhook(Order $order, Notification $notification): ?array
     {
+        $adyenOrderPaymentTable = $this->getTable('adyen_order_payment');
         $select = $this->getConnection()->select()
             ->from(['adyen_invoice' => $this->getTable('adyen_invoice')])
             ->joinInner(
-                ['aop' => 'adyen_order_payment'],
+                ['aop' => $adyenOrderPaymentTable],
                 'aop.entity_id = adyen_invoice.adyen_order_payment_id'
             )
             ->where('aop.payment_id=?', $order->getPayment()->getEntityId())


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
Currently in `Invoice::getAdyenInvoiceByCaptureWebhook` we are directly passing the `adyen_order_payment` table name as a string.

This works fine in our environment, but if there's a table prefix (m2_adyen_order_payment), the table won't be found and it will result in a 'Base table or view not found' error.

**Tested scenarios**
* Payment w/partial auth and partial capture