### PR TITLE
[PW-6590] Fix payment status request for inactive cart

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -65,6 +65,7 @@ jobs:
         run: |
           docker exec magento2-container bin/magento config:set payment/adyen_abstract/demo_mode 1
           docker exec magento2-container bin/magento config:set payment/adyen_hpp/active 1
+          docker exec magento2-container bin/magento config:set payment/adyen_cc/active 1
           docker exec magento2-container bin/magento config:set payment/adyen_abstract/merchant_account "${{secrets.ADYEN_MERCHANT}}"
           docker exec magento2-container ./n98-magerun2.phar config:store:set --encrypt payment/adyen_abstract/api_key_test "${{secrets.ADYEN_API_KEY}}" > /dev/null
 

--- a/Model/Resolver/GetAdyenPaymentStatus.php
+++ b/Model/Resolver/GetAdyenPaymentStatus.php
@@ -25,6 +25,7 @@ declare(strict_types=1);
 
 namespace Adyen\Payment\Model\Resolver;
 
+use Adyen\Payment\Helper\Quote;
 use Adyen\Payment\Logger\AdyenLogger;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\GraphQl\Config\Element\Field;
@@ -40,10 +41,6 @@ use Magento\Sales\Model\Order;
 class GetAdyenPaymentStatus implements ResolverInterface
 {
     /**
-     * @var GetCartForUser
-     */
-    private $getCartForUser;
-    /**
      * @var DataProvider\GetAdyenPaymentStatus
      */
     protected $getAdyenPaymentStatusDataProvider;
@@ -55,23 +52,26 @@ class GetAdyenPaymentStatus implements ResolverInterface
      * @var AdyenLogger
      */
     protected $adyenLogger;
+    /**
+     * @var Quote
+     */
+    private $quoteHelper;
 
     /**
-     * @param GetCartForUser $getCartForUser
      * @param DataProvider\GetAdyenPaymentStatus $getAdyenPaymentStatusDataProvider
      * @param Order $order
      * @param AdyenLogger $adyenLogger
      */
     public function __construct(
-        GetCartForUser $getCartForUser,
+        Quote $quoteHelper,
         DataProvider\GetAdyenPaymentStatus $getAdyenPaymentStatusDataProvider,
         Order $order,
         AdyenLogger $adyenLogger
     ) {
-        $this->getCartForUser = $getCartForUser;
         $this->getAdyenPaymentStatusDataProvider = $getAdyenPaymentStatusDataProvider;
         $this->order = $order;
         $this->adyenLogger = $adyenLogger;
+        $this->quoteHelper = $quoteHelper;
     }
 
     /**
@@ -105,7 +105,7 @@ class GetAdyenPaymentStatus implements ResolverInterface
 
         $storeId = (int)$context->getExtensionAttributes()->getStore()->getId();
         try {
-            $cart = $this->getCartForUser->execute($maskedCartId, $context->getUserId(), $storeId);
+            $cart = $this->quoteHelper->getCartForUser($maskedCartId, $context->getUserId(), $storeId);
             $order = $this->order->loadByIncrementId($orderIncrementId);
             $orderId = $order->getId();
             if (!$orderId || $order->getQuoteId() !== $cart->getEntityId()) {

--- a/Test/api-functional/GraphQl/AdyenTest.php
+++ b/Test/api-functional/GraphQl/AdyenTest.php
@@ -347,7 +347,6 @@ QUERY;
     private function getHeaderMap(string $username = 'customer@example.com', string $password = 'password'): array
     {
         $customerToken = $this->customerTokenService->createCustomerAccessToken($username, $password);
-        $headerMap = ['Authorization' => 'Bearer ' . $customerToken];
-        return $headerMap;
+        return ['Authorization' => 'Bearer ' . $customerToken];
     }
 }


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Checking the payment status must support active/inactive carts. Some payments like iDeal or 3DS2 leave the cart active to collect more details while a non 3DS card closes the cart as soon as the payment is authorised.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
* iDeal
* Credit card

**Fixes**  #1470