### PR TITLE
[PW-5810] Enforce correct states when multiple states are assigned to a status

### DIFF
--- a/Helper/Webhook.php
+++ b/Helper/Webhook.php
@@ -1643,8 +1643,6 @@ class Webhook
      */
     private function setState($status, $possibleStates)
     {
-        $this->logger->addAdyenNotificationCronjob('Looking for states: ' . json_encode($possibleStates));
-
         // Loop over possible states, select first available status that fits this state
         foreach ($possibleStates as $state) {
             $statusObject = $this->orderStatusCollection->create()

--- a/Helper/Webhook.php
+++ b/Helper/Webhook.php
@@ -1208,11 +1208,13 @@ class Webhook
             'adyen_abstract',
             $this->order->getStoreId()
         );
+        // Possible states entered by the configured status
+        $possibleStates = ['new', 'processing'];
 
         // only do this if status in configuration is set
         if (!empty($status)) {
             $this->order->setStatus($status);
-            $this->setState($status, ['new', 'processing']);
+            $this->setState($status, $possibleStates);
 
             $this->logger->addAdyenNotificationCronjob(
                 'Order status is changed to Pre-authorised status, status is ' . $status
@@ -1571,6 +1573,8 @@ class Webhook
             'adyen_abstract',
             $order->getStoreId()
         );
+        // Possible states entered by the configured status
+        $possibleStates = ['processing'];
 
         // virtual order can have different status
         if ($order->getIsVirtual()) {
@@ -1625,7 +1629,8 @@ class Webhook
             // Else add comment
             if (!empty($status)) {
                 $order->addStatusHistoryComment(__($comment), $status);
-                $this->setState($status, ['processing']); // TODO: make this dynamic!
+
+                $this->setState($status, $possibleStates);
                 $this->logger->addAdyenNotificationCronjob(
                     'Order status was changed to authorised status: ' . $status
                 );

--- a/Helper/Webhook.php
+++ b/Helper/Webhook.php
@@ -80,6 +80,14 @@ class Webhook
     ];
 
     /**
+     * Indicative matrix for possible states to enter after given event
+     */
+    const STATE_TRANSITION_MATRIX = [
+        'payment_pre_authorized' => [Order::STATE_NEW, Order::STATE_PROCESSING],
+        'payment_authorized' => [Order::STATE_PROCESSING]
+    ];
+
+    /**
      * @var Order
      */
     private $order;
@@ -1203,13 +1211,13 @@ class Webhook
      */
     private function setPrePaymentAuthorized()
     {
+        $eventLabel = "payment_pre_authorized";
         $status = $this->configHelper->getConfigData(
-            'payment_pre_authorized',
+            $eventLabel,
             'adyen_abstract',
             $this->order->getStoreId()
         );
-        // Possible states entered by the configured status
-        $possibleStates = ['new', 'processing'];
+        $possibleStates = self::STATE_TRANSITION_MATRIX[$eventLabel];
 
         // only do this if status in configuration is set
         if (!empty($status)) {
@@ -1568,13 +1576,13 @@ class Webhook
             ->formatAmount($orderAmountCurrency->getAmount(), $orderAmountCurrency->getCurrencyCode());
         $fullAmountFinalized = $this->adyenOrderPaymentHelper->isFullAmountFinalized($order);
 
+        $eventLabel = 'payment_authorized';
         $status = $this->configHelper->getConfigData(
-            'payment_authorized',
+            $eventLabel,
             'adyen_abstract',
             $order->getStoreId()
         );
-        // Possible states entered by the configured status
-        $possibleStates = ['processing'];
+        $possibleStates = self::STATE_TRANSITION_MATRIX[$eventLabel];
 
         // virtual order can have different status
         if ($order->getIsVirtual()) {


### PR DESCRIPTION
**Description**
This PR addresses the issue from #1173.
When configuring statuses, a status can be assigned to multiple states. 
_E.g. the status 'Waiting for capture' can be assigned to both the 'pending_payment' and 'processing' state. When configuring "Order status: payment authorisation" it is possible to select statuses that lead to the 'processing' state, thus 'Waiting for capture' is shown in the dropdown. When this status is selected it is possible for the flow to enter the 'pending_payment' state. This should not be possible._

Further explanation of the problem and the corresponding code can be found in #1173. This PR proposes a solution in which the possible states are passed as a parameter when the `setState` function is called in the Webhook module. Before selecting a state to enter, the list of possible states will be filtered on this parameter. 
_E.g. this will prevent the 'pending_payment' state from the example to be removed._

When multiple states are possible to enter, and the passed status is also tied to all of these states _(e.g. if 'Waiting for capture' would be assigned to both 'new' and 'processing' on "Order status: payment authorisation")_. The first one that fits will be selected. This means the unpredictability is not fully removed, however this should be clear to the user as the 'Waiting for capture' label will appear multiple times in the dropdown.

**Tested scenarios**
- [x] Tested for multiple states

**Fixed issue**: 
Fixes #1173 