### PR TITLE
#GCC currency - saved amount on create adyen order 

### DIFF
--- a/Helper/AdyenOrderPayment.php
+++ b/Helper/AdyenOrderPayment.php
@@ -214,7 +214,7 @@ class AdyenOrderPayment extends AbstractHelper
     {
         $adyenOrderPayment = null;
         $payment = $order->getPayment();
-        $amount = $this->adyenDataHelper->originalAmount($notification->getAmountValue(), $order->getBaseCurrencyCode());
+        $amount = $this->adyenDataHelper->originalAmount($notification->getAmountValue(), $order->getOrderCurrencyCode());
         $captureStatus = $autoCapture ? Payment::CAPTURE_STATUS_AUTO_CAPTURE : Payment::CAPTURE_STATUS_NO_CAPTURE;
         $merchantReference = $notification->getMerchantReference();
         $pspReference = $notification->getPspreference();

--- a/Helper/AdyenOrderPayment.php
+++ b/Helper/AdyenOrderPayment.php
@@ -34,6 +34,7 @@ use Magento\Framework\App\Helper\AbstractHelper;
 use Magento\Framework\App\Helper\Context;
 use Magento\Framework\Exception\AlreadyExistsException;
 use Magento\Sales\Model\Order;
+use Adyen\Payment\Helper\Config;
 
 /**
  * Helper class for anything related to the adyen_order_payment entity
@@ -79,6 +80,11 @@ class AdyenOrderPayment extends AbstractHelper
     protected $invoiceHelper;
 
     /**
+     * @var Config
+     */
+    protected $config;
+
+    /**
      * AdyenOrderPayment constructor.
      *
      * @param Context $context
@@ -97,7 +103,8 @@ class AdyenOrderPayment extends AbstractHelper
         ChargedCurrency $adyenChargedCurrencyHelper,
         OrderPaymentResourceModel $orderPaymentResourceModel,
         PaymentFactory $adyenOrderPaymentFactory,
-        Invoice $invoiceHelper
+        Invoice $invoiceHelper,
+        Config $config
     ) {
         parent::__construct($context);
         $this->adyenLogger = $adyenLogger;
@@ -107,6 +114,7 @@ class AdyenOrderPayment extends AbstractHelper
         $this->orderPaymentResourceModel = $orderPaymentResourceModel;
         $this->adyenOrderPaymentFactory = $adyenOrderPaymentFactory;
         $this->invoiceHelper = $invoiceHelper;
+        $this->config = $config;
     }
 
     /**
@@ -214,7 +222,7 @@ class AdyenOrderPayment extends AbstractHelper
     {
         $adyenOrderPayment = null;
         $payment = $order->getPayment();
-        $chargedCurrencyCode = $this->adyenChargedCurrencyHelper->getChargedCurrency() === "display"
+        $chargedCurrencyCode = $this->config->getChargedCurrency() === "display"
             ? $order->getOrderCurrencyCode() : $order->getBaseCurrencyCode();
         $amount = $this->adyenDataHelper->originalAmount($notification->getAmountValue(), $chargedCurrencyCode);
         $captureStatus = $autoCapture ? Payment::CAPTURE_STATUS_AUTO_CAPTURE : Payment::CAPTURE_STATUS_NO_CAPTURE;

--- a/Helper/AdyenOrderPayment.php
+++ b/Helper/AdyenOrderPayment.php
@@ -214,7 +214,9 @@ class AdyenOrderPayment extends AbstractHelper
     {
         $adyenOrderPayment = null;
         $payment = $order->getPayment();
-        $amount = $this->adyenDataHelper->originalAmount($notification->getAmountValue(), $order->getOrderCurrencyCode());
+        $chargedCurrencyCode = $this->adyenChargedCurrencyHelper->getChargedCurrency() === "display"
+            ? $order->getOrderCurrencyCode() : $order->getBaseCurrencyCode();
+        $amount = $this->adyenDataHelper->originalAmount($notification->getAmountValue(), $chargedCurrencyCode);
         $captureStatus = $autoCapture ? Payment::CAPTURE_STATUS_AUTO_CAPTURE : Payment::CAPTURE_STATUS_NO_CAPTURE;
         $merchantReference = $notification->getMerchantReference();
         $pspReference = $notification->getPspreference();


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
- Issue occurs on - Adyen_Payments version 7 and above

- When display currency is KWD, or BHD data is not formatted correctly in :
$this->adyenDataHelper->originalAmount($notification->getAmountValue(), $order->getBaseCurrencyCode());

- Shop base currency is different than KWD, BHD, and all others mentioned for formatting here: 
\Adyen\Payment\Helper\Data::originalAmount 

- It will always format the amount based on base currency not on display currency and therefore the amount is not correctly saved here: \Adyen\Payment\Helper\AdyenOrderPayment::createAdyenOrderPayment

- Adyen notification returns back the amount in mentioned currency that should be formatted(divided) by 1000, but since the base currency is different it falls under the default case which is /100, which leads to a wrong amount saved in the database. 
- 
Steps to reproduce the issue before the fix: 
1. Set USD as the base currency
2. Place an order with BHD, KWD as a display currency
3. Wait for the auth and capture notifications to be executed.
4. Order status stays in pending payment after capture. 
Comment:  order was partially authorized but it's actually the whole amount. 
5. No invoice, no status update is performed. 

**Tested scenarios**
- Placed orders in KWD and USD as a display currency
- Works as expected
- Notifications are sent and Magento handle those as needed after the fix
- I tested only for GCC currencies which are KWD, BHD as those are we are using,  but I assume the fix will work for all the rest included here: \Adyen\Payment\Helper\Data::originalAmount 
- 
**Fixed issue**:  <!-- #-prefixed issue number -->