### PR TITLE
PW-6425 - Enable the auto capture for AfterPay transactions.

### DIFF
--- a/Gateway/Request/CheckoutDataBuilder.php
+++ b/Gateway/Request/CheckoutDataBuilder.php
@@ -125,7 +125,6 @@ class CheckoutDataBuilder implements BuilderInterface
 
         $brandCode = $payment->getAdditionalInformation(AdyenHppDataAssignObserver::BRAND_CODE);
         if ($this->adyenHelper->isPaymentMethodOpenInvoiceMethod($brandCode)
-            || $this->adyenHelper->isPaymentMethodAfterpayTouchMethod($brandCode)
             || $this->adyenHelper->isPaymentMethodOneyMethod($brandCode)
             || $payment->getMethod() == AdyenPayByLinkConfigProvider::CODE
         ) {

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -998,28 +998,6 @@ class Data extends AbstractHelper
     }
 
     /**
-     * Excludes AfterPay (NL/BE) from the open invoice list.
-     * AfterPay variants should be excluded (not afterpaytouch)as an option for auto capture.
-     * @param $paymentMethod
-     * @return bool
-     */
-    public function isPaymentMethodOpenInvoiceMethodValidForAutoCapture($paymentMethod)
-    {
-        if (strpos($paymentMethod, self::AFTERPAY_TOUCH) !== false ||
-            strpos($paymentMethod, self::KLARNA) !== false ||
-            strpos($paymentMethod, self::RATEPAY) !== false ||
-            strpos($paymentMethod, self::FACILYPAY) !== false ||
-            strpos($paymentMethod, self::AFFIRM) !== false ||
-            strpos($paymentMethod, self::CLEARPAY) !== false ||
-            strpos($paymentMethod, self::ZIP) !== false ||
-            strpos($paymentMethod, self::PAYBRIGHT) !== false
-        ) {
-            return true;
-        }
-
-        return false;
-    }
-    /**
      * @param $paymentMethod
      * @return bool
      */

--- a/Helper/Webhook.php
+++ b/Helper/Webhook.php
@@ -1361,7 +1361,7 @@ class Webhook
 
             // if auto capture mode for openinvoice is turned on then use auto capture
             if ($captureModeOpenInvoice &&
-                $this->adyenHelper->isPaymentMethodOpenInvoiceMethodValidForAutoCapture($notificationPaymentMethod)
+                $this->adyenHelper->isPaymentMethodOpenInvoiceMethod($notificationPaymentMethod)
             ) {
                 $this->logger->addAdyenNotificationCronjob(
                     'This payment method is configured to be working as auto capture '

--- a/etc/adminhtml/system/adyen_order_processing.xml
+++ b/etc/adminhtml/system/adyen_order_processing.xml
@@ -40,7 +40,7 @@
         </field>
         <field id="auto_capture_openinvoice" translate="label" type="select" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
             <label>Use auto-capture for OpenInvoice payments</label>
-            <tooltip>Applicable for Klarna, Afterpay Touch, Ratepay, FacilyPay/Oney, Affirm, Clearpay, Zip and PayBright. By default, Open Invoice methods are set to manual capture. If you want auto capture you need to contact magento@adyen.com. After approval has been given you can set this option to 'Yes'.</tooltip>
+            <tooltip>Applicable for Klarna, Afterpay, Afterpay Touch, Ratepay, FacilyPay/Oney, Affirm, Clearpay, Zip and PayBright. By default, Open Invoice methods are set to manual capture. If you want auto capture you need to contact magento@adyen.com. After approval has been given you can set this option to 'Yes'.</tooltip>
             <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
             <config_path>payment/adyen_abstract/auto_capture_openinvoice</config_path>
         </field>


### PR DESCRIPTION
**Description**
Enable the auto capture for AfterPay transactions.

**Tested scenarios**
Complete the AfterPay transaction with auto-capture for invoice payment methods enabled, checked whether the transaction was successful and the order updated upon the processing of the notifications by cronjob.


Complete manual capture AfterPay transaction with auto-capture for invoice payment method disabled, captured the payment manually within Magento with invoicing it, payment was successfully settled.