### PR TITLE
[PW-6427] - GraphQL add cart id

### DIFF
--- a/Logger/AdyenLogger.php
+++ b/Logger/AdyenLogger.php
@@ -34,7 +34,6 @@ class AdyenLogger extends Logger
     const ADYEN_NOTIFICATION = 201;
     const ADYEN_RESULT = 202;
     const ADYEN_NOTIFICATION_CRONJOB = 203;
-    const ADYEN_WARNING = 301;
 
     /**
      * Logging levels from syslog protocol defined in RFC 5424
@@ -51,7 +50,6 @@ class AdyenLogger extends Logger
         203 => 'ADYEN_NOTIFICATION_CRONJOB',
         250 => 'NOTICE',
         300 => 'WARNING',
-        301 => 'ADYEN_WARNING',
         400 => 'ERROR',
         500 => 'CRITICAL',
         550 => 'ALERT',

--- a/Logger/Handler/AdyenWarning.php
+++ b/Logger/Handler/AdyenWarning.php
@@ -35,7 +35,7 @@ class AdyenWarning extends AdyenBase
     /**
      * @var int
      */
-    protected $loggerType = AdyenLogger::ADYEN_WARNING;
+    protected $loggerType = AdyenLogger::WARNING;
 
-    protected $level = AdyenLogger::ADYEN_WARNING;
+    protected $level = AdyenLogger::WARNING;
 }

--- a/Model/Resolver/GetAdyenPaymentDetails.php
+++ b/Model/Resolver/GetAdyenPaymentDetails.php
@@ -25,11 +25,14 @@ declare(strict_types=1);
 
 namespace Adyen\Payment\Model\Resolver;
 
+use Adyen\Payment\Logger\AdyenLogger;
 use Magento\Framework\GraphQl\Config\Element\Field;
 use Magento\Framework\GraphQl\Exception\GraphQlInputException;
+use Magento\Framework\GraphQl\Exception\GraphQlNoSuchEntityException;
 use Magento\Framework\GraphQl\Query\ResolverInterface;
 use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
 use Magento\Framework\Serialize\Serializer\Json;
+use Magento\QuoteGraphQl\Model\Cart\GetCartForUser;
 use Magento\Sales\Model\Order;
 
 class GetAdyenPaymentDetails implements ResolverInterface
@@ -49,16 +52,34 @@ class GetAdyenPaymentDetails implements ResolverInterface
     protected $jsonSerializer;
 
     /**
-     * @param DataProvider\GetAdyenPaymentStatus $getAdyenPaymentStatusRepository
+     * @var GetCartForUser
+     */
+    protected $getCartForUser;
+
+    /**
+     * @var AdyenLogger
+     */
+    protected $adyenLogger;
+
+    /**
+     * @param DataProvider\GetAdyenPaymentStatus $getAdyenPaymentStatusDataProvider
+     * @param Order $order
+     * @param Json $jsonSerializer
+     * @param GetCartForUser $getCartForUser
+     * @param AdyenLogger $adyenLogger
      */
     public function __construct(
         DataProvider\GetAdyenPaymentStatus $getAdyenPaymentStatusDataProvider,
         Order $order,
-        Json $jsonSerializer
+        Json $jsonSerializer,
+        GetCartForUser $getCartForUser,
+        AdyenLogger $adyenLogger
     ) {
         $this->getAdyenPaymentStatusDataProvider = $getAdyenPaymentStatusDataProvider;
         $this->order = $order;
         $this->jsonSerializer = $jsonSerializer;
+        $this->getCartForUser = $getCartForUser;
+        $this->adyenLogger = $adyenLogger;
     }
 
     /**
@@ -73,11 +94,34 @@ class GetAdyenPaymentDetails implements ResolverInterface
     ) {
         if (empty($args['payload'])) {
             throw new GraphQlInputException(__('Required parameter "payload" is missing'));
+        } elseif (empty($args['cart_id'])) {
+            throw new GraphQlInputException(__('Required parameter "cart_id" is missing'));
         }
 
-        $payload = $this->jsonSerializer->unserialize($args['payload']);
-        $orderId = $this->order->loadByIncrementId($payload['orderId'])->getId();
-        $payload['orderId'] = $orderId;
+        $maskedCartId = $args['cart_id'];
+
+        $currentUserId = $context->getUserId();
+        $storeId = (int)$context->getExtensionAttributes()->getStore()->getId();
+
+        try {
+            $payload = $this->jsonSerializer->unserialize($args['payload']);
+            $cart = $this->getCartForUser->execute($maskedCartId, $currentUserId, $storeId);
+            $order = $this->order->loadByIncrementId($payload['orderId']);
+            $orderId = $order->getEntityId();
+
+            if (is_null($orderId) || $order->getQuoteId() !== $cart->getEntityId()) {
+                throw new GraphQlNoSuchEntityException(__('Order does not exist'));
+            }
+        } catch (GraphQlNoSuchEntityException $exception) {
+            if (isset($payload) && array_key_exists('orderId', $payload)) {
+                $this->adyenLogger->addWarning(sprintf('Attempted to get the payment details for order %s.', $payload['orderId']));
+            }
+
+            throw $exception;
+        }
+
+        // Set the orderId in the payload to the entity id, instead of the incrementId
+        $payload['orderId'] = $order->getId();
 
         return $this->getAdyenPaymentStatusDataProvider->getGetAdyenPaymentDetails($this->jsonSerializer->serialize($payload));
     }

--- a/Model/Resolver/GetAdyenPaymentMethods.php
+++ b/Model/Resolver/GetAdyenPaymentMethods.php
@@ -35,15 +35,16 @@ use Magento\QuoteGraphQl\Model\Cart\GetCartForUser;
 
 class GetAdyenPaymentMethods implements ResolverInterface
 {
-
     /**
      * @var GetCartForUser
      */
     protected $getCartForUser;
