### PR TITLE
PW-6442: Remove authentication from redirect handler

### DIFF
--- a/Controller/Process/Result.php
+++ b/Controller/Process/Result.php
@@ -105,7 +105,6 @@ class Result extends \Magento\Framework\App\Action\Action
     public function execute()
     {
         $response = $this->getRequest()->getParams();
-        $this->_adyenLogger->addAdyenResult(print_r($response, true));
 
         if ($response) {
             $result = $this->validateResponse($response);

--- a/Controller/Process/Result.php
+++ b/Controller/Process/Result.php
@@ -53,11 +53,6 @@ class Result extends \Magento\Framework\App\Action\Action
     protected $_session;
 
     /**
-     * @var \Magento\Customer\Model\Session
-     */
-    private $customerSession;
-
-    /**
      * @var \Adyen\Payment\Logger\AdyenLogger
      */
     protected $_adyenLogger;
@@ -90,7 +85,6 @@ class Result extends \Magento\Framework\App\Action\Action
         \Magento\Sales\Model\OrderFactory $orderFactory,
         \Magento\Sales\Model\Order\Status\HistoryFactory $orderHistoryFactory,
         \Magento\Checkout\Model\Session $session,
-        \Magento\Customer\Model\Session $customerSession,
         \Adyen\Payment\Logger\AdyenLogger $adyenLogger,
         \Magento\Store\Model\StoreManagerInterface $storeManager,
         \Adyen\Payment\Helper\Quote $quoteHelper
@@ -99,7 +93,6 @@ class Result extends \Magento\Framework\App\Action\Action
         $this->_orderFactory = $orderFactory;
         $this->_orderHistoryFactory = $orderHistoryFactory;
         $this->_session = $session;
-        $this->customerSession = $customerSession;
         $this->_adyenLogger = $adyenLogger;
         $this->storeManager = $storeManager;
         $this->quoteHelper = $quoteHelper;
@@ -214,30 +207,6 @@ class Result extends \Magento\Framework\App\Action\Action
 
         $order = $this->_getOrder($incrementId);
         if ($order->getId()) {
-            // Check logged-in order ownership
-            if ($this->customerSession->isLoggedIn()) {
-                if ($order->getCustomerId() !== $this->customerSession->getCustomerId()) {
-                    $this->_adyenLogger->addError("Order belongs to another customer", [
-                        'order' => $order->getId(),
-                        'customer' => $this->customerSession->getCustomerId()
-                    ]);
-
-                    throw new \Magento\Framework\Exception\AuthorizationException(
-                        __('Order is unavailable at the moment')
-                    );
-                }
-            } else {
-                // Check guest order ownership
-                if ($order->getIncrementId() !== $this->_session->getLastRealOrderId()) {
-                    $this->_adyenLogger->addError("Order belongs to another customer", [
-                        'order' => $order->getId(),
-                    ]);
-                    throw new \Magento\Framework\Exception\AuthorizationException(
-                        __('Order is unavailable at the moment')
-                    );
-                }
-            }
-
             $this->_eventManager->dispatch(
                 'adyen_payment_process_resulturl_before',
                 [


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
The redirect handler endpoint cannot require authentication because in the [headless](https://docs.adyen.com/plugins/magento-2/magento-headless-integration) scenario, customers don't always use the session based login. In this case authentication is managed client side and provided via HTTP headers which won't ever be shared with Adyen servers. 

This endpoint can be accessible to anyone and should have minimal functionalities. Specially, do not perform order mutations according to our [recommendation](https://docs.adyen.com/online-payments/web-drop-in/advanced-use-cases/redirect-result):
> Because a synchronous result is not always available, for example if the shopper didn't return to your website, we strongly recommend that you only use it to present the payment result to your shopper. Use the webhooks to update your order management system.  

The quote restore/clone on error will still work for non-headless stores or the ones using sessions. If a headless storefront does not use sessions, it can handle the redirect result client side via checkout component by following this [guide](https://docs.adyen.com/online-payments/web-drop-in#handle-redirect-result).   

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
* 3DS1
* iDeal