### PR TITLE
[PW-5743] Disable all payment methods by default

### DIFF
--- a/.github/docker-compose.yml
+++ b/.github/docker-compose.yml
@@ -34,8 +34,6 @@ services:
       ELASTICSEARCH_SERVER: elasticsearch
       MAGENTO_HOST: magento2.test.com
       VIRTUAL_HOST: magento2.test.com
-      ADMIN_USERNAME: admin
-      ADMIN_PASSWORD: 123123q
       ADMIN_URLEXT: admin
     depends_on:
       - db

--- a/.github/docker-compose.yml
+++ b/.github/docker-compose.yml
@@ -40,6 +40,8 @@ services:
       - elastic
     volumes:
       - ../:/data/extensions/workdir
+      - ./scripts/mftf.sh:/var/www/html/mftf.sh
+
   ## Selenium for MFTF tests
   selenium:
    image: selenium/standalone-chrome-debug:3.8.1

--- a/.github/docker-compose.yml
+++ b/.github/docker-compose.yml
@@ -30,11 +30,14 @@ services:
         aliases:
           - magento2.test.com
     environment:
-      DB_SERVER: mariadb
-      ELASTICSEARCH_SERVER: elasticsearch
-      MAGENTO_HOST: magento2.test.com
-      VIRTUAL_HOST: magento2.test.com
-      ADMIN_URLEXT: admin
+      - DB_SERVER=mariadb
+      - ELASTICSEARCH_SERVER=elasticsearch
+      - MAGENTO_HOST=magento2.test.com
+      - VIRTUAL_HOST=magento2.test.com
+      - ADMIN_URLEXT=admin
+      - ADMIN_USERNAME
+      - ADMIN_PASSWORD
+
     depends_on:
       - db
       - elastic

--- a/.github/docker-compose.yml
+++ b/.github/docker-compose.yml
@@ -1,0 +1,53 @@
+version: '3'
+
+services:
+  db:
+    image: mariadb:10.4
+    container_name: mariadb
+    networks: 
+      - backend
+    environment:
+      MARIADB_ROOT_PASSWORD: root_password
+      MARIADB_DATABASE: magento
+      MARIADB_USER: magento
+      MARIADB_PASSWORD: magento
+  elastic:
+    image: elasticsearch:7.16.2
+    container_name: elasticsearch
+    networks: 
+      - backend
+    ports:
+      - 9200:9200
+      - 9300:9300
+    environment:
+      - "discovery.type=single-node"
+      - "ES_JAVA_OPTS=-Xms750m -Xmx750m"
+  web:
+    image: ataberkylmz/magento2:2.4.2
+    container_name: magento2-container
+    networks:
+      backend:
+        aliases:
+          - magento2.test.com
+    environment:
+      DB_SERVER: mariadb
+      ELASTICSEARCH_SERVER: elasticsearch
+      MAGENTO_HOST: magento2.test.com
+      VIRTUAL_HOST: magento2.test.com
+      ADMIN_USERNAME: admin
+      ADMIN_PASSWORD: 123123q
+      ADMIN_URLEXT: admin
+    depends_on:
+      - db
+      - elastic
+    volumes:
+      - ../:/data/extensions/workdir
+  ## Selenium for MFTF tests
+  selenium:
+   image: selenium/standalone-chrome-debug:3.8.1
+   ports:
+     - "5900:5900"
+   networks: 
+    - backend
+networks:
+  backend:

--- a/.github/scripts/mftf.sh
+++ b/.github/scripts/mftf.sh
@@ -30,8 +30,8 @@ rm -f dev/tests/acceptance/.env;
 vendor/bin/mftf setup:env \
     --MAGENTO_BASE_URL "http://${MAGENTO_HOST}/" \
     --MAGENTO_BACKEND_NAME $ADMIN_URLEXT \
