### PR TITLE
PW-6442: Remove clone quote and authentication from redirect handler

### DIFF
--- a/Controller/Process/Result.php
+++ b/Controller/Process/Result.php
@@ -153,7 +153,6 @@ class Result extends \Magento\Framework\App\Action\Action
     {
         // Receive all params as this could be a GET or POST request
         $response = $this->getRequest()->getParams();
-        $this->_adyenLogger->addAdyenResult(json_encode($response));
 
         if ($response) {
             $result = $this->validateResponse($response);

--- a/Controller/Process/Result.php
+++ b/Controller/Process/Result.php
@@ -196,25 +196,7 @@ class Result extends \Magento\Framework\App\Action\Action
      */
     protected function replaceCart($response)
     {
-        if ($this->_adyenHelper->getConfigData(
-            "clone_quote",
-            "adyen_abstract",
-            $this->_order->getStoreId(),
-            true
-        )) {
-            try {
-                $newQuote = $this->quoteHelper->cloneQuote($this->_session->getQuote(), $this->_order);
-                $this->_session->replaceQuote($newQuote);
-            } catch (\Magento\Framework\Exception\LocalizedException $e) {
-                $this->_session->restoreQuote();
-                $this->_adyenLogger->addAdyenResult(
-                    'Error when trying to create a new quote, ' .
-                    'the previous quote has been restored instead: ' . $e->getMessage()
-                );
-            }
-        } else {
-            $this->_session->restoreQuote();
-        }
+        $this->_session->restoreQuote();
 
         if (isset($response['authResult']) && $response['authResult'] == \Adyen\Payment\Model\Notification::CANCELLED) {
             $this->messageManager->addError(__('You have cancelled the order. Please try again'));

--- a/Helper/PaymentResponseHandler.php
+++ b/Helper/PaymentResponseHandler.php
@@ -24,10 +24,9 @@
 namespace Adyen\Payment\Helper;
 
 use Adyen\Payment\Logger\AdyenLogger;
+use Exception;
 use Magento\Sales\Api\Data\OrderInterface;
 use Magento\Sales\Api\Data\OrderPaymentInterface;
-use Magento\Sales\Model\Order;
-use Adyen\Payment\Helper\Vault;
 
 class PaymentResponseHandler
 {
@@ -217,7 +216,13 @@ class PaymentResponseHandler
                     }
                 }
                 $this->orderResourceModel->save($order);
-                $this->quoteHelper->disableQuote($order->getQuoteId());
+                try {
+                    $this->quoteHelper->disableQuote($order->getQuoteId());
+                } catch (Exception $e) {
+                    $this->adyenLogger->error('Failed to disable quote: ' . $e->getMessage(), [
+                        'quoteId' => $order->getQuoteId()
+                    ]);
+                }
                 break;
             case self::REFUSED:
                 // Cancel order in case result is refused

--- a/Helper/PaymentResponseHandler.php
+++ b/Helper/PaymentResponseHandler.php
@@ -61,6 +61,10 @@ class PaymentResponseHandler
      * @var \Magento\Sales\Model\ResourceModel\Order
      */
     private $orderResourceModel;
+    /**
+     * @var Quote
+     */
+    private $quoteHelper;
 
     /**
      * PaymentResponseHandler constructor.
@@ -73,12 +77,14 @@ class PaymentResponseHandler
         AdyenLogger $adyenLogger,
         Data $adyenHelper,
         Vault $vaultHelper,
-        \Magento\Sales\Model\ResourceModel\Order $orderResourceModel
+        \Magento\Sales\Model\ResourceModel\Order $orderResourceModel,
+        Quote $quoteHelper
     ) {
         $this->adyenLogger = $adyenLogger;
         $this->adyenHelper = $adyenHelper;
         $this->vaultHelper = $vaultHelper;
         $this->orderResourceModel = $orderResourceModel;
+        $this->quoteHelper = $quoteHelper;
     }
 
     public function formatPaymentResponse($resultCode, $action = null, $additionalData = null)
@@ -201,6 +207,7 @@ class PaymentResponseHandler
                     }
                 }
                 $this->orderResourceModel->save($order);
+                $this->quoteHelper->disableQuote($order->getQuoteId());
                 break;
             case self::REFUSED:
                 // Cancel order in case result is refused

--- a/Helper/Quote.php
+++ b/Helper/Quote.php
@@ -79,14 +79,11 @@ class Quote
     /**
      * Try to disable a quote after successful payment
      * @param $quoteId
+     * @throws NoSuchEntityException
      */
     public function disableQuote($quoteId)
     {
-        try {
-            $quote = $this->quoteRepository->get($quoteId);
-        } catch (NoSuchEntityException $e) {
-            return;
-        }
+        $quote = $this->quoteRepository->get($quoteId);
         if (!$quote || !$quote->getIsActive()) {
             return;
         }

--- a/Helper/Quote.php
+++ b/Helper/Quote.php
@@ -25,15 +25,9 @@
 namespace Adyen\Payment\Helper;
 
 use Magento\Framework\Api\SearchCriteriaBuilder;
-use Magento\Quote\Model\Quote\Address;
-use Magento\Quote\Model\QuoteRepository;
-use Magento\Framework\Exception\AlreadyExistsException;
-use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Quote\Api\CartRepositoryInterface;
-use Magento\Quote\Model\Quote as QuoteModel;
-use Magento\Quote\Model\Quote\AddressFactory as QuoteAddressFactory;
-use Magento\Quote\Model\ResourceModel\Quote\Address as QuoteAddressResource;
-use Magento\Sales\Model\Order;
+use Magento\Quote\Model\QuoteRepository;
 use Magento\Sales\Model\OrderRepository;
 
 class Quote
@@ -47,14 +41,6 @@ class Quote
      */
     private $cartRepository;
     /**
-     * @var QuoteAddressFactory
-     */
-    private $quoteAddressFactory;
-    /**
-     * @var QuoteAddressResource
-     */
-    private $quoteAddressResource;
-    /**
      * @var SearchCriteriaBuilder
      */
     private $searchCriteriaBuilder;
@@ -67,53 +53,12 @@ class Quote
         CartRepositoryInterface $cartRepository,
         QuoteRepository $quoteRepository,
         OrderRepository $orderRepository,
-        QuoteAddressFactory $quoteAddressFactory,
-        QuoteAddressResource $quoteAddressResource,
         SearchCriteriaBuilder $searchCriteriaBuilder
     ) {
         $this->cartRepository = $cartRepository;
         $this->quoteRepository = $quoteRepository;
         $this->orderRepository = $orderRepository;
-        $this->quoteAddressFactory = $quoteAddressFactory;
-        $this->quoteAddressResource = $quoteAddressResource;
         $this->searchCriteriaBuilder = $searchCriteriaBuilder;
-    }
-
-    /**
-     * @param QuoteModel $newQuote
-     * @param Order $previousOrder
-     * @return false|QuoteModel
-     * @throws LocalizedException
-     */
-    public function cloneQuote(QuoteModel $newQuote, Order $previousOrder)
-    {
-        $oldQuote = $this->quoteRepository->get($previousOrder->getQuoteId());
-        $newQuote->merge($oldQuote)->collectTotals();
-        $newQuote->setShippingAddress($oldQuote->getShippingAddress());
-        $newQuote->setBillingAddress($oldQuote->getBillingAddress());
-        $this->cartRepository->save($newQuote);
-        $this->cloneQuoteAddresses($oldQuote, $newQuote);
-        return $newQuote;
-    }
-
-    /**
-     * @param QuoteModel $oldQuote
-     * @param QuoteModel $newQuote
-     * @return false|QuoteModel
-     * @throws AlreadyExistsException
-     */
-    protected function cloneQuoteAddresses(QuoteModel $oldQuote, QuoteModel $newQuote)
-    {
-        foreach ([Address::ADDRESS_TYPE_SHIPPING, Address::ADDRESS_TYPE_BILLING] as $type) {
-            $quoteAddress = $this->quoteAddressFactory->create();
-            if ($type == Address::ADDRESS_TYPE_SHIPPING) {
-                $this->quoteAddressResource->load($quoteAddress, $oldQuote->getShippingAddress()->getId());
-            } else {
-                $this->quoteAddressResource->load($quoteAddress, $oldQuote->getBillingAddress()->getId());
-            }
-            $quoteAddress->setQuoteId($newQuote->getId())->unsetData('address_id');
-            $this->quoteAddressResource->save($quoteAddress);
-        }
     }
 
     public function getIsQuoteMultiShippingWithMerchantReference(string $merchantReference)
@@ -129,5 +74,23 @@ class Quote
         $quote = reset($quoteList);
 
         return $quote->getIsMultiShipping();
+    }
+
+    /**
+     * Try to disable a quote after successful payment
+     * @param $quoteId
+     */
+    public function disableQuote($quoteId)
+    {
+        try {
+            $quote = $this->quoteRepository->get($quoteId);
+        } catch (NoSuchEntityException $e) {
+            return;
+        }
+        if (!$quote || !$quote->getIsActive()) {
+            return;
+        }
+        $quote->setIsActive(false);
+        $this->cartRepository->save($quote);
     }
 }

--- a/Observer/SubmitQuoteObserver.php
+++ b/Observer/SubmitQuoteObserver.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Adyen\Payment\Observer;
+
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+use Magento\Quote\Model\Quote;
+
+/**
+ * Keep cart active based on payment method
+ */
+class SubmitQuoteObserver implements ObserverInterface
+{
+    public function execute(Observer $observer)
+    {
+        /** @var Quote $quote */
+        $quote = $observer->getEvent()->getQuote();
+        $method = $quote->getPayment()->getMethod();
+        if (in_array($method, ['adyen_hpp', 'adyen_cc'], true)) {
+            $quote->setIsActive(true);
+        }
+    }
+}

--- a/etc/adminhtml/system/adyen_checkout_experience.xml
+++ b/etc/adminhtml/system/adyen_checkout_experience.xml
@@ -42,12 +42,6 @@
             <config_path>payment/adyen_abstract/return_path</config_path>
             <tooltip><![CDATA[The path the customer will be redirected to when payment was <b>not</b> successful. Default is <i>checkout/cart</i>.]]></tooltip>
         </field>
-        <field id="clone_quote" translate="label" type="select" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
-            <label>Clone quote on failed payment</label>
-            <config_path>payment/adyen_abstract/clone_quote</config_path>
-            <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-            <tooltip><![CDATA[3DS1, 3DS2 and redirect failed payments can restore the previous quote or clone it for a retry.]]></tooltip>
-        </field>
         <field id="house_number_street_line" translate="label" type="select" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
             <label>Address street line used for the house number input</label>
             <config_path>payment/adyen_abstract/house_number_street_line</config_path>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -38,7 +38,6 @@
                 <group>adyen</group>
                 <notifications_can_cancel>1</notifications_can_cancel>
                 <charged_currency>display</charged_currency>
-                <clone_quote>0</clone_quote>
                 <house_number_street_line>0</house_number_street_line>
             </adyen_abstract>
             <adyen_cc>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -984,7 +984,6 @@
                 <item name="payment/adyen_abstract/debug" xsi:type="string">1</item>
                 <item name="payment/adyen_abstract/notifications_ip_check" xsi:type="string">1</item>
                 <item name="payment/adyen_abstract/notifications_hmac_check" xsi:type="string">1</item>
-                <item name="payment/adyen_abstract/clone_quote" xsi:type="string">1</item>
             </argument>
             <argument name="sensitive" xsi:type="array">
                 <item name="payment/adyen_abstract/merchant_account" xsi:type="string">1</item>

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -47,4 +47,7 @@
     <event name="sales_order_invoice_save_after">
         <observer name="adyen_invoice_save_after" instance="Adyen\Payment\Observer\InvoiceObserver" />
     </event>
+    <event name="sales_model_service_quote_submit_success">
+        <observer name="adyen_quote_submit" instance="Adyen\Payment\Observer\SubmitQuoteObserver" />
+    </event>
 </config>


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
The redirect handler endpoint cannot require authentication because in the [headless](https://docs.adyen.com/plugins/magento-2/magento-headless-integration) scenario, customers don't always use the session based login. In this case authentication is managed client side and provided via HTTP headers which won't ever be shared with Adyen servers. 

This endpoint can be accessible to anyone and should have minimal functionalities. Specially, do not perform order mutations according to our [recommendation](https://docs.adyen.com/online-payments/web-drop-in/advanced-use-cases/redirect-result):
> Because a synchronous result is not always available, for example if the shopper didn't return to your website, we strongly recommend that you only use it to present the payment result to your shopper. Use the webhooks to update your order management system.  

For this reason, the clone quote (mutation) functionally based on a provided order id must be removed. The quote restore on error will still work for non-headless stores or the ones using sessions. If a headless storefront does not use sessions, it can handle the redirect result client side via checkout component by following this [guide](https://docs.adyen.com/online-payments/web-drop-in#handle-redirect-result).   

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
* 3DS1
* iDeal