### PR TITLE
[PW-6308] Fullscreen loader does not disappear on wrong credentials 

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/adyen-hpp-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-hpp-method.js
@@ -149,8 +149,8 @@ define(
 
                     self.adyenPaymentMethods(
                         self.getAdyenHppPaymentMethods(paymentMethodsResponse));
-                    fullScreenLoader.stopLoader();
                 }
+                fullScreenLoader.stopLoader();
             },
             getAdyenHppPaymentMethods: function(paymentMethodsResponse) {
                 var self = this;


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. --> 
**Description** 
The fullscreen loader does not disappear when empty response is received due to wrong api credentials. Loader now closes as it is moved outside the if statement. No extra error message is needed as the following message appears when selecting the cc method: <img width="868" alt="image" src="https://user-images.githubusercontent.com/23633368/154267038-4e2c5d3c-9402-4ade-8ec5-48693921bbbe.png">
 **Tested scenarios** 
- Credit card with no API credentials 

**Fixed issue**: <!-- #-prefixed issue number --> 
Closes #1344 