### PR TITLE
[PW-6324] - Remove storePaymentMethodMode from PBL on v7

### DIFF
--- a/Helper/Requests.php
+++ b/Helper/Requests.php
@@ -368,11 +368,7 @@ class Requests extends AbstractHelper
         $stateData = $this->stateData->getStateData($payment->getOrder()->getQuoteId()) ?:
             (json_decode($payment->getCcNumber(), true) ?: []);
 
-        if ($payment->getMethod() === AdyenPayByLinkConfigProvider::CODE) {
-            $request['storePaymentMethodMode'] = 'askForConsent';
-        } else {
-            $request['storePaymentMethod'] = (bool)($stateData['storePaymentMethod'] ?? $storedPaymentMethodsEnabled);
-        }
+        $request['storePaymentMethod'] = (bool)($stateData['storePaymentMethod'] ?? $storedPaymentMethodsEnabled);
 
         //recurring
         if ($storedPaymentMethodsEnabled) {


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
Since v7.3.4 `storePaymentMethodMode` is being sent when a pay by link request is created. Since v7 uses Checkout v67 and this parameter was introduced on v68, this causes the following error:

```
Info.log: AdyenLoggerTest.INFO: JSON Response to Adyen:{"status":400,"errorCode":"702","message":"Structure of CreatePaymentLinkRequest contains the following unknown fields: [storePaymentMethodMode]","errorType":"validation"} {"is_exception":false} []
```

This PR will remove the `storePaymentMethodMode` parameter from v7.

**Tested scenarios**
* Pay by link payment