### PR TITLE
Add Plugin to handle place order with PCI compliance

### DIFF
--- a/Plugin/GraphQlEnrichPaymentWithStateData.php
+++ b/Plugin/GraphQlEnrichPaymentWithStateData.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2022 Adyen BV (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Lars Roettig <l.roettig@techdivisivion.com>
+ */
+declare(strict_types=1);
+
+namespace Adyen\Payment\Plugin;
+
+use Adyen\Payment\Helper\StateData;
+use Adyen\Payment\Observer\AdyenCcDataAssignObserver;
+use Magento\Quote\Api\Data\PaymentInterface;
+use Magento\Quote\Api\PaymentMethodManagementInterface;
+use Magento\Tests\NamingConvention\true\string;
+
+class GraphQlEnrichPaymentWithStateData
+{
+    /**
+     * @var StateData
+     */
+    private StateData $stateData;
+
+    /**
+     * @param StateData $stateData
+     */
+    public function __construct(StateData $stateData)
+    {
+        $this->stateData = $stateData;
+    }
+
+    /**
+     * Make sure that additional data enriched when payment is loaded from database.
+     *
+     * @param PaymentMethodManagementInterface $subject
+     * @param PaymentInterface | null $payment
+     * @param string|int $cartId
+     * @return PaymentInterface | null
+     */
+    public function afterGet(
+        PaymentMethodManagementInterface $subject,
+        ?PaymentInterface $payment,
+        string $cartId
+    ): ?PaymentInterface {
+
+        $stateData = $this->stateData->getStateData((int)$cartId);
+
+        if ($payment === null || empty($stateData)) {
+            return $payment;
+        }
+
+        $additionalData = $payment->getAdditionalData() ?? [];
+
+        if (!is_array($additionalData)) {
+            return $payment;
+        }
+
+        $additionalData[AdyenCcDataAssignObserver::STATE_DATA] = $stateData;
+        $payment->setAdditionalData($additionalData);
+
+        return $payment;
+    }
+}

--- a/etc/graphql/di.xml
+++ b/etc/graphql/di.xml
@@ -20,4 +20,7 @@
             </argument>
         </arguments>
     </type>
+    <type name="Magento\Quote\Api\PaymentMethodManagementInterface">
+        <plugin name="enrichPaymentWithStateData" type="Adyen\Payment\Plugin\GraphQlEnrichPaymentWithStateData"/>
+    </type>
 </config>


### PR DESCRIPTION
**Description**
[PW-6382] GraphQL PlaceOrder dont work

The recommended solution combine payment and place orders mutations, works not reliable. In Magento 2.4.3, the Magento Place Order Revolver loads the payment from the database without taking the singleton state. This behaviour triggers a reset of the Adyen\Payment\Helper\StateData this leads to a problem that an order can not place without the additional Data. 

As discussed, we can not save this information in the database regarding PCI compliance and security. Our approach is the enrich loaded payment to prevent Adyen\Payment\Helper\StateData is reset before placing an order. 

**Tested scenarios**
* Executed 
```php
mutation setPaymentMethodAndPlaceOrder(
    $cartId: String!
    $stateData: String!
) {
    setPaymentMethodOnCart(
        input: {
            cart_id: $cartId
            payment_method: {
                code: "adyen_cc"
                adyen_additional_data_cc: {
                    cc_type: "VI"
                    stateData: $stateData
                }
            }    
        }
    ) {
        cart {
            selected_payment_method {
                code
                title
            }
        }
    }

    placeOrder(
        input: {
            cart_id: $cartId
        }
    ) {
        order {
            order_id
            adyen_payment_status {
                isFinal
                resultCode
                additionalData
                action
            }
        }
    }
}
```
* Make sure that encprected card is not saved 

**Fixed issue**:  #1267