### PR TITLE
[PW-6344] - Klarna partial capture not initiated

### DIFF
--- a/Gateway/Request/CaptureDataBuilder.php
+++ b/Gateway/Request/CaptureDataBuilder.php
@@ -181,12 +181,15 @@ class CaptureDataBuilder implements BuilderInterface
 
         /* @var \Magento\Sales\Model\Order\Invoice\Item $invoiceItem */
         foreach ($latestInvoice->getItems() as $invoiceItem) {
-            if ($invoiceItem->getOrderItem()->getParentItem()) {
+            $numberOfItems = (int)$invoiceItem->getQty();
+
+            if ($invoiceItem->getOrderItem()->getParentItem() || $numberOfItems <= 0) {
                 continue;
             }
+
             ++$count;
             $itemAmountCurrency = $this->chargedCurrency->getInvoiceItemAmountCurrency($invoiceItem);
-            $numberOfItems = (int)$invoiceItem->getQty();
+
             $formFields = $this->adyenHelper->createOpenInvoiceLineItem(
                 $formFields,
                 $count,

--- a/Helper/ChargedCurrency.php
+++ b/Helper/ChargedCurrency.php
@@ -140,7 +140,7 @@ class ChargedCurrency
             $item->getPrice(),
             $item->getInvoice()->getOrderCurrencyCode(),
             null,
-            $item->getTaxAmount() / $item->getQty()
+            ($item->getQty() > 0) ? $item->getTaxAmount() / $item->getQty() : 0
         );
     }
 


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Partial capture for Klarna with the zero quantity invoice items was raising division by zero exception while defining item tax amount.

Division by zero is now being controlled with a simple logic statement.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
