### PR TITLE
[PW-6473] Required settings merchant account returns array 

### DIFF
--- a/Model/Config/Source/MerchantAccounts.php
+++ b/Model/Config/Source/MerchantAccounts.php
@@ -48,6 +48,8 @@ class MerchantAccounts implements \Magento\Framework\Data\OptionSourceInterface
     public function toOptionArray()
     {
         $merchantAccount = $this->_adyenHelper->getAdyenMerchantAccount('adyen_cc');
-        return !empty($merchantAccount) ? array($merchantAccount => $merchantAccount) : [];
+        return $merchantAccount ? array(
+            ['value' => $merchantAccount, 'label' => $merchantAccount]
+        ) : [];
     }
 }

--- a/Model/Config/Source/MerchantAccounts.php
+++ b/Model/Config/Source/MerchantAccounts.php
@@ -48,6 +48,6 @@ class MerchantAccounts implements \Magento\Framework\Data\OptionSourceInterface
     public function toOptionArray()
     {
         $merchantAccount = $this->_adyenHelper->getAdyenMerchantAccount('adyen_cc');
-        return $merchantAccount ? [$merchantAccount] : [];
+        return !empty($merchantAccount) ? array($merchantAccount => $merchantAccount) : [];
     }
 }


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
In required settings the merchant account resets every time the merchant clicks the saving button and change any other other value in the config. That caused because the merchant account was populated with select value and not with value after calling `get /me` With this pr we return the correct array format which is 
`array('value' => '<value>', 'label' => '<label>')`


**Tested scenarios**
- CC payment
- Save values in config