### PR TITLE
[PW-6491] Fix cart remaining active

### DIFF
--- a/Observer/SubmitQuoteObserver.php
+++ b/Observer/SubmitQuoteObserver.php
@@ -5,18 +5,28 @@ namespace Adyen\Payment\Observer;
 use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
 use Magento\Quote\Model\Quote;
+use Magento\Sales\Model\Order;
 
-/**
- * Keep cart active based on payment method
- */
 class SubmitQuoteObserver implements ObserverInterface
 {
     public function execute(Observer $observer)
     {
-        /** @var Quote $quote */
-        $quote = $observer->getEvent()->getQuote();
-        $method = $quote->getPayment()->getMethod();
-        if (in_array($method, ['adyen_hpp', 'adyen_cc'], true)) {
+        /** @var  Order $order */
+        $order = $observer->getEvent()->getOrder();
+        /** @var Order\Payment $payment */
+        $payment = $order->getPayment();
+
+        // No further shopper action required
+        $resultCode = $payment->getAdditionalInformation('resultCode');
+        if (in_array($resultCode, ['Authorised', 'Received'], true)) {
+            return;
+        }
+
+        // Further shopper action required (e.g. redirect or 3DS authentication)
+        if (in_array($payment->getMethod(), ['adyen_hpp', 'adyen_cc', 'adyen_oneclick'], true)) {
+            /** @var Quote $quote */
+            $quote = $observer->getEvent()->getQuote();
+            // Keep cart active until such actions are taken
             $quote->setIsActive(true);
         }
     }

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -41,13 +41,13 @@
     <event name="sales_model_service_quote_submit_before">
         <observer name="adyen_sales_order_charged_currency" instance="Adyen\Payment\Observer\AdyenSalesOrderChargedCurrencyObserver" />
     </event>
+    <event name="sales_model_service_quote_submit_success">
+        <observer name="adyen_quote_submit" instance="Adyen\Payment\Observer\SubmitQuoteObserver" />
+    </event>
     <event name="sales_order_shipment_save_before">
         <observer name="adyen_shipment_save_before" instance="Adyen\Payment\Observer\BeforeShipmentObserver" />
     </event>
     <event name="sales_order_invoice_save_after">
         <observer name="adyen_invoice_save_after" instance="Adyen\Payment\Observer\InvoiceObserver" />
-    </event>
-    <event name="sales_model_service_quote_submit_success">
-        <observer name="adyen_quote_submit" instance="Adyen\Payment\Observer\SubmitQuoteObserver" />
     </event>
 </config>

--- a/view/frontend/templates/checkout/success.phtml
+++ b/view/frontend/templates/checkout/success.phtml
@@ -25,6 +25,16 @@
  * @var \Adyen\Payment\Block\Checkout\Success $block
  */
 ?>
+<script type="text/javascript">
+    // Refresh cart status
+    require(['Magento_Customer/js/customer-data'], function (customerData) {
+        'use strict';
+
+        customerData.getInitCustomerData().done(function () {
+            customerData.reload(['cart'], true);
+        });
+    });
+</script>
 <?php if ($block->renderAction()): ?>
     <script type="text/javascript">
         require([


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->

Simple credit card (non 3DS) payments don't trigger the redirect handler or payment details call where we are disabling the cart.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
* Credit Card (3DS: yes/no, version: 1/2)
* iDeal