### PR TITLE
[PW-6155] Keep cart inactive on PresentToShopper

### DIFF
--- a/Observer/SubmitQuoteObserver.php
+++ b/Observer/SubmitQuoteObserver.php
@@ -9,6 +9,8 @@ use Magento\Sales\Model\Order;
 
 class SubmitQuoteObserver implements ObserverInterface
 {
+    const PAYMENT_COMPLETE = ['Authorised', 'Received', 'PresentToShopper'];
+
     public function execute(Observer $observer)
     {
         /** @var  Order $order */
@@ -18,7 +20,7 @@ class SubmitQuoteObserver implements ObserverInterface
 
         // No further shopper action required
         $resultCode = $payment->getAdditionalInformation('resultCode');
-        if (in_array($resultCode, ['Authorised', 'Received'], true)) {
+        if (in_array($resultCode, self::PAYMENT_COMPLETE, true)) {
             return;
         }
 


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Payment methods like Multibanco or SEPA don't require extra details so the cart can remain inactive. 

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
* Multibanco
* SEPA Direct Debit 