-    --MAGENTO_ADMIN_USERNAME $MAGENTO_ADMIN_USERNAME \
-    --MAGENTO_ADMIN_PASSWORD $MAGENTO_ADMIN_PASSWORD \
+    --MAGENTO_ADMIN_USERNAME $ADMIN_USERNAME \
+    --MAGENTO_ADMIN_PASSWORD $ADMIN_PASSWORD \
     --BROWSER chrome \
     --ELASTICSEARCH_VERSION 7;
 echo 'SELENIUM_HOST=selenium' >> dev/tests/acceptance/.env;

--- a/.github/scripts/mftf.sh
+++ b/.github/scripts/mftf.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-        
+set -euo pipefail
+
 # docker-compose -f .github/docker-compose.yml up -d
 # sleep 120
 
@@ -12,6 +13,10 @@ bin/magento setup:di:compile
 bin/magento cache:flush
 
 # Configuration
+bin/magento config:set currency/options/allow USD,EUR
+bin/magento config:set currency/options/default USD
+bin/magento config:set currency/options/base USD
+
 bin/magento config:set cms/wysiwyg/enabled disabled
 bin/magento config:set admin/security/admin_account_sharing 1
 bin/magento config:set admin/security/use_form_key 0
@@ -25,8 +30,8 @@ rm -f dev/tests/acceptance/.env;
 vendor/bin/mftf setup:env \
     --MAGENTO_BASE_URL "http://${MAGENTO_HOST}/" \
     --MAGENTO_BACKEND_NAME $ADMIN_URLEXT \
-    --MAGENTO_ADMIN_USERNAME $ADMIN_USERNAME \
-    --MAGENTO_ADMIN_PASSWORD $ADMIN_PASSWORD \
+    --MAGENTO_ADMIN_USERNAME $MAGENTO_ADMIN_USERNAME \
+    --MAGENTO_ADMIN_PASSWORD $MAGENTO_ADMIN_PASSWORD \
     --BROWSER chrome \
     --ELASTICSEARCH_VERSION 7;
 echo 'SELENIUM_HOST=selenium' >> dev/tests/acceptance/.env;

--- a/.github/scripts/mftf.sh
+++ b/.github/scripts/mftf.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 set -euo pipefail
 
-# docker-compose -f .github/docker-compose.yml up -d
-# sleep 120
-
 # Install plugin 
 composer config --json repositories.local '{"type": "path", "url": "/data/extensions/workdir", "options": { "symlink": false } }'
 composer require "adyen/module-payment:*"

--- a/.github/scripts/mftf.sh
+++ b/.github/scripts/mftf.sh
@@ -13,7 +13,6 @@ bin/magento cache:flush
 
 # Configuration
 bin/magento config:set cms/wysiwyg/enabled disabled
-bin/magento cache:clean config full_page
 bin/magento config:set admin/security/admin_account_sharing 1
 bin/magento config:set admin/security/use_form_key 0
 bin/magento cache:clean config full_page

--- a/.github/scripts/mftf.sh
+++ b/.github/scripts/mftf.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+        
+# docker-compose -f .github/docker-compose.yml up -d
+# sleep 120
+
+# Install plugin 
+composer config --json repositories.local '{"type": "path", "url": "/data/extensions/workdir", "options": { "symlink": false } }'
+composer require "adyen/module-payment:*"
+bin/magento module:enable Adyen_Payment
+bin/magento setup:upgrade
+bin/magento setup:di:compile
+bin/magento cache:flush
+
+# Configuration
+bin/magento config:set cms/wysiwyg/enabled disabled
+bin/magento cache:clean config full_page
+bin/magento config:set admin/security/admin_account_sharing 1
+bin/magento config:set admin/security/use_form_key 0
+bin/magento cache:clean config full_page
+
+# Build test project
+vendor/bin/mftf build:project
+          
+# Edit environmental settings
+rm -f dev/tests/acceptance/.env;
+vendor/bin/mftf setup:env \
+    --MAGENTO_BASE_URL "http://${MAGENTO_HOST}/" \
+    --MAGENTO_BACKEND_NAME $ADMIN_URLEXT \
+    --MAGENTO_ADMIN_USERNAME $ADMIN_USERNAME \
+    --MAGENTO_ADMIN_PASSWORD $ADMIN_PASSWORD \
+    --BROWSER chrome \
+    --ELASTICSEARCH_VERSION 7;
+echo 'SELENIUM_HOST=selenium' >> dev/tests/acceptance/.env;
+
+# Enable the Magento CLI commands
+cp dev/tests/acceptance/.htaccess.sample dev/tests/acceptance/.htaccess

