### PR TITLE
[PW-6595] - Use new config value to display checkbox during checkout

### DIFF
--- a/Model/Ui/AdyenCcConfigProvider.php
+++ b/Model/Ui/AdyenCcConfigProvider.php
@@ -23,6 +23,8 @@
 
 namespace Adyen\Payment\Model\Ui;
 
+use Adyen\Payment\Helper\Config;
+use Adyen\Payment\Helper\Recurring;
 use Magento\Checkout\Model\ConfigProviderInterface;
 
 class AdyenCcConfigProvider implements ConfigProviderInterface
@@ -72,6 +74,9 @@ class AdyenCcConfigProvider implements ConfigProviderInterface
      */
     private $serializer;
 
+    /** @var Config $configHelper */
+    private $configHelper;
+
     /**
      * AdyenCcConfigProvider constructor.
      *
@@ -92,7 +97,8 @@ class AdyenCcConfigProvider implements ConfigProviderInterface
         \Magento\Framework\View\Asset\Source $assetSource,
         \Magento\Store\Model\StoreManagerInterface $storeManager,
         \Magento\Payment\Model\CcConfig $ccConfig,
-        \Magento\Framework\Serialize\SerializerInterface $serializer
+        \Magento\Framework\Serialize\SerializerInterface $serializer,
+        Config $configHelper
     ) {
         $this->_paymentHelper = $paymentHelper;
         $this->_adyenHelper = $adyenHelper;
@@ -102,6 +108,7 @@ class AdyenCcConfigProvider implements ConfigProviderInterface
         $this->ccConfig = $ccConfig;
         $this->storeManager = $storeManager;
         $this->serializer = $serializer;
+        $this->configHelper = $configHelper;
     }
 
     /**
@@ -141,15 +148,15 @@ class AdyenCcConfigProvider implements ConfigProviderInterface
             ]
         );
 
-        $enableOneclick = $this->_adyenHelper->getAdyenAbstractConfigData('enable_oneclick');
+
+        //Test m,e
+
+        $storeId = $this->storeManager->getStore()->getId();
+        $recurringEnabled = $this->configHelper->getConfigData('card_mode', Config::XML_ADYEN_ONECLICK, $storeId, true);
 
         $config['payment']['adyenCc']['methodCode'] = self::CODE;
-
-        $config['payment']['adyenCc']['locale'] = $this->_adyenHelper->getStoreLocale(
-            $this->storeManager->getStore()->getId()
-        );
-
-        $config['payment']['adyenCc']['isOneClickEnabled'] = $enableOneclick;
+        $config['payment']['adyenCc']['locale'] = $this->_adyenHelper->getStoreLocale($storeId);
+        $config['payment']['adyenCc']['isOneClickEnabled'] = $recurringEnabled;
         $config['payment']['adyenCc']['icons'] = $this->getIcons();
 
 

--- a/Model/Ui/AdyenCcConfigProvider.php
+++ b/Model/Ui/AdyenCcConfigProvider.php
@@ -148,11 +148,8 @@ class AdyenCcConfigProvider implements ConfigProviderInterface
             ]
         );
 
-
-        //Test m,e
-
         $storeId = $this->storeManager->getStore()->getId();
-        $recurringEnabled = $this->configHelper->getConfigData('card_mode', Config::XML_ADYEN_ONECLICK, $storeId, true);
+        $recurringEnabled = $this->configHelper->getConfigData('active', Config::XML_ADYEN_ONECLICK, $storeId, true);
 
         $config['payment']['adyenCc']['methodCode'] = self::CODE;
         $config['payment']['adyenCc']['locale'] = $this->_adyenHelper->getStoreLocale($storeId);

--- a/view/frontend/web/js/view/payment/method-renderer/adyen-cc-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-cc-method.js
@@ -120,7 +120,7 @@ define(
              */
             getEnableStoreDetails: function () {
                 // TODO refactor the configuration for this
-                return this.isOneClickEnabled() === "1" || this.isVaultEnabled();
+                return this.isOneClickEnabled() || this.isVaultEnabled();
             },
             /**
              * Renders the secure fields,


### PR DESCRIPTION
**Description**
Since https://github.com/Adyen/adyen-magento2/pull/1447 we updated the configuration parameters required for recurring payments. However, the functionality which identifies if the `Save payment method` checkbox should be shown during checkout, was still using the older configuration field.

Hence, in new installations of the plugin, the checkbox was never shown since the older configuration field was not able to be set.

**Tested scenarios**
* Checkbox shown when recurring is enabled on a fresh installation
* Checkbox not shown when recurring is not enabled