### PR TITLE
[PW-6238] Set authorized amount in sales_order_payment

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 name: Main CI workflow
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   build:

--- a/Cron/WebhookProcessor.php
+++ b/Cron/WebhookProcessor.php
@@ -28,6 +28,7 @@ use Adyen\Payment\Helper\Webhook;
 use Adyen\Payment\Logger\AdyenLogger;
 use Adyen\Payment\Model\Notification;
 use Adyen\Payment\Model\ResourceModel\Notification\CollectionFactory;
+use Exception;
 
 class WebhookProcessor
 {
@@ -47,7 +48,6 @@ class WebhookProcessor
      * @var Webhook
      */
     private $webhookHelper;
-
 
     /**
      * Cron constructor.
@@ -70,20 +70,20 @@ class WebhookProcessor
      * Run the webhook processor
      *
      * @return void
-     * @throws \Exception
+     * @throws Exception
      */
     public function execute()
     {
         try {
             $this->doProcessWebhook();
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             $this->adyenLogger->addAdyenNotificationCronjob($e->getMessage() . "\n" . $e->getTraceAsString());
             throw $e;
         }
     }
 
     /**
-     * @throws \Exception
+     * @throws Exception
      */
     public function doProcessWebhook()
     {
@@ -97,13 +97,12 @@ class WebhookProcessor
         foreach ($notifications as $notification) {
             // ignore duplicate notification
             if ($notification->isDuplicate(
-                    $notification->getPspreference(),
-                    $notification->getEventCode(),
-                    $notification->getSuccess(),
-                    $notification->getOriginalReference(),
-                    true
-                )
-            ) {
+                $notification->getPspreference(),
+                $notification->getEventCode(),
+                $notification->getSuccess(),
+                $notification->getOriginalReference(),
+                true
+            )) {
                 $this->adyenLogger->addAdyenNotificationCronjob(
                     "This is a duplicate notification and will be ignored",
                     $notification->toArray(['entity_id', 'pspreference', 'event_code', 'success', 'original_reference'])
@@ -116,7 +115,7 @@ class WebhookProcessor
                 continue;
             }
 
-            if($this->webhookHelper->processNotification($notification)) {
+            if ($this->webhookHelper->processNotification($notification)) {
                 $count++;
             }
         }

--- a/Helper/Webhook.php
+++ b/Helper/Webhook.php
@@ -884,6 +884,12 @@ class Webhook
         if ($isFullAmountAuthorized) {
             $this->setPrePaymentAuthorized();
             $this->prepareInvoice($notification);
+
+            // Set authorized amount in sales_order_payment
+            $orderAmountCurrency = $this->chargedCurrency->getOrderAmountCurrency($this->order, false);
+            $orderAmount = $orderAmountCurrency->getAmount();
+            $this->order->getPayment()->setAmountAuthorized($orderAmount);
+
             // For Boleto confirmation mail is sent on order creation
             // Send order confirmation mail after invoice creation so merchant can add invoicePDF to this mail
             if ($notification->getPaymentMethod() != "adyen_boleto" && !$this->order->getEmailSent()) {

--- a/Helper/Webhook.php
+++ b/Helper/Webhook.php
@@ -885,11 +885,6 @@ class Webhook
             $this->setPrePaymentAuthorized();
             $this->prepareInvoice($notification);
 
-            // Set authorized amount in sales_order_payment
-            $orderAmountCurrency = $this->chargedCurrency->getOrderAmountCurrency($this->order, false);
-            $orderAmount = $orderAmountCurrency->getAmount();
-            $this->order->getPayment()->setAmountAuthorized($orderAmount);
-
             // For Boleto confirmation mail is sent on order creation
             // Send order confirmation mail after invoice creation so merchant can add invoicePDF to this mail
             if ($notification->getPaymentMethod() != "adyen_boleto" && !$this->order->getEmailSent()) {
@@ -898,6 +893,11 @@ class Webhook
         } else {
             $this->addProcessedStatusHistoryComment($notification);
         }
+
+        // Set authorized amount in sales_order_payment
+        $orderAmountCurrency = $this->chargedCurrency->getOrderAmountCurrency($this->order, false);
+        $orderAmount = $orderAmountCurrency->getAmount();
+        $this->order->getPayment()->setAmountAuthorized($orderAmount);
 
         if ($notification->getPaymentMethod() == "c_cash" &&
             $this->configHelper->getConfigData('create_shipment', 'adyen_cash', $this->order->getStoreId())

--- a/Test/Unit/Helper/WebhookTest.php
+++ b/Test/Unit/Helper/WebhookTest.php
@@ -29,6 +29,7 @@ use Magento\Sales\Model\Order\Email\Sender\InvoiceSender;
 use Magento\Sales\Model\Order\Email\Sender\OrderSender;
 use Magento\Sales\Model\Order\InvoiceFactory as MagentoInvoiceFactory;
 use Magento\Sales\Model\Order\Payment;
+use Magento\Sales\Model\Order\Payment\Transaction;
 use Magento\Sales\Model\Order\Payment\Transaction\Builder;
 use Magento\Sales\Model\OrderRepository;
 use Magento\Sales\Model\ResourceModel\Order\Invoice as InvoiceResourceModel;
@@ -46,12 +47,15 @@ class WebhookTest extends TestCase
     private $orderSender;
     private $adyenOrderPaymentCollectionFactory;
     private $caseManagementHelper;
+    private $adyenOrderPaymentHelper;
+    private $transactionBuilder;
+    private $payment;
 
     protected function setUp(): void
     {
-        $payment = $this->createMock(Payment::class);
+        $this->payment = $this->createMock(Payment::class);
         $this->order = $this->createMock(Order::class);
-        $this->order->method('getPayment')->willReturn($payment);
+        $this->order->method('getPayment')->willReturn($this->payment);
         $this->order->method('getGlobalCurrencyCode')->willReturn('EUR');
         $this->order->method('getOrderCurrencyCode')->willReturn('EUR');
         $this->order->method('getBaseGrandTotal')->willReturn('64.0000');
@@ -76,6 +80,8 @@ class WebhookTest extends TestCase
             ->setMethods(['create'])
             ->getMock();
         $this->caseManagementHelper = $this->createMock(CaseManagement::class);
+        $this->adyenOrderPaymentHelper = $this->createMock(AdyenOrderPayment::class);
+        $this->transactionBuilder = $this->createMock(Builder::class);
 
         $this->sut = new Webhook(
             $this->createMock(ScopeConfigInterface::class),
@@ -91,7 +97,7 @@ class WebhookTest extends TestCase
             $this->adyenOrderPaymentCollectionFactory,
             $this->createGeneratedMock(OrderStatusCollectionFactory::class),
             $this->createMock(Agreement::class),
-            $this->createMock(Builder::class),
+            $this->transactionBuilder,
             $this->createMock(SerializerInterface::class),
             $this->createMock(NotifierInterface::class),
             $this->createMock(TimezoneInterface::class),
@@ -103,7 +109,7 @@ class WebhookTest extends TestCase
             new ChargedCurrency($this->configHelper),
             $this->createMock(PaymentMethodsHelper::class),
             $this->createMock(InvoiceResourceModel::class),
-            $this->createMock(AdyenOrderPayment::class),
+            $this->adyenOrderPaymentHelper,
             $this->createMock(InvoiceHelper::class),
             $this->caseManagementHelper,
             $this->createGeneratedMock(PaymentFactory::class),
@@ -136,6 +142,30 @@ class WebhookTest extends TestCase
         $notification->expects($this->once())
             ->method('setDone')
             ->with(true);
+
+        $result = $this->sut->processNotification($notification);
+
+        $this->assertTrue($result);
+    }
+
+    public function testProcessNotificationAuthorisationFullAmount()
+    {
+        $this->adyenOrderPaymentHelper->method('isFullAmountAuthorized')->willReturn(true);
+        $this->transactionBuilder->method('setPayment')->willReturnSelf();
+        $this->transactionBuilder->method('setOrder')->willReturnSelf();
+        $this->transactionBuilder->method('setTransactionId')->willReturnSelf();
+        $this->transactionBuilder->method('build')->willReturn($this->createMock(Transaction::class));
+        $this->order->method('getState')->willReturn(Order::STATE_NEW);
+        $notification = $this->createConfiguredMock(Notification::class, [
+            'getEventCode' => 'AUTHORISATION',
+            'getSuccess' => true,
+        ]);
+        $this->orderSender->expects($this->once())
+            ->method('send')
+            ->with($this->order);
+        $this->payment->expects($this->once())
+            ->method('setAmountAuthorized')
+            ->with('64.0000');
 
         $result = $this->sut->processNotification($notification);
 


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**

The `amount_authorized` field in `sales_order_payment` table was not getting populated for Adyen HPP, but the credit cards are already initialized in Magento `Payment.php` so the table is updating properly.

With this PR when receiving a `AUTHORISATION` notification and the amount is full authorised, then the amount is updated in the `sales_order_payment` table.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

Tested for CC and IDeal. 