### PR TITLE
[PW-6268] Removed unused code

### DIFF
--- a/Controller/Process/Result.php
+++ b/Controller/Process/Result.php
@@ -529,20 +529,6 @@ class Result extends \Magento\Framework\App\Action\Action
 
         $request["details"] = $details;
 
-        if (!empty($this->payment)) {
-            // for pending payment that redirect we store this under adyenPaymentData
-            // TODO: refactor the code in the plugin that all paymentData is stored in paymentData and not in adyenPaymentData
-            if (!empty($this->payment->getAdditionalInformation('adyenPaymentData'))) {
-                $request['paymentData'] = $this->payment->getAdditionalInformation("adyenPaymentData");
-
-                // remove paymentData from db
-                $this->payment->unsAdditionalInformation('adyenPaymentData');
-                $this->payment->save();
-            }
-        } else {
-            $this->_adyenLogger->addError("Payment object cannot be loaded from order");
-        }
-
         try {
             $response = $service->paymentsDetails($request);
             $responseMerchantReference = !empty($response['merchantReference']) ? $response['merchantReference'] : null;

--- a/Gateway/Validator/CheckoutResponseValidator.php
+++ b/Gateway/Validator/CheckoutResponseValidator.php
@@ -102,10 +102,6 @@ class CheckoutResponseValidator extends AbstractValidator
                 $payment->setAdditionalInformation('pspReference', $response['pspReference']);
             }
 
-            if (!empty($response['paymentData'])) {
-                $payment->setAdditionalInformation('adyenPaymentData', $response['paymentData']);
-            }
-
             if (!empty($response['details'])) {
                 $payment->setAdditionalInformation('details', $response['details']);
             }

--- a/Helper/PaymentResponseHandler.php
+++ b/Helper/PaymentResponseHandler.php
@@ -148,10 +148,6 @@ class PaymentResponseHandler
             $payment->setAdditionalInformation('pspReference', $paymentsResponse['pspReference']);
         }
 
-        if (!empty($paymentsResponse['paymentData'])) {
-            $payment->setAdditionalInformation('adyenPaymentData', $paymentsResponse['paymentData']);
-        }
-
         if (!empty($paymentsResponse['details'])) {
             $payment->setAdditionalInformation('details', $paymentsResponse['details']);
         }


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
The code used to store and retrieve `paymentData` is not used anymore since we upgraded to [v67](https://docs.adyen.com/online-payments/release-notes?version=67&integration_type=api) on [7.0.0](https://github.com/Adyen/adyen-magento2/releases/tag/7.0.0). Since then, the `/payments` response no longer contains a top level `paymentData` field (still does under the `action` level) making the following `if` always `false`:  

https://github.com/Adyen/adyen-magento2/blob/d1a12068fcbe5ec9ab03196f98151d12728988b4/Gateway/Validator/CheckoutResponseValidator.php#L88-L90

The same applies to this case (which is handling a `/payments/details` response): 

https://github.com/Adyen/adyen-magento2/blob/d1a12068fcbe5ec9ab03196f98151d12728988b4/Helper/PaymentResponseHandler.php#L144-L146

The `paymentData` field is deprecated since v64. Sessions based payments won't use it either. 

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
* Credit cards
* iDeal
* Bancontact
* AfterPay