### PR TITLE
PW-6484 - Check if component is defined before showing validation

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/adyen-hpp-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-hpp-method.js
@@ -259,10 +259,12 @@ define(
                     placeOrder: function() {
                         var innerSelf = this;
 
-                        innerSelf.component.showValidation();
-
-                        if (innerSelf.component.state.isValid === false) {
-                            return false;
+                        // Skip in case of pms without a component (giftcards)
+                        if (innerSelf.component !== undefined) {
+                            innerSelf.component.showValidation();
+                            if (innerSelf.component.state.isValid === false) {
+                                return false;
+                            }
                         }
 
                         if (innerSelf.validate()) {


### PR DESCRIPTION
**Description**

After the change in https://github.com/Adyen/adyen-magento2/pull/1471 giftcard payments were not operational since we were not checking if a component is actually defined. This PR will check if the component is defined before attempting to access it's functionality


**Tested scenarios**
* Giftcard payment
* iDeal payment
* Paypal payment