### PR TITLE
[PW-5668-2] Orders staying in Payment Review after OFFER_CLOSED

### DIFF
--- a/Helper/Webhook.php
+++ b/Helper/Webhook.php
@@ -738,9 +738,10 @@ class Webhook
             $isWalletPaymentMethod = $this->paymentMethodsHelper->isWalletPaymentMethod($orderPaymentMethod);
 
             /*
-             * Return if payment method is cc like VI, MI
+             * Return true if payment method is cc like VI, MI or oneclick
              */
-            $isCCPaymentMethod = $this->order->getPayment()->getMethod() === 'adyen_cc';
+            $isCCPaymentMethod = $this->order->getPayment()->getMethod() === 'adyen_cc'
+                || $this->order->getPayment()->getMethod() === 'adyen_oneclick';
 
             /*
             * If the order was made with an Alternative payment method,

--- a/Test/Unit/Helper/WebhookTest.php
+++ b/Test/Unit/Helper/WebhookTest.php
@@ -234,4 +234,17 @@ class WebhookTest extends TestCase
 
         $this->assertTrue($result);
     }
+
+    public function testProcessOfferClosed()
+    {
+        $notification = $this->createConfiguredMock(Notification::class, [
+            'getEventCode' => Notification::OFFER_CLOSED,
+            'getSuccess' => true
+        ]);
+
+        $this->order->method('getState')->willReturn(Order::STATE_PAYMENT_REVIEW);
+        $result = $this->sut->processNotification($notification);
+        $this->assertTrue($result);
+    }
+
 }


### PR DESCRIPTION
**Description**
Some history on this: in PR #1215 a fix was implemented for #1193. As the 'VI' and 'visa' string indicate the same PM but will not pass the string comparison, the notification was skipped thinking that different methods were used. In #1215 a work around was added for the CC flow. However, this did not include CC flow when oneclick was used, this PR adds oneclick to the workaround.

**Tested scenarios**
- [x] Oneclick

**Fixed issue**:  <!-- #-prefixed issue number -->
Fixes #1408