+
     /**
      * @var PaymentMethods
      */
     protected $_paymentMethodsHelper;
+
     /**
      * @var Json
      */

--- a/Model/Resolver/GetAdyenPaymentStatus.php
+++ b/Model/Resolver/GetAdyenPaymentStatus.php
@@ -92,12 +92,9 @@ class GetAdyenPaymentStatus implements ResolverInterface
             throw new GraphQlInputException(__('Required parameter "cart_id" is missing'));
         }
 
-        if (isset($args['orderId'])) {
-            $orderIncrementId = $args['orderId'];
-        } else {
-            $orderIncrementId = $value['order_id'];
-        }
-        $maskedCartId = $args['cartId'];
+        // Get the required values either from the passed arguments OR the query parameters (used in request chaining)
+        $orderIncrementId = $args['orderId'] ?? $value['order_id'];
+        $maskedCartId = $args['cartId'] ?? $value['cart_id'];
 
         $currentUserId = $context->getUserId();
         $storeId = (int)$context->getExtensionAttributes()->getStore()->getId();
@@ -113,7 +110,10 @@ class GetAdyenPaymentStatus implements ResolverInterface
             return $this->getAdyenPaymentStatusDataProvider->getGetAdyenPaymentStatus($orderId);
 
         } catch (NoSuchEntityException $e) {
-            $this->adyenLogger->addWarning(sprintf('Attempted to get the payment status for order %s.', $orderIncrementId));
+            $this->adyenLogger->addWarning(sprintf(
+                'Attempted to get the payment status for order %s. Exception: %s',
+                $orderIncrementId, $e->getMessage()
+            ));
 
             throw new GraphQlNoSuchEntityException(__('Order does not exist'));
         }

