### PR TITLE
Save invoice through repository

### DIFF
--- a/Helper/Webhook.php
+++ b/Helper/Webhook.php
@@ -60,7 +60,7 @@ use Magento\Sales\Model\Order\Email\Sender\InvoiceSender;
 use Magento\Sales\Model\Order\Email\Sender\OrderSender;
 use Magento\Sales\Model\Order\Payment\Transaction\Builder;
 use Magento\Sales\Model\OrderRepository;
-use Magento\Sales\Model\ResourceModel\Order\Invoice as InvoiceResourceModel;
+use Magento\Sales\Api\InvoiceRepositoryInterface;
 use Magento\Sales\Model\ResourceModel\Order\Status\CollectionFactory as OrderStatusCollectionFactory;
 use Magento\Store\Model\ScopeInterface;
 use Magento\Vault\Api\Data\PaymentTokenFactoryInterface;
@@ -183,9 +183,9 @@ class Webhook
      */
     private $paymentMethodsHelper;
     /**
-     * @var InvoiceResourceModel
+     * @var InvoiceRepositoryInterface
      */
-    private $invoiceResourceModel;
+    private $InvoiceRepositoryInterface;
     /**
      * @var AdyenOrderPayment
      */
@@ -238,7 +238,7 @@ class Webhook
         EncryptorInterface $encryptor,
         ChargedCurrency $chargedCurrency,
         PaymentMethodsHelper $paymentMethodsHelper,
-        InvoiceResourceModel $invoiceResourceModel,
+        InvoiceRepositoryInterface $InvoiceRepositoryInterface,
         AdyenOrderPayment $adyenOrderPaymentHelper,
         InvoiceHelper $invoiceHelper,
         CaseManagement $caseManagementHelper,
@@ -269,7 +269,7 @@ class Webhook
         $this->encryptor = $encryptor;
         $this->chargedCurrency = $chargedCurrency;
         $this->paymentMethodsHelper = $paymentMethodsHelper;
-        $this->invoiceResourceModel = $invoiceResourceModel;
+        $this->InvoiceRepositoryInterface = $InvoiceRepositoryInterface;
         $this->adyenOrderPaymentHelper = $adyenOrderPaymentHelper;
         $this->invoiceHelper = $invoiceHelper;
         $this->caseManagementHelper = $caseManagementHelper;
@@ -1506,7 +1506,7 @@ class Webhook
                     $invoice->register()->pay();
                 }
 
-                $this->invoiceResourceModel->save($invoice);
+                $this->InvoiceRepositoryInterface->save($invoice);
             } catch (Exception $e) {
                 $this->logger->addAdyenNotificationCronjob('Error saving invoice: ' . $e->getMessage());
                 throw $e;


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Save invoice through repository instead of resource model. Magento uses the repository pattern to save newly created invoice. Using the repository, is therefore in line with Magento's implementation. Second, this pattern should be used when storing entities. The interface allows customised implementations to deal with persisting data. The resource model is a particular implementation and is more low-level.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

**Fixed issue**:  <!-- #-prefixed issue number -->