--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -9,12 +9,18 @@ jobs:
           - PHP_VERSION: 7.4
             MAGENTO_VERSION: 2.4.2
     runs-on: ubuntu-latest
+    env:
+      MAGENTO_ADMIN_USERNAME: ${{ secrets.MAGENTO_ADMIN_USERNAME }}
+      MAGENTO_ADMIN_PASSWORD: ${{ secrets.MAGENTO_ADMIN_PASSWORD }}
     steps:
       - uses: actions/checkout@v2
 
       - name: Create docker image
-        run: MAGENTO_USERNAME=${{ secrets.MAGENTO_USERNAME }} MAGENTO_PASSWORD=${{ secrets.MAGENTO_PASSWORD }} docker-compose -f .github/docker-compose.yml up -d
-
+        run: docker-compose -f .github/docker-compose.yml up -d
+        env:
+          MAGENTO_USERNAME: ${{ secrets.MAGENTO_USERNAME }}
+          MAGENTO_PASSWORD: ${{ secrets.MAGENTO_PASSWORD }}
+      
       # Temp solution to wait for install script to run
       - name: Sleep for 120 seconds
         uses: jakejarvis/wait-action@master
@@ -39,5 +45,4 @@ jobs:
         run: docker exec magento2-container vendor/bin/mftf doctor
 
       - name: Run MFTF tests
-        run: |
-          docker exec magento2-container vendor/bin/mftf run:test AdminLoginSuccessfulTest --remove
+        run: docker exec magento2-container vendor/bin/mftf run:group --remove AdyenMagentoSuite

--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -10,16 +10,13 @@ jobs:
             MAGENTO_VERSION: 2.4.2
     runs-on: ubuntu-latest
     env:
-      MAGENTO_ADMIN_USERNAME: ${{ secrets.MAGENTO_ADMIN_USERNAME }}
-      MAGENTO_ADMIN_PASSWORD: ${{ secrets.MAGENTO_ADMIN_PASSWORD }}
+      ADMIN_USERNAME: ${{ secrets.MAGENTO_ADMIN_USERNAME }}
+      ADMIN_PASSWORD: ${{ secrets.MAGENTO_ADMIN_PASSWORD }}
     steps:
       - uses: actions/checkout@v2
 
       - name: Create docker image
         run: docker-compose -f .github/docker-compose.yml up -d
-        env:
-          MAGENTO_USERNAME: ${{ secrets.MAGENTO_USERNAME }}
-          MAGENTO_PASSWORD: ${{ secrets.MAGENTO_PASSWORD }}
 
       # Temp solution to wait for install script to run
       - name: Sleep for 120 seconds
@@ -34,7 +31,7 @@ jobs:
         run: docker exec magento2-container /etc/init.d/cron stop
 
       - name: Build MFTF project
-        run: docker exec -e MAGENTO_ADMIN_USERNAME -e MAGENTO_ADMIN_PASSWORD magento2-container ./mftf.sh
+        run: docker exec magento2-container ./mftf.sh
 
       - name: Check setup
         run: docker exec magento2-container vendor/bin/mftf doctor

