### PR TITLE
Hot Fix: escaper variable is not available in Magento 2.3.x templates

### DIFF
--- a/view/adminhtml/templates/form/pay_by_link.phtml
+++ b/view/adminhtml/templates/form/pay_by_link.phtml
@@ -27,7 +27,9 @@
  * @var $block \Adyen\Payment\Block\Form\PayByLink
  * @var $escaper \Magento\Framework\Escaper
  */
-
+if (!isset($escaper)) {
+    $escaper = $block;
+}
 ?>
 
 <script>

--- a/view/adminhtml/templates/info/adyen_pay_by_link.phtml
+++ b/view/adminhtml/templates/info/adyen_pay_by_link.phtml
@@ -27,7 +27,9 @@
  * @var $block \Adyen\Payment\Block\Info\PayByLink
  * @var $escaper \Magento\Framework\Escaper
  */
-
+if (!isset($escaper)) {
+    $escaper = $block;
+}
 $paymentInfo = $block->getInfo();
 ?>
 <span><?= $escaper->escapeHtml($block->getMethod()->getTitle()); ?></span>

--- a/view/frontend/templates/info/adyen_pay_by_link.phtml
+++ b/view/frontend/templates/info/adyen_pay_by_link.phtml
@@ -27,7 +27,9 @@
  * @var $block \Adyen\Payment\Block\Info\PayByLink
  * @var $escaper \Magento\Framework\Escaper
  */
-
+if (!isset($escaper)) {
+    $escaper = $block;
+}
 $paymentInfo = $block->getInfo();
 ?>
 <span><?= $escaper->escapeHtml(__('The payment can be completed with the following link:')); ?></span>


### PR DESCRIPTION
**Description**
Set `$escaper` to `$block` in pay by link templates, in both adminhtml and frontend directories, if it is unavailable since `$block` has the same escape methods

**Tested scenarios**
Manually tested creating an order in 2.3.7-p2.  I have not tested in 2.4.x.
Current test suite passes

**Fixed issue**:  #1358