--- a/Model/Resolver/GetAdyenPaymentStatus.php
+++ b/Model/Resolver/GetAdyenPaymentStatus.php
@@ -86,14 +86,14 @@ class GetAdyenPaymentStatus implements ResolverInterface
         array $value = null,
         array $args = null
     ) {
-        if (empty($args['orderId']) && empty($value['order_id'])) {
+        if (empty($args['orderNumber']) && empty($value['order_number'])) {
             throw new GraphQlInputException(__('Required parameter "order_id" is missing'));
         } elseif (empty($args['cartId']) && empty($value['cart_id'])) {
             throw new GraphQlInputException(__('Required parameter "cart_id" is missing'));
         }
 
         // Get the required values either from the passed arguments OR the query parameters (used in request chaining)
-        $orderIncrementId = $args['orderId'] ?? $value['order_id'];
+        $orderIncrementId = $args['orderNumber'] ?? $value['order_number'];
         $maskedCartId = $args['cartId'] ?? $value['cart_id'];
 
         $currentUserId = $context->getUserId();

--- a/Observer/AdyenHppDataAssignObserver.php
+++ b/Observer/AdyenHppDataAssignObserver.php
@@ -124,7 +124,7 @@ class AdyenHppDataAssignObserver extends AbstractDataAssignObserver
             $stateData = $this->checkoutStateDataValidator->getValidatedAdditionalData($stateData);
         }
 
-        if ($additionalData[self::BRAND_CODE] === Data::SEPA) {
+        if (array_key_exists(self::BRAND_CODE, $additionalData) && $additionalData[self::BRAND_CODE] === Data::SEPA) {
             $additionalDataToSave = $this->getSepaAdditionalDataToSave($stateData);
         }
 

--- a/Plugin/GraphQlPlaceOrderAddCartId.php
+++ b/Plugin/GraphQlPlaceOrderAddCartId.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2022 Adyen BV (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\Payment\Plugin;
+use Adyen\Payment\Helper\Quote;
+use Adyen\Payment\Logger\AdyenLogger;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Quote\Model\QuoteIdToMaskedQuoteIdInterface;
+use Magento\QuoteGraphQl\Model\Resolver\PlaceOrder;
+
+class GraphQlPlaceOrderAddCartId
+{
+    /**
+     * @var Quote
+     */
+    private $quoteHelper;
+
+    /**
+     * @var AdyenLogger
+     */
+    private $adyenLogger;
+
+    /**
+     * @var QuoteIdToMaskedQuoteIdInterface
+     */
+    private $quoteIdToMaskedQuoteId;
+
+    /**
+     * GraphQlPlaceOrderAddCartId constructor.
+     * @param Quote $quoteHelper
+     * @param AdyenLogger $adyenLogger
+     * @param QuoteIdToMaskedQuoteIdInterface $quoteIdToMaskedQuoteId
+     */
+    public function __construct(
+        Quote $quoteHelper,
+        AdyenLogger $adyenLogger,
+        QuoteIdToMaskedQuoteIdInterface $quoteIdToMaskedQuoteId
+    )
+    {
+        $this->quoteHelper = $quoteHelper;
+        $this->adyenLogger = $adyenLogger;
+        $this->quoteIdToMaskedQuoteId = $quoteIdToMaskedQuoteId;
+    }
+
+    /**
+     * This function adds the masked cart_id to the output of PlaceOrder::resolve
+     *
+     * @param PlaceOrder $placeOrder
+     * @param array $result
+     * @return array
+     */
+    public function afterResolve(PlaceOrder $placeOrder, array $result): array
+    {
+        try {
+            $cart = $this->quoteHelper->getQuoteByOrderIncrementId($result['order']['order_number']);
+            $maskedId = $this->quoteIdToMaskedQuoteId->execute($cart->getId());
+            $result['order']['cart_id'] = $maskedId;
+        } catch (NoSuchEntityException $exception) {
+            $this->adyenLogger->addError($exception->getMessage());
+        }
+
+        return $result;
+    }
+}

--- a/Test/api-functional/GraphQl/AdyenTest.php
+++ b/Test/api-functional/GraphQl/AdyenTest.php
@@ -251,7 +251,7 @@ mutation {
 
     placeOrder(
         input: {
-            cart_id: $maskedQuoteId
+            cart_id: "$maskedQuoteId"
         }
     ) {
         order {

--- a/Test/api-functional/GraphQl/AdyenTest.php
+++ b/Test/api-functional/GraphQl/AdyenTest.php
@@ -100,10 +100,32 @@ QUERY;
         self::assertArrayHasKey('setPaymentMethodAndPlaceOrder', $response);
         self::assertArrayHasKey('order', $response['setPaymentMethodAndPlaceOrder']);
         self::assertArrayHasKey('order_number', $response['setPaymentMethodAndPlaceOrder']['order']);
-        self::assertArrayHasKey('adyen_payment_status', $response['setPaymentMethodAndPlaceOrder']['order']);
-        self::assertArrayHasKey('isFinal', $response['setPaymentMethodAndPlaceOrder']['order']['adyen_payment_status']);
-        self::assertArrayHasKey('resultCode', $response['setPaymentMethodAndPlaceOrder']['order']['adyen_payment_status']);
-        self::assertArrayHasKey('action', $response['setPaymentMethodAndPlaceOrder']['order']['adyen_payment_status']);
+
+        $orderNumber = $response['setPaymentMethodAndPlaceOrder']['order']['order_number'];
+
+        $query =
+            <<<QUERY
+{
+    adyenPaymentStatus(orderId: "$orderNumber", cartId: "$maskedQuoteId") {
+        isFinal
+        resultCode
+        additionalData
+        action
+    }
+}
+QUERY;
+
+        $response = $this->graphQlQuery(
+            $query,
+            [],
+            '',
+        );
+
+        $adyenPaymentStatusArray = $response['adyen_payment_status'];
+
+        self::assertArrayHasKey('isFinal', $adyenPaymentStatusArray);
+        self::assertArrayHasKey('resultCode', $adyenPaymentStatusArray);
+        self::assertArrayHasKey('action', $adyenPaymentStatusArray);
     }
 
     /**
@@ -241,17 +263,9 @@ mutation {
   }) {
     order {
       order_number,
-      adyen_payment_status {
-        isFinal,
-        resultCode,
-        additionalData,
-        action
-        }
     }
   }
 }
 QUERY;
     }
-
-
 }

--- a/Test/api-functional/GraphQl/AdyenTest.php
+++ b/Test/api-functional/GraphQl/AdyenTest.php
@@ -97,13 +97,14 @@ QUERY;
         $query = $this->getPlaceOrderQuery($maskedQuoteId, $methodCode, $adyenAdditionalData);
         $response = $this->graphQlMutation($query);
 
-        self::assertArrayHasKey('setPaymentMethodAndPlaceOrder', $response);
-        self::assertArrayHasKey('order', $response['setPaymentMethodAndPlaceOrder']);
-        self::assertArrayHasKey('order_number', $response['setPaymentMethodAndPlaceOrder']['order']);
-        self::assertArrayHasKey('adyen_payment_status', $response['setPaymentMethodAndPlaceOrder']['order']);
-        self::assertArrayHasKey('isFinal', $response['setPaymentMethodAndPlaceOrder']['order']['adyen_payment_status']);
-        self::assertArrayHasKey('resultCode', $response['setPaymentMethodAndPlaceOrder']['order']['adyen_payment_status']);
-        self::assertArrayHasKey('action', $response['setPaymentMethodAndPlaceOrder']['order']['adyen_payment_status']);
+        self::assertArrayHasKey('placeOrder', $response);
+        self::assertArrayHasKey('order', $response['placeOrder']);
+        self::assertArrayHasKey('order_number', $response['placeOrder']['order']);
+        self::assertArrayHasKey('cart_id', $response['placeOrder']['order']);
+        self::assertArrayHasKey('adyen_payment_status', $response['placeOrder']['order']);
+        self::assertArrayHasKey('isFinal', $response['placeOrder']['order']['adyen_payment_status']);
+        self::assertArrayHasKey('resultCode', $response['placeOrder']['order']['adyen_payment_status']);
+        self::assertArrayHasKey('action', $response['placeOrder']['order']['adyen_payment_status']);
     }
 
     /**

--- a/Test/api-functional/GraphQl/AdyenTest.php
+++ b/Test/api-functional/GraphQl/AdyenTest.php
@@ -232,24 +232,39 @@ QUERY;
     {
         return <<<QUERY
 mutation {
-  setPaymentMethodAndPlaceOrder(input: {
-      cart_id: "$maskedQuoteId"
-      payment_method: {
-          code: "$methodCode",
-          {$adyenAdditionalData}
-      }
-  }) {
-    order {
-      order_number
-      cart_id
-      adyen_payment_status {
-        isFinal
-        resultCode
-        additionalData
-        action
-      }
+    setPaymentMethodOnCart(
+        input: {
+            cart_id: $maskedQuoteId
+            payment_method: {
+              code: "$methodCode",
+              {$adyenAdditionalData}
+            }
+        }
+    ) {
+        cart {
+            selected_payment_method {
+                code
+                title
+            }
+        }
     }
-  }
+
+    placeOrder(
+        input: {
+            cart_id: $maskedQuoteId
+        }
+    ) {
+        order {
+            order_number
+            cart_id
+            adyen_payment_status {
+                isFinal
+                resultCode
+                additionalData
+                action
+            }
+        }
+    }
 }
 QUERY;
     }

--- a/Test/api-functional/GraphQl/AdyenTest.php
+++ b/Test/api-functional/GraphQl/AdyenTest.php
@@ -234,7 +234,7 @@ QUERY;
 mutation {
     setPaymentMethodOnCart(
         input: {
-            cart_id: $maskedQuoteId
+            cart_id: "$maskedQuoteId"
             payment_method: {
               code: "$methodCode",
               {$adyenAdditionalData}

--- a/Test/api-functional/GraphQl/AdyenTest.php
+++ b/Test/api-functional/GraphQl/AdyenTest.php
@@ -100,32 +100,10 @@ QUERY;
         self::assertArrayHasKey('setPaymentMethodAndPlaceOrder', $response);
         self::assertArrayHasKey('order', $response['setPaymentMethodAndPlaceOrder']);
         self::assertArrayHasKey('order_number', $response['setPaymentMethodAndPlaceOrder']['order']);
-
-        $orderNumber = $response['setPaymentMethodAndPlaceOrder']['order']['order_number'];
-
-        $query =
-            <<<QUERY
-{
-    adyenPaymentStatus(orderId: "$orderNumber", cartId: "$maskedQuoteId") {
-        isFinal
-        resultCode
-        additionalData
-        action
-    }
-}
-QUERY;
-
-        $response = $this->graphQlQuery(
-            $query,
-            [],
-            '',
-        );
-
-        $adyenPaymentStatusArray = $response['adyenPaymentStatus'];
-
-        self::assertArrayHasKey('isFinal', $adyenPaymentStatusArray);
-        self::assertArrayHasKey('resultCode', $adyenPaymentStatusArray);
-        self::assertArrayHasKey('action', $adyenPaymentStatusArray);
+        self::assertArrayHasKey('adyen_payment_status', $response['setPaymentMethodAndPlaceOrder']['order']);
+        self::assertArrayHasKey('isFinal', $response['setPaymentMethodAndPlaceOrder']['order']['adyen_payment_status']);
+        self::assertArrayHasKey('resultCode', $response['setPaymentMethodAndPlaceOrder']['order']['adyen_payment_status']);
+        self::assertArrayHasKey('action', $response['setPaymentMethodAndPlaceOrder']['order']['adyen_payment_status']);
     }
 
     /**
@@ -262,7 +240,14 @@ mutation {
       }
   }) {
     order {
-      order_number,
+      order_number
+      cart_id
+      adyen_payment_status {
+        isFinal
+        resultCode
+        additionalData
+        action
+      }
     }
   }
 }

--- a/Test/api-functional/GraphQl/AdyenTest.php
+++ b/Test/api-functional/GraphQl/AdyenTest.php
@@ -121,7 +121,7 @@ QUERY;
             '',
         );
 
-        $adyenPaymentStatusArray = $response['adyen_payment_status'];
+        $adyenPaymentStatusArray = $response['adyenPaymentStatus'];
 
         self::assertArrayHasKey('isFinal', $adyenPaymentStatusArray);
         self::assertArrayHasKey('resultCode', $adyenPaymentStatusArray);

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -958,7 +958,7 @@
                 sortOrder="10"/>
     </type>
     <type name="Magento\QuoteGraphQl\Model\Resolver\PlaceOrder">
-        <plugin name="GraphQlPlaceOrder" type="Adyen\Payment\Plugin\GraphQlPlaceOrder" sortOrder="10"/>
+        <plugin name="GraphQlPlaceOrderAddCartId" type="Adyen\Payment\Plugin\GraphQlPlaceOrderAddCartId" sortOrder="10"/>
     </type>
 
     <virtualType name="AdyenCancelOrders" type="Adyen\Payment\Cron\CancelOrders">

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -957,6 +957,9 @@
         <plugin name="GuestAdyenPaymentInformationResetOrderId" type="Adyen\Payment\Plugin\GuestPaymentInformationResetOrderId"
                 sortOrder="10"/>
     </type>
+    <type name="Magento\QuoteGraphQl\Model\Resolver\PlaceOrder">
+        <plugin name="GraphQlPlaceOrder" type="Adyen\Payment\Plugin\GraphQlPlaceOrder" sortOrder="10"/>
+    </type>
 
     <virtualType name="AdyenCancelOrders" type="Adyen\Payment\Cron\CancelOrders">
         <arguments>

--- a/etc/schema.graphqls
+++ b/etc/schema.graphqls
@@ -1,7 +1,7 @@
 type Query {
     adyenPaymentStatus (
         orderId: String @doc(description: "Magento Increment Order ID.")
-        cartId: String! @doc(description: "Cart ID.")
+        cartId: String @doc(description: "Cart ID.")
     ) : AdyenPaymentStatus @resolver(class: "Adyen\\Payment\\Model\\Resolver\\GetAdyenPaymentStatus")
 
     adyenPaymentMethods (
@@ -79,10 +79,6 @@ type AdyenPaymentMethodIcon {
 type AdyenPaymentMethodsExtraDetailsConfiguration {
     amount: Money @doc(description: "Current order amount in minor units.")
     currency: String @doc(description: "Current order currency.")
-}
-
-type Order {
-    adyen_payment_status: AdyenPaymentStatus @resolver(class: "Adyen\\Payment\\Model\\Resolver\\GetAdyenPaymentStatus")
 }
 
 input PaymentMethodInput {

--- a/etc/schema.graphqls
+++ b/etc/schema.graphqls
@@ -10,6 +10,7 @@ type Query {
 
     adyenPaymentDetails (
         payload: String! @doc(description: "Payload JSON String with orderId, details, paymentData and threeDSAuthenticationOnly.")
+        cart_id: String! @doc(description: "Cart ID.")
     ) : AdyenPaymentStatus @resolver(class: "Adyen\\Payment\\Model\\Resolver\\GetAdyenPaymentDetails")
 }
 

--- a/etc/schema.graphqls
+++ b/etc/schema.graphqls
@@ -32,11 +32,7 @@ type AdyenPaymentMethodsResponse {
 
 type PlaceOrderOutput {
     order: Order!,
-    cart: CartMaskedId!
-}
-
-type CartMaskedId {
-    id: String! @doc(description: "Cart ID.")
+    cart: Cart!
 }
 
 type AdyenPaymentMethodsArray {

--- a/etc/schema.graphqls
+++ b/etc/schema.graphqls
@@ -1,6 +1,7 @@
 type Query {
     adyenPaymentStatus (
         orderId: String @doc(description: "Magento Increment Order ID.")
+        cartId: String! @doc(description: "Cart ID.")
     ) : AdyenPaymentStatus @resolver(class: "Adyen\\Payment\\Model\\Resolver\\GetAdyenPaymentStatus")
 
     adyenPaymentMethods (

--- a/etc/schema.graphqls
+++ b/etc/schema.graphqls
@@ -30,6 +30,15 @@ type AdyenPaymentMethodsResponse {
     paymentMethods: [AdyenPaymentMethodsArray]
 }
 
+type PlaceOrderOutput {
+    order: Order!,
+    cart: CartMaskedId!
+}
+
+type CartMaskedId {
+    id: String! @doc(description: "Cart ID.")
+}
+
 type AdyenPaymentMethodsArray {
     name: String @doc(description: "The displayable name of this payment method.")
     type: String @doc(description: "The unique payment method code.")

--- a/etc/schema.graphqls
+++ b/etc/schema.graphqls
@@ -30,9 +30,9 @@ type AdyenPaymentMethodsResponse {
     paymentMethods: [AdyenPaymentMethodsArray]
 }
 
-type PlaceOrderOutput {
-    order: Order!,
-    cart: Cart!
+type Order {
+    cart_id: String! @doc(description: "Cart ID.")
+    adyen_payment_status: AdyenPaymentStatus @resolver(class: "Adyen\\Payment\\Model\\Resolver\\GetAdyenPaymentStatus")
 }
 
 type AdyenPaymentMethodsArray {


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
This PR will add the `masked_cart_id` requirement to the **GetAdyenPaymentStatus** and the **GetAdyenPaymentDetails** resolvers.

Hence, the **GetAdyenPaymentStatus** will have to be made as a specific separate call, instead of automatically included in the placeOrder resolver, since this resolver does not return the cart_id automatically.

**Tested scenarios**
* Adyen payment methods
* Adyen payment status - guest
* Adyen payment status - logged in
* Adyen payment details - invalid payload
* Adyen payment details - incorrect order number
* Adyen payment details - correct