### PR TITLE
[PW-6287] - Check if LPM supports recurring before adding recurring info

### DIFF
--- a/Controller/Process/Result.php
+++ b/Controller/Process/Result.php
@@ -24,6 +24,7 @@
 namespace Adyen\Payment\Controller\Process;
 
 use Adyen\Payment\Helper\Data;
+use Adyen\Payment\Helper\Recurring;
 use Adyen\Payment\Helper\StateData;
 use \Adyen\Payment\Model\Notification;
 use Adyen\Service\Validator\DataArrayValidator;
@@ -127,6 +128,11 @@ class Result extends \Magento\Framework\App\Action\Action
     private $orderRepository;
 
     /**
+     * @var Recurring
+     */
+    private $recurringHelper;
+
+    /**
      * Result constructor.
      *
      * @param \Magento\Framework\App\Action\Context $context
@@ -156,7 +162,8 @@ class Result extends \Magento\Framework\App\Action\Action
         \Magento\Sales\Model\ResourceModel\Order $orderResourceModel,
         StateData $stateDataHelper,
         Data $dataHelper,
-        OrderRepositoryInterface $orderRepository
+        OrderRepositoryInterface $orderRepository,
+        Recurring $recurringHelper
     ) {
         $this->_adyenHelper = $adyenHelper;
         $this->_orderFactory = $orderFactory;
@@ -171,6 +178,7 @@ class Result extends \Magento\Framework\App\Action\Action
         $this->stateDataHelper = $stateDataHelper;
         $this->dataHelper = $dataHelper;
         $this->orderRepository = $orderRepository;
+        $this->recurringHelper = $recurringHelper;
         parent::__construct($context);
     }
 
@@ -297,7 +305,7 @@ class Result extends \Magento\Framework\App\Action\Action
                 $this->vaultHelper->saveRecurringDetails($this->payment, $response['additionalData']);
             } else {
                 $order = $this->payment->getOrder();
-                $this->_adyenHelper->createAdyenBillingAgreement($order, $response['additionalData']);
+                $this->recurringHelper->createAdyenBillingAgreement($order, $response['additionalData'], $this->payment->getAdditionalInformation());
             }
             $this->orderResourceModel->save($order);
         }

--- a/Gateway/Request/RecurringDataBuilder.php
+++ b/Gateway/Request/RecurringDataBuilder.php
@@ -92,12 +92,13 @@ class RecurringDataBuilder implements BuilderInterface
         $payment = $paymentDataObject->getPayment();
         $order = $payment->getOrder();
         $storeId = $order->getStoreId();
+        $method = $payment->getMethod();
 
-        if ($this->paymentMethodsHelper->isCardPayment($payment)) {
+        if ($method === PaymentMethods::ADYEN_CC) {
             $body = $this->adyenRequestsHelper->buildCardRecurringData($storeId, $payment);
-        } elseif ($this->paymentMethodsHelper->isAlternativePayment($payment)) {
+        } elseif ($method === PaymentMethods::ADYEN_HPP) {
             $body = $this->adyenRequestsHelper->buildAlternativePaymentRecurringData($storeId, $payment);
-        } elseif ($this->paymentMethodsHelper->isTokenPayment($payment)) {
+        } elseif ($method === PaymentMethods::ADYEN_ONE_CLICK) {
             $body = $this->adyenRequestsHelper->buildTokenizedPaymentRecurringData($storeId, $payment);
         } else {
             $this->adyenLogger->addAdyenWarning(

--- a/Gateway/Request/RecurringDataBuilder.php
+++ b/Gateway/Request/RecurringDataBuilder.php
@@ -23,9 +23,12 @@
 
 namespace Adyen\Payment\Gateway\Request;
 
+use Adyen\Payment\Helper\AdyenOrderPayment;
 use Adyen\Payment\Helper\PaymentMethods;
 use Adyen\Payment\Helper\Requests;
+use Adyen\Payment\Logger\AdyenLogger;
 use Magento\Framework\Model\Context;
+use Magento\Payment\Gateway\Helper\SubjectReader;
 use Magento\Payment\Gateway\Request\BuilderInterface;
 
 class RecurringDataBuilder implements BuilderInterface
@@ -46,38 +49,61 @@ class RecurringDataBuilder implements BuilderInterface
     private $paymentMethodsHelper;
 
     /**
+     * @var AdyenLogger
+     */
+    private $adyenLogger;
+
+    /**
+     * @var AdyenOrderPayment
+     */
+    private $adyenOrderPayment;
+
+    /**
      * RecurringDataBuilder constructor.
      *
      * @param Context $context
      * @param Requests $adyenRequestsHelper
      * @param PaymentMethods $paymentMethodsHelper
+     * @param AdyenLogger $adyenLogger
      */
     public function __construct(
         Context $context,
         Requests $adyenRequestsHelper,
-        PaymentMethods $paymentMethodsHelper
+        PaymentMethods $paymentMethodsHelper,
+        AdyenLogger $adyenLogger,
+        AdyenOrderPayment $adyenOrderPayment
     ) {
         $this->appState = $context->getAppState();
         $this->adyenRequestsHelper = $adyenRequestsHelper;
         $this->paymentMethodsHelper = $paymentMethodsHelper;
+        $this->adyenLogger = $adyenLogger;
+        $this->adyenOrderPayment = $adyenOrderPayment;
     }
 
     /**
      * @param array $buildSubject
      * @return array
-     * @throws \Magento\Framework\Exception\LocalizedException
      */
     public function build(array $buildSubject): array
     {
+        $body = [];
         /** @var \Magento\Payment\Gateway\Data\PaymentDataObject $paymentDataObject */
-        $paymentDataObject = \Magento\Payment\Gateway\Helper\SubjectReader::readPayment($buildSubject);
+        $paymentDataObject = SubjectReader::readPayment($buildSubject);
         $payment = $paymentDataObject->getPayment();
-        $storeId = $payment->getOrder()->getStoreId();
+        $order = $payment->getOrder();
+        $storeId = $order->getStoreId();
 
         if ($this->paymentMethodsHelper->isCardPayment($payment)) {
             $body = $this->adyenRequestsHelper->buildCardRecurringData($storeId, $payment);
-        } else {
+        } elseif ($this->paymentMethodsHelper->isAlternativePayment($payment)) {
             $body = $this->adyenRequestsHelper->buildAlternativePaymentRecurringData($storeId, $payment);
+        } elseif ($this->paymentMethodsHelper->isTokenPayment($payment)) {
+            $body = $this->adyenRequestsHelper->buildTokenizedPaymentRecurringData($storeId, $payment);
+        } else {
+            $this->adyenLogger->addAdyenWarning(
+                sprintf('Unknown payment method: %s', $payment->getMethod()),
+                $this->adyenOrderPayment->getLogOrderContext($order)
+            );
         }
 
         return [

--- a/Gateway/Response/CheckoutPaymentsDetailsHandler.php
+++ b/Gateway/Response/CheckoutPaymentsDetailsHandler.php
@@ -78,7 +78,7 @@ class CheckoutPaymentsDetailsHandler implements HandlerInterface
             $payment->getMethodInstance()->getCode() !== \Adyen\Payment\Model\Ui\AdyenOneclickConfigProvider::CODE
         ) {
             $order = $payment->getOrder();
-            $this->recurringHelper->createAdyenBillingAgreement($order, $response['additionalData']);
+            $this->recurringHelper->createAdyenBillingAgreement($order, $response['additionalData'], $payment->getAdditionalInformation());
         }
 
         // do not close transaction so you can do a cancel() and void

--- a/Gateway/Response/CheckoutPaymentsDetailsHandler.php
+++ b/Gateway/Response/CheckoutPaymentsDetailsHandler.php
@@ -23,19 +23,24 @@
 
 namespace Adyen\Payment\Gateway\Response;
 
+use Adyen\Payment\Helper\Data;
+use Adyen\Payment\Helper\Recurring;
 use Magento\Payment\Gateway\Response\HandlerInterface;
 
 class CheckoutPaymentsDetailsHandler implements HandlerInterface
 {
-    /**
-     * @var \Adyen\Payment\Helper\Data
-     */
+    /** @var Data  */
     protected $adyenHelper;
 
+    /** @var Recurring */
+    private $recurringHelper;
+
     public function __construct(
-        \Adyen\Payment\Helper\Data $adyenHelper
+        Data $adyenHelper,
+        Recurring $recurringHelper
     ) {
         $this->adyenHelper = $adyenHelper;
+        $this->recurringHelper = $recurringHelper;
     }
 
     /**
@@ -73,7 +78,7 @@ class CheckoutPaymentsDetailsHandler implements HandlerInterface
             $payment->getMethodInstance()->getCode() !== \Adyen\Payment\Model\Ui\AdyenOneclickConfigProvider::CODE
         ) {
             $order = $payment->getOrder();
-            $this->adyenHelper->createAdyenBillingAgreement($order, $response['additionalData']);
+            $this->recurringHelper->createAdyenBillingAgreement($order, $response['additionalData']);
         }
 
         // do not close transaction so you can do a cancel() and void

--- a/Gateway/Response/PaymentPosCloudHandler.php
+++ b/Gateway/Response/PaymentPosCloudHandler.php
@@ -26,6 +26,7 @@ namespace Adyen\Payment\Gateway\Response;
 
 use Adyen\AdyenException;
 use Adyen\Payment\Helper\Data;
+use Adyen\Payment\Helper\Recurring;
 use Adyen\Payment\Logger\AdyenLogger;
 use Magento\Payment\Gateway\Helper\SubjectReader;
 use Magento\Payment\Gateway\Response\HandlerInterface;
@@ -42,12 +43,19 @@ class PaymentPosCloudHandler implements HandlerInterface
      */
     private $adyenLogger;
 
+    /**
+     * @var Recurring
+     */
+    private $recurringHelper;
+
     public function __construct(
         AdyenLogger $adyenLogger,
-        Data $adyenHelper
+        Data $adyenHelper,
+        Recurring $recurringHelper
     ) {
         $this->adyenLogger = $adyenLogger;
         $this->adyenHelper = $adyenHelper;
+        $this->recurringHelper = $recurringHelper;
     }
 
     /**
@@ -99,7 +107,7 @@ class PaymentPosCloudHandler implements HandlerInterface
                 $additionalData['pos_payment'] = true;
 
                 if (!$this->adyenHelper->isCreditCardVaultEnabled()) {
-                    $this->adyenHelper->createAdyenBillingAgreement($payment->getOrder(), $additionalData);
+                    $this->recurringHelper->createAdyenBillingAgreement($payment->getOrder(), $additionalData);
                 }
             }
         }

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -43,6 +43,7 @@ class Config
     const XML_HAS_HOLDER_NAME = "has_holder_name";
     const XML_HOLDER_NAME_REQUIRED = "holder_name_required";
     const XML_HOUSE_NUMBER_STREET_LINE = "house_number_street_line";
+    const XML_ADYEN_HPP = 'adyen_hpp';
     const XML_ADYEN_HPP_VAULT = 'adyen_hpp_vault';
     const XML_PAYMENT_ORIGIN_URL = 'payment_origin_url';
     const XML_PAYMENT_RETURN_URL = 'payment_return_url';
@@ -190,6 +191,17 @@ class Config
     public function isDemoMode($storeId = null)
     {
         return $this->getConfigData('demo_mode', self::XML_ADYEN_ABSTRACT_PREFIX, $storeId, true);
+    }
+
+    /**
+     * Get how the alternative payment should be tokenized
+     *
+     * @param null|int|string $storeId
+     * @return mixed
+     */
+    public function getAlternativePaymentMethodTokenType($storeId = null)
+    {
+        return $this->getConfigData('token_type', self::XML_ADYEN_HPP, $storeId);
     }
 
     /**

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -200,7 +200,7 @@ class Config
      */
     public function isStoreAlternativePaymentMethodEnabled($storeId = null)
     {
-        return $this->getConfigData('active', self::XML_ADYEN_HPP_VAULT, $storeId);
+        return $this->getConfigData('active', self::XML_ADYEN_HPP_VAULT, $storeId, true);
     }
 
     /**

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -24,7 +24,6 @@
 namespace Adyen\Payment\Helper;
 
 use Adyen\Payment\Logger\AdyenLogger;
-use Adyen\Payment\Model\Billing\AgreementFactory;
 use Adyen\Payment\Model\RecurringType;
 use Adyen\Payment\Model\ResourceModel\Billing\Agreement;
 use Adyen\Payment\Model\ResourceModel\Billing\Agreement\CollectionFactory as BillingCollectionFactory;
@@ -142,16 +141,6 @@ class Data extends AbstractHelper
     protected $cache;
 
     /**
-     * @var AgreementFactory
-     */
-    protected $billingAgreementFactory;
-
-    /**
-     * @var Agreement
-     */
-    private $agreementResourceModel;
-
-    /**
      * @var ResolverInterface
      */
     private $localeResolver;
@@ -203,8 +192,6 @@ class Data extends AbstractHelper
      * @param AdyenLogger $adyenLogger
      * @param StoreManagerInterface $storeManager
      * @param CacheInterface $cache
-     * @param AgreementFactory $billingAgreementFactory
-     * @param Agreement $agreementResourceModel
      * @param ResolverInterface $localeResolver
      * @param ScopeConfigInterface $config
      * @param SerializerInterface $serializer
@@ -228,8 +215,6 @@ class Data extends AbstractHelper
         AdyenLogger $adyenLogger,
         StoreManagerInterface $storeManager,
         CacheInterface $cache,
-        AgreementFactory $billingAgreementFactory,
-        Agreement $agreementResourceModel,
         ResolverInterface $localeResolver,
         ScopeConfigInterface $config,
         SerializerInterface $serializer,
@@ -253,8 +238,6 @@ class Data extends AbstractHelper
         $this->adyenLogger = $adyenLogger;
         $this->storeManager = $storeManager;
         $this->cache = $cache;
-        $this->billingAgreementFactory = $billingAgreementFactory;
-        $this->agreementResourceModel = $agreementResourceModel;
         $this->localeResolver = $localeResolver;
         $this->config = $config;
         $this->serializer = $serializer;
@@ -1644,77 +1627,6 @@ class Data extends AbstractHelper
     private function createAdyenCheckoutUtilityService($client)
     {
         return new \Adyen\Service\CheckoutUtility($client);
-    }
-
-    /**
-     * @param $order
-     * @param $additionalData
-     */
-    public function createAdyenBillingAgreement($order, $additionalData)
-    {
-        if (!empty($additionalData['recurring.recurringDetailReference'])) {
-            $listRecurringContracts = null;
-            try {
-                // Get or create billing agreement
-                /** @var \Adyen\Payment\Model\Billing\Agreement $billingAgreement */
-                $billingAgreement = $this->billingAgreementFactory->create();
-                $billingAgreement->load($additionalData['recurring.recurringDetailReference'], 'reference_id');
-
-                // check if BA exists
-                if (!($billingAgreement && $billingAgreement->getAgreementId() > 0 && $billingAgreement->isValid())) {
-                    // create new BA
-                    $billingAgreement = $this->billingAgreementFactory->create();
-                    $billingAgreement->setStoreId($order->getStoreId());
-                    $billingAgreement->importOrderPaymentWithRecurringDetailReference(
-                        $order->getPayment(),
-                        $additionalData['recurring.recurringDetailReference']
-                    );
-
-                    $message = __(
-                        'Created billing agreement #%1.',
-                        $additionalData['recurring.recurringDetailReference']
-                    );
-                } else {
-                    $billingAgreement->setIsObjectChanged(true);
-                    $message = __(
-                        'Updated billing agreement #%1.',
-                        $additionalData['recurring.recurringDetailReference']
-                    );
-                }
-
-                // Populate billing agreement data
-                $storeOneClick = $order->getPayment()->getAdditionalInformation('store_cc');
-
-                $billingAgreement->setCcBillingAgreement($additionalData, $storeOneClick, $order->getStoreId());
-                $billingAgreementErrors = $billingAgreement->getErrors();
-
-                if ($billingAgreement->isValid() && empty($billingAgreementErrors)) {
-                    if (!$this->agreementResourceModel->getOrderRelation(
-                        $billingAgreement->getAgreementId(),
-                        $order->getId()
-                    )) {
-                        // save into billing_agreement_order
-                        $billingAgreement->addOrderRelation($order);
-                    }
-                    // add to order to save agreement
-                    $order->addRelatedObject($billingAgreement);
-                } else {
-                    $message = __('Failed to create billing agreement for this order. Reason(s): ') . join(
-                            ', ',
-                            $billingAgreementErrors
-                        );
-                    throw new \Exception($message);
-                }
-            } catch (\Exception $exception) {
-                $message = $exception->getMessage();
-                $this->adyenLogger->error("exception: " . $message);
-            }
-
-            $comment = $order->addStatusHistoryComment($message, $order->getStatus());
-
-            $order->addRelatedObject($comment);
-            $order->save();
-        }
     }
 
     /**

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -902,7 +902,7 @@ class Data extends AbstractHelper
 
             // check if contractType is supporting the selected contractType for OneClick payments
             $allowedContractTypes = $agreementData['contractTypes'];
-            if (in_array(RecurringType::ONECLICK , $allowedContractTypes)) {
+            if (in_array(RecurringType::ONECLICK , $allowedContractTypes) || in_array(Recurring::CARD_ON_FILE, $allowedContractTypes)) {
                 // check if AgreementLabel is set and if contract has an recurringType
                 if ($billingAgreement->getAgreementLabel()) {
                     // for Ideal use sepadirectdebit because it is

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -68,7 +68,7 @@ class Data extends AbstractHelper
     const CLEARPAY = 'clearpay';
     const ZIP = 'zip';
     const PAYBRIGHT = 'paybright';
-
+    const SEPA = 'sepadirectdebit';
 
     /**
      * @var EncryptorInterface

--- a/Helper/PaymentMethods.php
+++ b/Helper/PaymentMethods.php
@@ -31,6 +31,7 @@ use Magento\Framework\App\Helper\AbstractHelper;
 class PaymentMethods extends AbstractHelper
 {
     const ADYEN_HPP = 'adyen_hpp';
+    const ADYEN_CC = 'adyen_cc';
 
     const METHODS_WITH_BRAND_LOGO = [
         "giftcard"
@@ -490,5 +491,63 @@ class PaymentMethods extends AbstractHelper
             'alipay_hk'
         ];
         return in_array($notificationPaymentMethod, $walletPaymentMethods);
+    }
+
+    /**
+     * Check if the payment method used was a card
+     *
+     * @param $payment
+     * @return bool
+     */
+    public function isCardPayment($payment): bool
+    {
+        return $payment->getMethod() === self::ADYEN_CC;
+    }
+
+    /**
+     * Check if the passed payment method supports recurring functionality.
+     * If a payment method is in this list it does not necessarily imply that it is already supported
+     * by the plugin
+     *
+     * @param string $lpm
+     * @return bool
+     */
+    public function paymentMethodSupportsRecurring(string $paymentMethod): bool
+    {
+        $paymentMethodRecurring = [
+            'ach',
+            'amazonpay',
+            'applepay',
+            'directdebit_GB',
+            'bcmc',
+            'dana',
+            'dankort',
+            'eps',
+            'gcash',
+            'giropay',
+            'googlepay',
+            'paywithgoogle',
+            'gopay_wallet',
+            'ideal',
+            'kakaopay',
+            'klarna',
+            'klarna_account',
+            'klarna_b2b',
+            'klarna_paynow',
+            'momo_wallet',
+            'paymaya_wallet',
+            'paypal',
+            'sepadirectdebit',
+            'trustly',
+            'twint',
+            'uatp',
+            'billdesk_upi',
+            'payu_IN_upi',
+            'vipps',
+            'yandex_money',
+            'zip'
+        ];
+
+        return in_array($paymentMethod, $paymentMethodRecurring);
     }
 }

--- a/Helper/PaymentMethods.php
+++ b/Helper/PaymentMethods.php
@@ -32,6 +32,7 @@ class PaymentMethods extends AbstractHelper
 {
     const ADYEN_HPP = 'adyen_hpp';
     const ADYEN_CC = 'adyen_cc';
+    const ADYEN_ONE_CLICK = 'adyen_oneclick';
 
     const METHODS_WITH_BRAND_LOGO = [
         "giftcard"
@@ -502,6 +503,28 @@ class PaymentMethods extends AbstractHelper
     public function isCardPayment($payment): bool
     {
         return $payment->getMethod() === self::ADYEN_CC;
+    }
+
+    /**
+     * Check if the payment method used was an alternative payment method
+     *
+     * @param $payment
+     * @return bool
+     */
+    public function isAlternativePayment($payment): bool
+    {
+        return $payment->getMethod() === self::ADYEN_HPP;
+    }
+
+    /**
+     * Check if the payment method used was a tokenized payment
+     *
+     * @param $payment
+     * @return bool
+     */
+    public function isTokenPayment($payment): bool
+    {
+        return $payment->getMethod() === self::ADYEN_ONE_CLICK;
     }
 
     /**

--- a/Helper/PaymentMethods.php
+++ b/Helper/PaymentMethods.php
@@ -30,6 +30,7 @@ use Magento\Framework\App\Helper\AbstractHelper;
  */
 class PaymentMethods extends AbstractHelper
 {
+    const ADYEN_HPP = 'adyen_hpp';
 
     const METHODS_WITH_BRAND_LOGO = [
         "giftcard"

--- a/Helper/PaymentMethods.php
+++ b/Helper/PaymentMethods.php
@@ -509,15 +509,17 @@ class PaymentMethods extends AbstractHelper
     /**
      * Check if the passed payment method supports recurring functionality.
      * If a payment method is in this list it does not necessarily imply that it is already supported
-     * by the plugin
+     * by the plugin.
      *
-     * @param string $lpm
+     * Currently only SEPA is allowed on our Magento plugin.
+     *
+     * @param string $paymentMethod
      * @return bool
      */
     public function paymentMethodSupportsRecurring(string $paymentMethod): bool
     {
         $paymentMethodRecurring = [
-            'ach',
+            /*'ach',
             'amazonpay',
             'applepay',
             'directdebit_GB',
@@ -539,7 +541,6 @@ class PaymentMethods extends AbstractHelper
             'momo_wallet',
             'paymaya_wallet',
             'paypal',
-            'sepadirectdebit',
             'trustly',
             'twint',
             'uatp',
@@ -547,7 +548,8 @@ class PaymentMethods extends AbstractHelper
             'payu_IN_upi',
             'vipps',
             'yandex_money',
-            'zip'
+            'zip',*/
+            'sepadirectdebit',
         ];
 
         return in_array($paymentMethod, $paymentMethodRecurring);

--- a/Helper/PaymentMethods.php
+++ b/Helper/PaymentMethods.php
@@ -495,36 +495,15 @@ class PaymentMethods extends AbstractHelper
     }
 
     /**
-     * Check if the payment method used was a card
+     * Check if the method of the passed payment is equal to the method passed in this function
      *
      * @param $payment
+     * @param string $method
      * @return bool
      */
-    public function isCardPayment($payment): bool
+    public function checkPaymentMethod($payment, string $method): bool
     {
-        return $payment->getMethod() === self::ADYEN_CC;
-    }
-
-    /**
-     * Check if the payment method used was an alternative payment method
-     *
-     * @param $payment
-     * @return bool
-     */
-    public function isAlternativePayment($payment): bool
-    {
-        return $payment->getMethod() === self::ADYEN_HPP;
-    }
-
-    /**
-     * Check if the payment method used was a tokenized payment
-     *
-     * @param $payment
-     * @return bool
-     */
-    public function isTokenPayment($payment): bool
-    {
-        return $payment->getMethod() === self::ADYEN_ONE_CLICK;
+        return $payment->getMethod() === $method;
     }
 
     /**

--- a/Helper/PaymentMethods.php
+++ b/Helper/PaymentMethods.php
@@ -505,10 +505,13 @@ class PaymentMethods extends AbstractHelper
 
     /**
      * Check if the passed payment method supports recurring functionality.
-     * If a payment method is in this list it does not necessarily imply that it is already supported
-     * by the plugin.
      *
      * Currently only SEPA is allowed on our Magento plugin.
+     * Possible future payment methods:
+     *
+     * 'ach','amazonpay','applepay','directdebit_GB','bcmc','dana','dankort','eps','gcash','giropay','googlepay','paywithgoogle',
+     * 'gopay_wallet','ideal','kakaopay','klarna','klarna_account','klarna_b2b','klarna_paynow','momo_wallet','paymaya_wallet',
+     * 'paypal','trustly','twint','uatp','billdesk_upi','payu_IN_upi','vipps','yandex_money','zip'
      *
      * @param string $paymentMethod
      * @return bool
@@ -516,36 +519,6 @@ class PaymentMethods extends AbstractHelper
     public function paymentMethodSupportsRecurring(string $paymentMethod): bool
     {
         $paymentMethodRecurring = [
-            /*'ach',
-            'amazonpay',
-            'applepay',
-            'directdebit_GB',
-            'bcmc',
-            'dana',
-            'dankort',
-            'eps',
-            'gcash',
-            'giropay',
-            'googlepay',
-            'paywithgoogle',
-            'gopay_wallet',
-            'ideal',
-            'kakaopay',
-            'klarna',
-            'klarna_account',
-            'klarna_b2b',
-            'klarna_paynow',
-            'momo_wallet',
-            'paymaya_wallet',
-            'paypal',
-            'trustly',
-            'twint',
-            'uatp',
-            'billdesk_upi',
-            'payu_IN_upi',
-            'vipps',
-            'yandex_money',
-            'zip',*/
             'sepadirectdebit',
         ];
 

--- a/Helper/PaymentResponseHandler.php
+++ b/Helper/PaymentResponseHandler.php
@@ -68,6 +68,11 @@ class PaymentResponseHandler
     private $dataHelper;
 
     /**
+     * @var Recurring
+     */
+    private $recurringHelper;
+
+    /**
      * PaymentResponseHandler constructor.
      *
      * @param AdyenLogger $adyenLogger
@@ -79,13 +84,15 @@ class PaymentResponseHandler
         Data $adyenHelper,
         Vault $vaultHelper,
         \Magento\Sales\Model\ResourceModel\Order $orderResourceModel,
-        Data $dataHelper
+        Data $dataHelper,
+        Recurring $recurringHelper
     ) {
         $this->adyenLogger = $adyenLogger;
         $this->adyenHelper = $adyenHelper;
         $this->vaultHelper = $vaultHelper;
         $this->orderResourceModel = $orderResourceModel;
         $this->dataHelper = $dataHelper;
+        $this->recurringHelper = $recurringHelper;
     }
 
     public function formatPaymentResponse($resultCode, $action = null, $additionalData = null)
@@ -200,7 +207,7 @@ class PaymentResponseHandler
                         $this->vaultHelper->saveRecurringDetails($payment, $paymentsResponse['additionalData']);
                     } else {
                         $order = $payment->getOrder();
-                        $this->adyenHelper->createAdyenBillingAgreement($order, $paymentsResponse['additionalData']);
+                        $this->recurringHelper->createAdyenBillingAgreement($order, $paymentsResponse['additionalData']);
                     }
                 }
 

--- a/Helper/Recurring.php
+++ b/Helper/Recurring.php
@@ -71,8 +71,9 @@ class Recurring
     /**
      * @param $order
      * @param $additionalData
+     * @param array $savedPaymentData
      */
-    public function createAdyenBillingAgreement($order, $additionalData)
+    public function createAdyenBillingAgreement($order, $additionalData, $savedPaymentData = [])
     {
         if (!empty($additionalData['recurring.recurringDetailReference'])) {
             $listRecurringContracts = null;
@@ -110,7 +111,7 @@ class Recurring
                 if ($order->getPayment()->getMethod() === PaymentMethods::ADYEN_CC) {
                     $billingAgreement->setCcBillingAgreement($additionalData, $storeOneClick, $order->getStoreId());
                 } else {
-                    $billingAgreement->setAlternativePaymentMethodBillingAgreement($additionalData, $order->getStoreId());
+                    $billingAgreement->setAlternativePaymentMethodBillingAgreement($additionalData, $order->getStoreId(), $savedPaymentData);
                 }
 
                 $billingAgreementErrors = $billingAgreement->getErrors();

--- a/Helper/Recurring.php
+++ b/Helper/Recurring.php
@@ -26,6 +26,7 @@ namespace Adyen\Payment\Helper;
 use Adyen\Payment\Model\Billing\AgreementFactory;
 use Adyen\Payment\Logger\AdyenLogger;
 use Adyen\Payment\Model\ResourceModel\Billing\Agreement;
+use Adyen\Payment\Observer\AdyenHppDataAssignObserver;
 
 class Recurring
 {
@@ -106,11 +107,12 @@ class Recurring
 
                 // Populate billing agreement data
                 $storeOneClick = $order->getPayment()->getAdditionalInformation('store_cc');
+                $payment = $order->getPayment();
 
-                if ($order->getPayment()->getMethod() === PaymentMethods::ADYEN_CC) {
+                if ($payment->getMethod() === PaymentMethods::ADYEN_CC) {
                     $billingAgreement->setCcBillingAgreement($additionalData, $storeOneClick, $order->getStoreId());
-                } else {
-                    $billingAgreement->setAlternativePaymentMethodBillingAgreement($additionalData, $order->getStoreId(), $savedPaymentData);
+                } elseif ($payment->getAdditionalInformation(AdyenHppDataAssignObserver::BRAND_CODE) === Data::SEPA) {
+                    $billingAgreement->setSepaBillingAgreement($additionalData, $order->getStoreId(), $savedPaymentData);
                 }
 
                 $billingAgreementErrors = $billingAgreement->getErrors();

--- a/Helper/Recurring.php
+++ b/Helper/Recurring.php
@@ -23,11 +23,39 @@
 
 namespace Adyen\Payment\Helper;
 
+use Adyen\Payment\Model\Billing\AgreementFactory;
+use Adyen\Payment\Logger\AdyenLogger;
+use Adyen\Payment\Model\ResourceModel\Billing\Agreement;
 
 class Recurring
 {
     const CARD_ON_FILE = 'CardOnFile';
     const SUBSCRIPTION = 'Subscription';
+
+    /** @var AdyenLogger */
+    private $adyenLogger;
+
+    /** @var AgreementFactory */
+    private $billingAgreementFactory;
+
+    /**
+     * @var Agreement
+     */
+    private $billingAgreementResourceModel;
+
+    /**
+     * Recurring constructor.
+     */
+    public function __construct(
+        AdyenLogger $adyenLogger,
+        AgreementFactory $agreementFactory,
+        Agreement $billingAgreementResourceModel
+    )
+    {
+        $this->adyenLogger = $adyenLogger;
+        $this->billingAgreementFactory = $agreementFactory;
+        $this->billingAgreementResourceModel = $billingAgreementResourceModel;
+    }
 
     /**
      * @return string[]
@@ -38,5 +66,76 @@ class Recurring
             self::CARD_ON_FILE,
             self::SUBSCRIPTION
         ];
+    }
+
+    /**
+     * @param $order
+     * @param $additionalData
+     */
+    public function createAdyenBillingAgreement($order, $additionalData)
+    {
+        if (!empty($additionalData['recurring.recurringDetailReference'])) {
+            $listRecurringContracts = null;
+            try {
+                // Get or create billing agreement
+                /** @var \Adyen\Payment\Model\Billing\Agreement $billingAgreement */
+                $billingAgreement = $this->billingAgreementFactory->create();
+                $billingAgreement->load($additionalData['recurring.recurringDetailReference'], 'reference_id');
+
+                // check if BA exists
+                if (!($billingAgreement && $billingAgreement->getAgreementId() > 0 && $billingAgreement->isValid())) {
+                    // create new BA
+                    $billingAgreement = $this->billingAgreementFactory->create();
+                    $billingAgreement->setStoreId($order->getStoreId());
+                    $billingAgreement->importOrderPaymentWithRecurringDetailReference(
+                        $order->getPayment(),
+                        $additionalData['recurring.recurringDetailReference']
+                    );
+
+                    $message = __(
+                        'Created billing agreement #%1.',
+                        $additionalData['recurring.recurringDetailReference']
+                    );
+                } else {
+                    $billingAgreement->setIsObjectChanged(true);
+                    $message = __(
+                        'Updated billing agreement #%1.',
+                        $additionalData['recurring.recurringDetailReference']
+                    );
+                }
+
+                // Populate billing agreement data
+                $storeOneClick = $order->getPayment()->getAdditionalInformation('store_cc');
+
+                $billingAgreement->setCcBillingAgreement($additionalData, $storeOneClick, $order->getStoreId());
+                $billingAgreementErrors = $billingAgreement->getErrors();
+
+                if ($billingAgreement->isValid() && empty($billingAgreementErrors)) {
+                    if (!$this->billingAgreementResourceModel->getOrderRelation(
+                        $billingAgreement->getAgreementId(),
+                        $order->getId()
+                    )) {
+                        // save into billing_agreement_order
+                        $billingAgreement->addOrderRelation($order);
+                    }
+                    // add to order to save agreement
+                    $order->addRelatedObject($billingAgreement);
+                } else {
+                    $message = __('Failed to create billing agreement for this order. Reason(s): ') . join(
+                            ', ',
+                            $billingAgreementErrors
+                        );
+                    throw new \Exception($message);
+                }
+            } catch (\Exception $exception) {
+                $message = $exception->getMessage();
+                $this->adyenLogger->error("exception: " . $message);
+            }
+
+            $comment = $order->addStatusHistoryComment($message, $order->getStatus());
+
+            $order->addRelatedObject($comment);
+            $order->save();
+        }
     }
 }

--- a/Helper/Recurring.php
+++ b/Helper/Recurring.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2021 Adyen BV (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\Payment\Helper;
+
+
+class Recurring
+{
+    const CARD_ON_FILE = 'CardOnFile';
+    const SUBSCRIPTION = 'Subscription';
+
+    /**
+     * @return string[]
+     */
+    public static function getRecurringTypes(): array
+    {
+        return [
+            self::CARD_ON_FILE,
+            self::SUBSCRIPTION
+        ];
+    }
+}

--- a/Helper/Recurring.php
+++ b/Helper/Recurring.php
@@ -73,10 +73,9 @@ class Recurring
      * @param $additionalData
      * @param array $savedPaymentData
      */
-    public function createAdyenBillingAgreement($order, $additionalData, $savedPaymentData = [])
+    public function createAdyenBillingAgreement($order, $additionalData, array $savedPaymentData = [])
     {
         if (!empty($additionalData['recurring.recurringDetailReference'])) {
-            $listRecurringContracts = null;
             try {
                 // Get or create billing agreement
                 /** @var \Adyen\Payment\Model\Billing\Agreement $billingAgreement */

--- a/Helper/Recurring.php
+++ b/Helper/Recurring.php
@@ -107,7 +107,12 @@ class Recurring
                 // Populate billing agreement data
                 $storeOneClick = $order->getPayment()->getAdditionalInformation('store_cc');
 
-                $billingAgreement->setCcBillingAgreement($additionalData, $storeOneClick, $order->getStoreId());
+                if ($order->getPayment()->getMethod() === PaymentMethods::ADYEN_CC) {
+                    $billingAgreement->setCcBillingAgreement($additionalData, $storeOneClick, $order->getStoreId());
+                } else {
+                    $billingAgreement->setAlternativePaymentMethodBillingAgreement($additionalData, $order->getStoreId());
+                }
+
                 $billingAgreementErrors = $billingAgreement->getErrors();
 
                 if ($billingAgreement->isValid() && empty($billingAgreementErrors)) {

--- a/Helper/Requests.php
+++ b/Helper/Requests.php
@@ -23,7 +23,7 @@
 
 namespace Adyen\Payment\Helper;
 
-use Adyen\Payment\Model\RecurringType;
+use Adyen\Payment\Model\Config\Source\CcType;
 use Adyen\Payment\Model\Ui\AdyenPayByLinkConfigProvider;
 use Adyen\Payment\Observer\AdyenHppDataAssignObserver;
 use Adyen\Util\Uuid;
@@ -395,6 +395,26 @@ class Requests extends AbstractHelper
 
         $request['storePaymentMethod'] = true;
         $request['recurringProcessingModel'] = $this->adyenConfig->getAlternativePaymentMethodTokenType($storeId);
+
+        return $request;
+    }
+
+    /**
+     * @param int $storeId
+     * @param $payment
+     * @return array
+     */
+    public function buildTokenizedPaymentRecurringData(int $storeId, $payment): array
+    {
+        $request = [];
+
+        if (in_array($payment->getAdditionalInformation('cc_type'), CcType::ALLOWED_TYPES)) {
+            //TODO: This should be revised in a future update
+            $enableOneclick = $this->adyenHelper->getAdyenAbstractConfigData('enable_oneclick', $storeId);
+            $request['recurringProcessingModel'] = $enableOneclick ? 'CardOnFile' : 'Subscription';
+        } else {
+            $request['recurringProcessingModel'] = $this->adyenConfig->getAlternativePaymentMethodTokenType($storeId);
+        }
 
         return $request;
     }

--- a/Helper/Requests.php
+++ b/Helper/Requests.php
@@ -23,6 +23,7 @@
 
 namespace Adyen\Payment\Helper;
 
+use Adyen\Payment\Model\RecurringType;
 use Adyen\Payment\Model\Ui\AdyenPayByLinkConfigProvider;
 use Adyen\Payment\Observer\AdyenHppDataAssignObserver;
 use Adyen\Util\Uuid;
@@ -405,7 +406,12 @@ class Requests extends AbstractHelper
         }*/
 
         $request['storePaymentMethod'] = true;
-        $request['recurringProcessingModel'] = 'CardOnFile';
+        //TODO: Update this
+        if ($this->adyenConfig->getAlternativePaymentMethodTokenType($storeId) === RecurringType::ONECLICK) {
+            $request['recurringProcessingModel'] = 'CardOnFile';
+        } else {
+            $request['recurringProcessingModel'] = 'Subscription';
+        }
 
         /*
         //recurring

--- a/Helper/Requests.php
+++ b/Helper/Requests.php
@@ -388,11 +388,6 @@ class Requests extends AbstractHelper
             return $request;
         }
 
-        // TODO: Check this ... Recurring payments feature is not currently available for PayPal
-        if ($brand === 'paypal') {
-            return $request;
-        }
-
         $request['storePaymentMethod'] = true;
         $request['recurringProcessingModel'] = $this->adyenConfig->getAlternativePaymentMethodTokenType($storeId);
 

--- a/Helper/Requests.php
+++ b/Helper/Requests.php
@@ -393,36 +393,8 @@ class Requests extends AbstractHelper
             return $request;
         }
 
-        /*$storedPaymentMethodsEnabled = $this->adyenHelper->getAdyenOneclickConfigData('active', $storeId);
-        // Initialize the request body with the current state data
-        // Multishipping checkout uses the cc_number field for state data
-        $stateData = $this->stateData->getStateData($payment->getOrder()->getQuoteId()) ?:
-            (json_decode($payment->getCcNumber(), true) ?: []);
-
-        if ($payment->getMethod() === AdyenPayByLinkConfigProvider::CODE) {
-            $request['storePaymentMethodMode'] = 'askForConsent';
-        } else {
-            $request['storePaymentMethod'] = (bool)($stateData['storePaymentMethod'] ?? $storedPaymentMethodsEnabled);
-        }*/
-
         $request['storePaymentMethod'] = true;
-        //TODO: Update this
-        if ($this->adyenConfig->getAlternativePaymentMethodTokenType($storeId) === RecurringType::ONECLICK) {
-            $request['recurringProcessingModel'] = 'CardOnFile';
-        } else {
-            $request['recurringProcessingModel'] = 'Subscription';
-        }
-
-        /*
-        //recurring
-        if ($storedPaymentMethodsEnabled) {
-            if ($this->adyenHelper->isCreditCardVaultEnabled()) {
-                $request['recurringProcessingModel'] = 'Subscription';
-            } else {
-                $enableOneclick = $this->adyenHelper->getAdyenAbstractConfigData('enable_oneclick', $storeId);
-                $request['recurringProcessingModel'] = $enableOneclick ? 'CardOnFile' : 'Subscription';
-            }
-        }*/
+        $request['recurringProcessingModel'] = $this->adyenConfig->getAlternativePaymentMethodTokenType($storeId);
 
         return $request;
     }

--- a/Helper/Requests.php
+++ b/Helper/Requests.php
@@ -337,7 +337,7 @@ class Requests extends AbstractHelper
     }
 
     /**
-     *
+     * Build the recurring data when payment is done using a card
      *
      * @param int $storeId
      * @param $payment
@@ -373,6 +373,8 @@ class Requests extends AbstractHelper
     }
 
     /**
+     * Build the recurring data when payment is done trough an alternative payment method
+     *
      * @param int $storeId
      * @param $payment
      * @return array

--- a/Helper/Requests.php
+++ b/Helper/Requests.php
@@ -388,13 +388,20 @@ class Requests extends AbstractHelper
             return $request;
         }
 
-        $request['storePaymentMethod'] = true;
-        $request['recurringProcessingModel'] = $this->adyenConfig->getAlternativePaymentMethodTokenType($storeId);
+
+        $recurringModel = $this->adyenConfig->getAlternativePaymentMethodTokenType($storeId);
+        if (isset($recurringModel)) {
+            $request['storePaymentMethod'] = true;
+            $request['recurringProcessingModel'] = $recurringModel;
+        }
 
         return $request;
     }
 
     /**
+     * Build the recurring data to be sent in case of a tokenized payment.
+     * Model will be fetched according to the type (card/other pm) of the original payment
+     *
      * @param int $storeId
      * @param $payment
      * @return array

--- a/Helper/Requests.php
+++ b/Helper/Requests.php
@@ -336,6 +336,10 @@ class Requests extends AbstractHelper
     public function buildRecurringData(int $storeId, $payment): array
     {
         $request = [];
+        if ($payment->getMethod() === PaymentMethods::ADYEN_HPP && !$this->adyenConfig->isStoreAlternativePaymentMethodEnabled()) {
+            return $request;
+        }
+
         // Recurring payments feature is not currently available for PayPal
         if ($payment->getAdditionalInformation(AdyenHppDataAssignObserver::BRAND_CODE) === 'paypal') {
             return $request;

--- a/Helper/Webhook.php
+++ b/Helper/Webhook.php
@@ -611,7 +611,7 @@ class Webhook
                     $this->order->addRelatedObject($comment);
                 }
                 //store recurring contract for alternative payments methods
-                if ($order->getPayment()->getMethod() == 'adyen_hpp' && $this->configHelper->isStoreAlternativePaymentMethodEnabled()) {
+                if ($order->getPayment()->getMethod() === PaymentMethods::ADYEN_HPP && $this->configHelper->isStoreAlternativePaymentMethodEnabled()) {
                     try {
                         //get the payment
                         $payment = $this->order->getPayment();

--- a/Logger/AdyenLogger.php
+++ b/Logger/AdyenLogger.php
@@ -34,6 +34,7 @@ class AdyenLogger extends Logger
     const ADYEN_NOTIFICATION = 201;
     const ADYEN_RESULT = 202;
     const ADYEN_NOTIFICATION_CRONJOB = 203;
+    const ADYEN_WARNING = 301;
 
     /**
      * Logging levels from syslog protocol defined in RFC 5424
@@ -50,6 +51,7 @@ class AdyenLogger extends Logger
         203 => 'ADYEN_NOTIFICATION_CRONJOB',
         250 => 'NOTICE',
         300 => 'WARNING',
+        301 => 'ADYEN_WARNING',
         400 => 'ERROR',
         500 => 'CRITICAL',
         550 => 'ALERT',
@@ -73,6 +75,11 @@ class AdyenLogger extends Logger
     public function addAdyenDebug($message, array $context = [])
     {
         return $this->addRecord(static::ADYEN_DEBUG, $message, $context);
+    }
+
+    public function addAdyenWarning($message, array $context = []): bool
+    {
+        return $this->addRecord(static::ADYEN_WARNING, $message, $context);
     }
 
     public function addAdyenResult($message, array $context = [])

--- a/Logger/Handler/AdyenWarning.php
+++ b/Logger/Handler/AdyenWarning.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2022 Adyen BV (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\Payment\Logger\Handler;
+
+use Adyen\Payment\Logger\AdyenLogger;
+
+class AdyenWarning extends AdyenBase
+{
+    /**
+     * @var string
+     */
+    protected $fileName = '/var/log/adyen/warning.log';
+
+    /**
+     * @var int
+     */
+    protected $loggerType = AdyenLogger::ADYEN_WARNING;
+
+    protected $level = AdyenLogger::ADYEN_WARNING;
+}

--- a/Model/Billing/Agreement.php
+++ b/Model/Billing/Agreement.php
@@ -23,37 +23,50 @@
 
 namespace Adyen\Payment\Model\Billing;
 
+use Adyen\Payment\Helper\Config;
+use Adyen\Payment\Helper\Data;
+use Adyen\Payment\Helper\PaymentMethods;
+use Magento\Framework\Data\Collection\AbstractDb;
+use Magento\Framework\Model\Context;
+use Magento\Framework\Model\ResourceModel\AbstractResource;
+use Magento\Framework\Registry;
+use Magento\Framework\Stdlib\DateTime\DateTimeFactory;
+use Magento\Paypal\Model\ResourceModel\Billing\Agreement\CollectionFactory;
 use Magento\Sales\Model\Order\Payment;
 
 class Agreement extends \Magento\Paypal\Model\Billing\Agreement
 {
     /**
-     * @var \Adyen\Payment\Helper\Data
+     * @var Data
      */
     private $adyenHelper;
+
+    /** @var Config */
+    private $configHelper;
 
     /**
      * Agreement constructor.
      *
-     * @param \Adyen\Payment\Helper\Data $adyenHelper
-     * @param \Magento\Framework\Model\Context $context
-     * @param \Magento\Framework\Registry $registry
+     * @param Data $adyenHelper
+     * @param Context $context
+     * @param Registry $registry
      * @param \Magento\Payment\Helper\Data $paymentData
-     * @param \Magento\Paypal\Model\ResourceModel\Billing\Agreement\CollectionFactory $billingAgreementFactory
-     * @param \Magento\Framework\Stdlib\DateTime\DateTimeFactory $dateFactory
-     * @param \Magento\Framework\Model\ResourceModel\AbstractResource|null $resource
-     * @param \Magento\Framework\Data\Collection\AbstractDb|null $resourceCollection
+     * @param CollectionFactory $billingAgreementFactory
+     * @param DateTimeFactory $dateFactory
+     * @param AbstractResource|null $resource
+     * @param AbstractDb|null $resourceCollection
      * @param array $data
      */
     public function __construct(
-        \Adyen\Payment\Helper\Data $adyenHelper,
-        \Magento\Framework\Model\Context $context,
-        \Magento\Framework\Registry $registry,
+        Data $adyenHelper,
+        Context $context,
+        Registry $registry,
         \Magento\Payment\Helper\Data $paymentData,
-        \Magento\Paypal\Model\ResourceModel\Billing\Agreement\CollectionFactory $billingAgreementFactory,
-        \Magento\Framework\Stdlib\DateTime\DateTimeFactory $dateFactory,
-        \Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
-        \Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
+        CollectionFactory $billingAgreementFactory,
+        DateTimeFactory $dateFactory,
+        Config $configHelper,
+        AbstractResource $resource = null,
+        AbstractDb $resourceCollection = null,
         array $data = []
     ) {
         parent::__construct(
@@ -68,6 +81,7 @@ class Agreement extends \Magento\Paypal\Model\Billing\Agreement
         );
 
         $this->adyenHelper = $adyenHelper;
+        $this->configHelper = $configHelper;
     }
 
     /**
@@ -256,6 +270,46 @@ class Agreement extends \Magento\Paypal\Model\Billing\Agreement
         if (!empty($contractDetail['pos_payment'])) {
             $agreementData['posPayment'] = true;
         }
+
+        $this->setAgreementData($agreementData);
+
+        return $this;
+    }
+
+    /**
+     * For sync result to store alternative billing agreement. Currently only sepa is supported. This should be changed
+     * to utilise the factory method for different payment methods
+     *
+     * @param $contractDetail
+     * @param $storeId
+     * @return $this
+     */
+    public function setAlternativePaymentMethodBillingAgreement($contractDetail, $storeId): Agreement
+    {
+        $this
+            ->setMethodCode(PaymentMethods::ADYEN_ONE_CLICK)
+            ->setReferenceId($contractDetail['recurring.recurringDetailReference']);
+
+        $variant = $contractDetail['paymentMethod'];
+
+        $label = __(
+            '%1, %2, %3',
+            $variant,
+            $contractDetail['sepadirectdebit.dateOfSignature'],
+            $contractDetail['sepadirectdebit.mandateId']
+        );
+
+        $this->setAgreementLabel($label);
+        $recurringType = $this->configHelper->getAlternativePaymentMethodTokenType($storeId);
+
+        $agreementData = [
+            'details' => [
+                'dateOfSignature' => $contractDetail['sepadirectdebit.dateOfSignature'],
+                'mandateId' => $contractDetail['sepadirectdebit.mandateId'],
+            ],
+            'variant' => $variant,
+            'billingAgreementType' => $recurringType
+        ];
 
         $this->setAgreementData($agreementData);
 

--- a/Model/Billing/Agreement.php
+++ b/Model/Billing/Agreement.php
@@ -277,15 +277,15 @@ class Agreement extends \Magento\Paypal\Model\Billing\Agreement
     }
 
     /**
-     * For sync result to store alternative billing agreement. Currently only sepa is supported. This should be changed
-     * to utilise the factory method for different payment methods
+     * Set SEPA billing agreement This should be changed to utilise the factory method for different payment methods
+     * in the future
      *
      * @param array $additionalData
      * @param $storeId
      * @param array $savedPaymentData
      * @return $this
      */
-    public function setAlternativePaymentMethodBillingAgreement(array $additionalData, $storeId, array $savedPaymentData): Agreement
+    public function setSepaBillingAgreement(array $additionalData, $storeId, array $savedPaymentData): Agreement
     {
         $this
             ->setMethodCode(PaymentMethods::ADYEN_ONE_CLICK)

--- a/Model/Billing/Agreement.php
+++ b/Model/Billing/Agreement.php
@@ -284,31 +284,30 @@ class Agreement extends \Magento\Paypal\Model\Billing\Agreement
      * @param $storeId
      * @return $this
      */
-    public function setAlternativePaymentMethodBillingAgreement($contractDetail, $storeId): Agreement
+    public function setAlternativePaymentMethodBillingAgreement(array $additionalData, $storeId, array $savedPaymentData): Agreement
     {
         $this
             ->setMethodCode(PaymentMethods::ADYEN_ONE_CLICK)
-            ->setReferenceId($contractDetail['recurring.recurringDetailReference']);
+            ->setReferenceId($additionalData['recurring.recurringDetailReference']);
 
-        $variant = $contractDetail['paymentMethod'];
+        $variant = $additionalData['paymentMethod'];
 
         $label = __(
-            '%1, %2, %3',
-            $variant,
-            $contractDetail['sepadirectdebit.dateOfSignature'],
-            $contractDetail['sepadirectdebit.mandateId']
+            '%1, %2',
+            $savedPaymentData['ownerName'],
+            $savedPaymentData['iban']
         );
 
         $this->setAgreementLabel($label);
         $recurringType = $this->configHelper->getAlternativePaymentMethodTokenType($storeId);
 
         $agreementData = [
-            'details' => [
-                'dateOfSignature' => $contractDetail['sepadirectdebit.dateOfSignature'],
-                'mandateId' => $contractDetail['sepadirectdebit.mandateId'],
+            'bank' => [
+                'ownerName' => $savedPaymentData['ownerName'],
+                'iban' => $savedPaymentData['iban'],
             ],
             'variant' => $variant,
-            'contractTypes' => $recurringType
+            'contractTypes' => [$recurringType]
         ];
 
         $this->setAgreementData($agreementData);

--- a/Model/Billing/Agreement.php
+++ b/Model/Billing/Agreement.php
@@ -308,7 +308,7 @@ class Agreement extends \Magento\Paypal\Model\Billing\Agreement
                 'mandateId' => $contractDetail['sepadirectdebit.mandateId'],
             ],
             'variant' => $variant,
-            'billingAgreementType' => $recurringType
+            'contractTypes' => $recurringType
         ];
 
         $this->setAgreementData($agreementData);

--- a/Model/Billing/Agreement.php
+++ b/Model/Billing/Agreement.php
@@ -280,8 +280,9 @@ class Agreement extends \Magento\Paypal\Model\Billing\Agreement
      * For sync result to store alternative billing agreement. Currently only sepa is supported. This should be changed
      * to utilise the factory method for different payment methods
      *
-     * @param $contractDetail
+     * @param array $additionalData
      * @param $storeId
+     * @param array $savedPaymentData
      * @return $this
      */
     public function setAlternativePaymentMethodBillingAgreement(array $additionalData, $storeId, array $savedPaymentData): Agreement

--- a/Model/Config/Source/CcType.php
+++ b/Model/Config/Source/CcType.php
@@ -15,7 +15,7 @@
  *
  * Adyen Payment module (https://www.adyen.com/)
  *
- * Copyright (c) 2015 Adyen BV (https://www.adyen.com/)
+ * Copyright (c) 2022 Adyen BV (https://www.adyen.com/)
  * See LICENSE.txt for license details.
  *
  * Author: Adyen <magento@adyen.com>
@@ -23,38 +23,33 @@
 
 namespace Adyen\Payment\Model\Config\Source;
 
+use Adyen\Payment\Helper\Data;
+use Magento\Payment\Model\Config;
+
 /**
  * @codeCoverageIgnore
  */
 class CcType extends \Magento\Payment\Model\Source\Cctype
 {
+    const ALLOWED_TYPES = ['VI', 'MC', 'AE', 'DI', 'JCB', 'UN', 'MI', 'DN', 'BCMC', 'HIPERCARD', 'ELO', 'TROY', 'DANKORT', 'CB'];
+
     /**
-     * @var \Adyen\Payment\Helper\Data
+     * @var Data
      */
     private $_adyenHelper;
 
     /**
      * CcType constructor.
      *
-     * @param \Magento\Payment\Model\Config $paymentConfig
-     * @param \Adyen\Payment\Helper\Data $adyenHelper
+     * @param Config $paymentConfig
+     * @param Data $adyenHelper
      */
     public function __construct(
-        \Magento\Payment\Model\Config $paymentConfig,
-        \Adyen\Payment\Helper\Data $adyenHelper
+        Config $paymentConfig,
+        Data $adyenHelper
     ) {
         parent::__construct($paymentConfig);
         $this->_adyenHelper = $adyenHelper;
-    }
-
-    /**
-     * Allowed credit card types
-     *
-     * @return string[]
-     */
-    public function getAllowedTypes()
-    {
-        return ['VI', 'MC', 'AE', 'DI', 'JCB', 'UN', 'MI', 'DN', 'BCMC', 'HIPERCARD', 'ELO', 'TROY', 'DANKORT', 'CB'];
     }
 
     /**
@@ -65,7 +60,7 @@ class CcType extends \Magento\Payment\Model\Source\Cctype
         /**
          * making filter by allowed cards
          */
-        $allowed = $this->getAllowedTypes();
+        $allowed = self::ALLOWED_TYPES;
         $options = [];
 
         foreach ($this->_adyenHelper->getAdyenCcTypes() as $code => $name) {

--- a/Model/Config/Source/RecurringPaymentType.php
+++ b/Model/Config/Source/RecurringPaymentType.php
@@ -23,22 +23,26 @@
 
 namespace Adyen\Payment\Model\Config\Source;
 
-class RecurringPaymentType implements \Magento\Framework\Option\ArrayInterface
+use Adyen\Payment\Helper\Data;
+use Adyen\Payment\Helper\Recurring;
+use Magento\Framework\Data\OptionSourceInterface;
+
+class RecurringPaymentType implements OptionSourceInterface
 {
     const UNDEFINED_OPTION_LABEL = 'NONE';
 
     /**
-     * @var \Adyen\Payment\Helper\Data
+     * @var Data
      */
     protected $_adyenHelper;
 
     /**
      * RecurringPaymentType constructor.
      *
-     * @param \Adyen\Payment\Helper\Data $adyenHelper
+     * @param Data $adyenHelper
      */
     public function __construct(
-        \Adyen\Payment\Helper\Data $adyenHelper
+        Data $adyenHelper
     ) {
         $this->_adyenHelper = $adyenHelper;
     }
@@ -46,16 +50,15 @@ class RecurringPaymentType implements \Magento\Framework\Option\ArrayInterface
     /**
      * @return array
      */
-    public function toOptionArray()
+    public function toOptionArray(): array
     {
-        $recurringTypes = $this->_adyenHelper->getRecurringTypes();
+        $options = [];
+        $recurringTypes = Recurring::getRecurringTypes();
 
         foreach ($recurringTypes as $code => $label) {
-            if ($code == \Adyen\Payment\Model\RecurringType::ONECLICK ||
-                $code == \Adyen\Payment\Model\RecurringType::RECURRING) {
-                $options[] = ['value' => $code, 'label' => $label];
-            }
+            $options[] = ['value' => $code, 'label' => $label];
         }
+
         return $options;
     }
 }

--- a/Model/Config/Source/RecurringPaymentType.php
+++ b/Model/Config/Source/RecurringPaymentType.php
@@ -55,8 +55,8 @@ class RecurringPaymentType implements OptionSourceInterface
         $options = [];
         $recurringTypes = Recurring::getRecurringTypes();
 
-        foreach ($recurringTypes as $code => $label) {
-            $options[] = ['value' => $code, 'label' => $label];
+        foreach ($recurringTypes as $recurringType) {
+            $options[] = ['value' => $recurringType, 'label' => $recurringType];
         }
 
         return $options;

--- a/Model/Config/Source/RecurringType.php
+++ b/Model/Config/Source/RecurringType.php
@@ -23,6 +23,11 @@
 
 namespace Adyen\Payment\Model\Config\Source;
 
+/**
+ * Class RecurringType
+ * @package Adyen\Payment\Model\Config\Source
+ * @deprecated Use RecurringPaymentType instead
+ */
 class RecurringType implements \Magento\Framework\Option\ArrayInterface
 {
     const UNDEFINED_OPTION_LABEL = 'NONE';

--- a/Model/RecurringType.php
+++ b/Model/RecurringType.php
@@ -23,6 +23,11 @@
 
 namespace Adyen\Payment\Model;
 
+/**
+ * Class RecurringType
+ * @package Adyen\Payment\Model
+ * @deprecated Use Helper\Recurring instead, for enums
+ */
 class RecurringType
 {
     const NONE = '';

--- a/Observer/AdyenHppDataAssignObserver.php
+++ b/Observer/AdyenHppDataAssignObserver.php
@@ -96,6 +96,7 @@ class AdyenHppDataAssignObserver extends AbstractDataAssignObserver
      */
     public function execute(Observer $observer)
     {
+        $additionalDataToSave = [];
         // Get request fields
         $data = $this->readDataArgument($observer);
         $paymentInfo = $this->readPaymentModelArgument($observer);

--- a/Observer/AdyenHppDataAssignObserver.php
+++ b/Observer/AdyenHppDataAssignObserver.php
@@ -92,6 +92,7 @@ class AdyenHppDataAssignObserver extends AbstractDataAssignObserver
      */
     public function execute(Observer $observer)
     {
+        $additionalDataToSave = [];
         // Get request fields
         $data = $this->readDataArgument($observer);
         $paymentInfo = $this->readPaymentModelArgument($observer);
@@ -118,12 +119,21 @@ class AdyenHppDataAssignObserver extends AbstractDataAssignObserver
         if (!empty($stateData)) {
             $stateData = $this->checkoutStateDataValidator->getValidatedAdditionalData($stateData);
         }
+
+        if (array_key_exists('iban', $stateData['paymentMethod'])) {
+            $additionalDataToSave['iban'] = $stateData['paymentMethod']['iban'];
+        }
+
+        if (array_key_exists('ownerName', $stateData['paymentMethod'])) {
+            $additionalDataToSave['ownerName'] = $stateData['paymentMethod']['ownerName'];
+        }
+
         // Set stateData in a service and remove from payment's additionalData
         $this->stateData->setStateData($stateData, $paymentInfo->getData('quote_id'));
         unset($additionalData[self::STATE_DATA]);
 
         // Set additional data in the payment
-        foreach ($additionalData as $key => $data) {
+        foreach (array_merge($additionalData, $additionalDataToSave) as $key => $data) {
             $paymentInfo->setAdditionalInformation($key, $data);
         }
 

--- a/Observer/AdyenHppDataAssignObserver.php
+++ b/Observer/AdyenHppDataAssignObserver.php
@@ -125,7 +125,7 @@ class AdyenHppDataAssignObserver extends AbstractDataAssignObserver
         }
 
         if ($additionalData[self::BRAND_CODE] === Data::SEPA) {
-            $additionalDataToSave = $this->getAdditionalDataToSave($stateData);
+            $additionalDataToSave = $this->getSepaAdditionalDataToSave($stateData);
         }
 
         // Set stateData in a service and remove from payment's additionalData
@@ -152,7 +152,7 @@ class AdyenHppDataAssignObserver extends AbstractDataAssignObserver
      * @param array $stateData
      * @return array
      */
-    private function getAdditionalDataToSave(array $stateData): array
+    private function getSepaAdditionalDataToSave(array $stateData): array
     {
         $additionalData = [];
         if (array_key_exists('iban', $stateData['paymentMethod'])) {

--- a/Test/Unit/Helper/DataTest.php
+++ b/Test/Unit/Helper/DataTest.php
@@ -56,10 +56,6 @@ class DataTest extends \PHPUnit\Framework\TestCase
         $adyenLogger = $this->getSimpleMock(\Adyen\Payment\Logger\AdyenLogger::class);
         $storeManager = $this->getSimpleMock(\Magento\Store\Model\StoreManager::class);
         $cache = $this->getSimpleMock(\Magento\Framework\App\CacheInterface::class);
-        $billingAgreementFactory = $this->getSimpleMock(\Adyen\Payment
-                                                        \Model\Billing\AgreementFactory::class);
-        $agreementResourceModel = $this->getSimpleMock(\Adyen\Payment
-                                                       \Model\ResourceModel\Billing\Agreement::class);
         $localeResolver = $this->getSimpleMock(\Magento\Framework\Locale\ResolverInterface::class);
         $config = $this->getSimpleMock(\Magento\Framework\App\Config\ScopeConfigInterface::class);
         $serializer = $this->getSimpleMock(\Magento\Framework\Serialize\SerializerInterface::class);

--- a/Test/Unit/Helper/DataTest.php
+++ b/Test/Unit/Helper/DataTest.php
@@ -85,8 +85,6 @@ class DataTest extends \PHPUnit\Framework\TestCase
             $adyenLogger,
             $storeManager,
             $cache,
-            $billingAgreementFactory,
-            $agreementResourceModel,
             $localeResolver,
             $config,
             $serializer,

--- a/etc/adminhtml/system/adyen_hpp.xml
+++ b/etc/adminhtml/system/adyen_hpp.xml
@@ -48,7 +48,7 @@
         <field id="adyen_hpp_token_type" translate="label" type="select" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
             <label>Token type</label>
             <tooltip>Currently we support SEPA tokenization only</tooltip>
-            <source_model>Adyen\Payment\Model\Config\Source\RecurringType</source_model>
+            <source_model>Adyen\Payment\Model\Config\Source\RecurringPaymentType</source_model>
             <config_path>payment/adyen_hpp/token_type</config_path>
             <depends>
                 <field id="adyen_hpp_vault_active">1</field>

--- a/etc/adminhtml/system/adyen_hpp.xml
+++ b/etc/adminhtml/system/adyen_hpp.xml
@@ -47,7 +47,7 @@
         </field>
         <field id="adyen_hpp_token_type" translate="label" type="select" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
             <label>Token type</label>
-            <tooltip>Currently we support SEPA tokenization only</tooltip>
+            <tooltip>Currently only SEPA tokenization is supported</tooltip>
             <source_model>Adyen\Payment\Model\Config\Source\RecurringPaymentType</source_model>
             <config_path>payment/adyen_hpp/token_type</config_path>
             <depends>

--- a/etc/adminhtml/system/adyen_hpp.xml
+++ b/etc/adminhtml/system/adyen_hpp.xml
@@ -45,6 +45,15 @@
             <tooltip>Currently we support SEPA tokenization only</tooltip>
             <config_path>payment/adyen_hpp_vault/active</config_path>
         </field>
+        <field id="adyen_hpp_token_type" translate="label" type="select" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
+            <label>Token type</label>
+            <tooltip>Currently we support SEPA tokenization only</tooltip>
+            <source_model>Adyen\Payment\Model\Config\Source\RecurringType</source_model>
+            <config_path>payment/adyen_hpp/token_type</config_path>
+            <depends>
+                <field id="adyen_hpp_vault_active">1</field>
+            </depends>
+        </field>
         <!--klarna\ratePay\afterpay settings-->
         <group id="adyen_hpp_openinvoice_settings" translate="label" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="100">
             <label>Klarna\RatePay\Afterpay Settings</label>

--- a/etc/adminhtml/system/adyen_hpp.xml
+++ b/etc/adminhtml/system/adyen_hpp.xml
@@ -25,7 +25,7 @@
 <include xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_include.xsd">
     <!--alternative payment methods-->
     <group id="adyen_hpp" translate="label" type="text" sortOrder="200" showInDefault="1" showInWebsite="1" showInStore="1">
-        <label><![CDATA[Alternative payment methods]]></label>
+        <label><![CDATA[Alternative Payment Methods]]></label>
         <frontend_model>Magento\Config\Block\System\Config\Form\Fieldset</frontend_model>
         <fieldset_css>adyen-method-adyen-cc</fieldset_css>
         <comment>Process alternative payments methods</comment>
@@ -38,19 +38,25 @@
             <label>Sort Order</label>
             <frontend_class>validate-number</frontend_class>
             <config_path>payment/adyen_hpp/sort_order</config_path>
+            <depends>
+                <field id="active">1</field>
+            </depends>
         </field>
         <field id="adyen_hpp_vault_active" translate="label" type="select" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
             <label>Store alternative payment methods</label>
             <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-            <tooltip>Currently we support SEPA tokenization only</tooltip>
+            <tooltip>Alternative payment methods will only be shown during checkout if Magento Vault is not being used. Currently only SEPA tokenization is supported.</tooltip>
             <config_path>payment/adyen_hpp_vault/active</config_path>
+            <depends>
+                <field id="active">1</field>
+            </depends>
         </field>
         <field id="adyen_hpp_token_type" translate="label" type="select" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
             <label>Token type</label>
-            <tooltip>Currently only SEPA tokenization is supported</tooltip>
             <source_model>Adyen\Payment\Model\Config\Source\RecurringPaymentType</source_model>
             <config_path>payment/adyen_hpp/token_type</config_path>
             <depends>
+                <field id="active">1</field>
                 <field id="adyen_hpp_vault_active">1</field>
             </depends>
         </field>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -820,6 +820,11 @@
             <argument name="filesystem" xsi:type="object">Magento\Framework\Filesystem\Driver\File</argument>
         </arguments>
     </type>
+    <type name="Adyen\Payment\Logger\Handler\AdyenWarning">
+        <arguments>
+            <argument name="filesystem" xsi:type="object">Magento\Framework\Filesystem\Driver\File</argument>
+        </arguments>
+    </type>
     <type name="Adyen\Payment\Logger\Handler\AdyenError">
         <arguments>
             <argument name="filesystem" xsi:type="object">Magento\Framework\Filesystem\Driver\File</argument>
@@ -835,6 +840,7 @@
                 <item name="adyenCronjob" xsi:type="object">Adyen\Payment\Logger\Handler\AdyenCronjob</item>
                 <item name="adyenInfo" xsi:type="object">Adyen\Payment\Logger\Handler\AdyenInfo</item>
                 <item name="adyenError" xsi:type="object">Adyen\Payment\Logger\Handler\AdyenError</item>
+                <item name="adyenWarning" xsi:type="object">Adyen\Payment\Logger\Handler\AdyenWarning</item>
                 <item name="system" xsi:type="object">Magento\Framework\Logger\Handler\System</item>
                 <item name="debug" xsi:type="object">Magento\Framework\Logger\Handler\Debug</item>
             </argument>

--- a/view/frontend/web/js/view/payment/method-renderer/adyen-oneclick-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-oneclick-method.js
@@ -369,6 +369,14 @@ define(
                                 let stateData;
                                 if ('component' in self) {
                                     stateData = self.component.data;
+                                } else if (self.agreement_data.bank) {
+                                    stateData = {
+                                        paymentMethod: {
+                                            type: self.agreement_data.variant,
+                                            iban: self.agreement_data.bank.iban,
+                                            ownerName: self.agreement_data.bank.ownerName
+                                        }
+                                    };
                                 } else {
                                     stateData = {
                                         paymentMethod: {
@@ -387,7 +395,6 @@ define(
                                 };
                             },
                             validate: function () {
-
                                 var code = self.item.method;
                                 var value = this.value;
                                 var codeValue = code + '_' + value;

--- a/view/frontend/web/js/view/payment/method-renderer/adyen-oneclick-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-oneclick-method.js
@@ -239,7 +239,8 @@ define(
 
                         // for recurring enable the placeOrder button at all times
                         var placeOrderAllowed = true;
-                        if (self.hasVerification()) {
+                        // if verification returns true and this is a card token
+                        if (self.hasVerification() && billingAgreement.agreement_data.card) {
                             placeOrderAllowed = false;
                         } else {
                             // for recurring cards there is no validation needed
@@ -296,7 +297,6 @@ define(
                                     additionalValidators.validate()) {
                                     fullScreenLoader.startLoader();
                                     this.isPlaceOrderActionAllowed(false);
-
                                     this.getPlaceOrderDeferredObject().fail(
                                         function () {
                                             fullScreenLoader.stopLoader();
@@ -369,6 +369,12 @@ define(
                                 let stateData;
                                 if ('component' in self) {
                                     stateData = self.component.data;
+                                } else {
+                                    stateData = {
+                                        paymentMethod: {
+                                            type: self.agreement_data.variant,
+                                        }
+                                    };
                                 }
                                 stateData = JSON.stringify(stateData);
                                 window.sessionStorage.setItem('adyen.stateData', stateData);
@@ -392,10 +398,7 @@ define(
                                     $(form).validation('isValid');
 
                                 // bcmc does not have any cvc
-                                if (!validate ||
-                                    (isValid() == false && variant() !=
-                                        'bcmc' && variant() !=
-                                        'maestro')) {
+                                if (!validate || (isValid() == false && variant() != 'bcmc' && variant() != 'maestro' && variant() != 'sepadirectdebit')) {
                                     return false;
                                 }
 
@@ -424,10 +427,7 @@ define(
                                 return self.afterPlaceOrder(); // needed for placeOrder method
                             },
                             getPlaceOrderDeferredObject: function () {
-                                return $.when(
-                                    placeOrderAction(this.getData(),
-                                        this.getMessageContainer()),
-                                );
+                                return $.when(placeOrderAction(this.getData(), this.getMessageContainer()));
                             },
                         };
                     });


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
Currently we are attempting to tokenize any alternative payment methods based on the settings related to stored card payments. The functionality should be divided and a list of payment methods that support recurring should be created. However from this list, only SEPA should be enabled for now.

Also add a new `Token Type` option to identify if the created token for alternative payment methods is a [CardOnFile](https://docs.adyen.com/online-payments/tokenization/create-and-use-tokens#save-for-one-off) or a [Subscription](https://docs.adyen.com/online-payments/tokenization/create-and-use-tokens?tab=subscriptions_2#save-for-subscriptions) token.

**Note that when upgrading the current `Store alternative payment methods` option will be set to *No*. This is done to ensure that once enabled, the admin will also choose what type of token should be created.**

**Tested scenarios**
* Card payment
* Card payment (CardOnFile token created)
* Card payment (Subscription token created)
* Tokenized card payment (CardOnFile)
* SEPA payment
* SEPA payment (CardOnFile token created)
* SEPA payment (Subscription token created)