### PR TITLE
[PW-6480] Added change of size for 3ds2 modal based on width

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/adyen-oneclick-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-oneclick-method.js
@@ -182,8 +182,13 @@ define(
                     popupModal = self.showModal();
                 }
                 try {
+                    // Determine threeDS2 modal size, based on screen width
+                    const threeDSConfiguration = {
+                        challengeWindowSize: screen.width < 460 ? '01' : '02'
+                    }
+
                     this.checkoutComponent.createFromAction(
-                        action).mount('#' + this.modalLabel + 'Content');
+                        action, threeDSConfiguration).mount('#' + this.modalLabel + 'Content');
                 } catch (e) {
                     console.log(e);
                     self.closeModal(popupModal);


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
For screen size smaller than 460px the 3ds2 modal does not fit:
![image](https://user-images.githubusercontent.com/23633368/162205750-e8625e1c-cb02-416c-b109-9a2abcf6ebe6.png)


Checkout provides [this configuration](https://docs.adyen.com/online-payments/3d-secure/native-3ds2/web-component?tab=v67-payment-response_2#3ds2-component) for this. Applying the '01' for lower than 460px results in:
![image](https://user-images.githubusercontent.com/23633368/162205472-647deac8-b501-43fb-9899-820a898f54f1.png)

**Tested scenarios**
- [x] Tested for 3ds2 modal
- [x] Tested for <460
- [x] Test for >=460

**Fixed issue**:  <!-- #-prefixed issue number -->
Fixes #1412