--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -1,0 +1,41 @@
+name: Functional Tests
+on: [pull_request]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - PHP_VERSION: 7.4
+            MAGENTO_VERSION: 2.4.2
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Create docker image
+        run: MAGENTO_USERNAME=${{ secrets.MAGENTO_USERNAME }} MAGENTO_PASSWORD=${{ secrets.MAGENTO_PASSWORD }} docker-compose -f .github/docker-compose.yml up -d
+
+      # Temp solution to wait for install script to run
+      - name: Sleep for 120 seconds
+        uses: jakejarvis/wait-action@master
+        with:
+          time: '120s'
+
+      - name: Show install logs
+        run: docker logs magento2-container
+
+      - name: Prevent cron from interfering with test execution
+        run: docker exec magento2-container /etc/init.d/cron stop
+
+      - name: Install MFTF script
+        run: |
+          docker exec magento2-container ln -s /data/extensions/workdir/.github/scripts/mftf.sh /var/www/html/mftf.sh
+          docker exec magento2-container chmod +x /var/www/html/mftf.sh
+
+      - name: Build MFTF project
+        run: docker exec magento2-container /var/www/html/mftf.sh
+
+      - name: Run MFTF tests
+        run: |
+          docker exec magento2-container vendor/bin/mftf doctor
+          docker exec magento2-container vendor/bin/mftf run:test AdminLoginSuccessfulTest --remove

--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -20,7 +20,7 @@ jobs:
         env:
           MAGENTO_USERNAME: ${{ secrets.MAGENTO_USERNAME }}
           MAGENTO_PASSWORD: ${{ secrets.MAGENTO_PASSWORD }}
-      
+
       # Temp solution to wait for install script to run
       - name: Sleep for 120 seconds
         uses: jakejarvis/wait-action@master
@@ -33,13 +33,8 @@ jobs:
       - name: Prevent cron from interfering with test execution
         run: docker exec magento2-container /etc/init.d/cron stop
 
-      - name: Install MFTF script
-        run: |
-          docker exec magento2-container ln -s /data/extensions/workdir/.github/scripts/mftf.sh /var/www/html/mftf.sh
-          docker exec magento2-container chmod +x /var/www/html/mftf.sh
-
       - name: Build MFTF project
-        run: docker exec magento2-container /var/www/html/mftf.sh
+        run: docker exec -e MAGENTO_ADMIN_USERNAME -e MAGENTO_ADMIN_PASSWORD magento2-container ./mftf.sh
 
       - name: Check setup
         run: docker exec magento2-container vendor/bin/mftf doctor

--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -1,5 +1,5 @@
 name: Functional Tests
-on: [pull_request]
+on: [workflow_dispatch, pull_request]
 
 jobs:
   build:
@@ -20,12 +20,11 @@ jobs:
 
       # Temp solution to wait for install script to run
       - name: Sleep for 120 seconds
-        uses: jakejarvis/wait-action@master
-        with:
-          time: '120s'
-
+        run: sleep 120s
+        shell: bash
+  
       - name: Show install logs
-        run: docker logs magento2-container
+        run: docker logs --tail 100 magento2-container
 
       - name: Prevent cron from interfering with test execution
         run: docker exec magento2-container /etc/init.d/cron stop
@@ -38,6 +37,9 @@ jobs:
 
       - name: Run MFTF tests
         run: docker exec magento2-container vendor/bin/mftf run:group --remove AdyenMagentoSuite
+
+      - name: Retry once on failure
+        run: docker exec magento2-container vendor/bin/mftf run:failed
 
       - name: Shutdown
         run: docker-compose -f .github/docker-compose.yml down --volumes

--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Create docker image
+      - name: Start services
         run: docker-compose -f .github/docker-compose.yml up -d
 
       # Temp solution to wait for install script to run
@@ -38,3 +38,6 @@ jobs:
 
       - name: Run MFTF tests
         run: docker exec magento2-container vendor/bin/mftf run:group --remove AdyenMagentoSuite
+
+      - name: Shutdown
+        run: docker-compose -f .github/docker-compose.yml down --volumes

--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -35,7 +35,9 @@ jobs:
       - name: Build MFTF project
         run: docker exec magento2-container /var/www/html/mftf.sh
 
+      - name: Check setup
+        run: docker exec magento2-container vendor/bin/mftf doctor
+
       - name: Run MFTF tests
         run: |
-          docker exec magento2-container vendor/bin/mftf doctor
           docker exec magento2-container vendor/bin/mftf run:test AdminLoginSuccessfulTest --remove

--- a/Console/Command/WebhookProcessorCommand.php
+++ b/Console/Command/WebhookProcessorCommand.php
@@ -2,7 +2,7 @@
 
 namespace Adyen\Payment\Console\Command;
 
-use Adyen\Payment\Cron\WebhookProcessor;
+use Adyen\Payment\Cron\WebhookProcessor\Proxy as WebhookProcessor;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;

--- a/Test/Mftf/Suite/AdyenMagentoSuite.xml
+++ b/Test/Mftf/Suite/AdyenMagentoSuite.xml
@@ -3,7 +3,8 @@
     <suite name="AdyenMagentoSuite">
         <include>
             <!-- Test core functionalities still work with our plugin -->
-            <test name="AdminLoginSuccessfulTest"/>
+            <test name="StorefrontReorderAsGuestTest"/>
+            <test name="AdminCreateSimpleProductTest"/>
             <test name="AdminCreateCreditMemoPartialRefundTest"/>
             <test name="CreateInvoiceWithShipmentAndCheckInvoicedOrderTest"/>
             <!-- Any other tests the plugin may define -->

--- a/Test/Mftf/Suite/AdyenMagentoSuite.xml
+++ b/Test/Mftf/Suite/AdyenMagentoSuite.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suites xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:mftf:Suite/etc/suiteSchema.xsd">
+    <suite name="AdyenMagentoSuite">
+        <include>
+            <!-- Test core functionalities still work with our plugin -->
+            <test name="AdminLoginSuccessfulTest"/>
+            <test name="AdminCreateCreditMemoPartialRefundTest"/>
+            <!-- Any other tests the plugin may define -->
+            <module name="Adyen_Payment"/>
+        </include>
+    </suite>
+</suites>

--- a/Test/Mftf/Suite/AdyenMagentoSuite.xml
+++ b/Test/Mftf/Suite/AdyenMagentoSuite.xml
@@ -5,6 +5,7 @@
             <!-- Test core functionalities still work with our plugin -->
             <test name="AdminLoginSuccessfulTest"/>
             <test name="AdminCreateCreditMemoPartialRefundTest"/>
+            <test name="CreateInvoiceWithShipmentAndCheckInvoicedOrderTest"/>
             <!-- Any other tests the plugin may define -->
             <module name="Adyen_Payment"/>
         </include>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -42,7 +42,7 @@
                 <house_number_street_line>0</house_number_street_line>
             </adyen_abstract>
             <adyen_cc>
-                <active>1</active>
+                <active>0</active>
                 <model>AdyenPaymentCcFacade</model>
                 <title>Credit Card</title>
                 <allowspecific>0</allowspecific>
@@ -76,7 +76,7 @@
                 </instant_purchase>
             </adyen_cc_vault>
             <adyen_oneclick>
-                <active>1</active>
+                <active>0</active>
                 <model>AdyenPaymentOneclickFacade</model>
                 <title>Adyen Stored Payment Methods</title>
                 <allowspecific>0</allowspecific>


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->

Right after installing the plugin, the payment methods "Credit Card" and "OneClick" come enabled. They won't work without setting up all the required settings (e.g. API key).

Normally, this is not an issue for regular merchants. But it breaks Magento core MFTF tests, which then blocks us from publishing on their Marketplace.

This PR disables all methods by default and introduces a Github Actions workflow to check if the core compatibility is maintained.  

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
* Disabling these settings did not effect existing values
* Run Core MFTF tests