### PR TITLE
[PW-6585] Management API: Fetch merchant accounts with /merchants endpoint

### DIFF
--- a/Controller/Adminhtml/Configuration/MerchantAccounts.php
+++ b/Controller/Adminhtml/Configuration/MerchantAccounts.php
@@ -80,7 +80,7 @@ class MerchantAccounts extends Action
             if (!empty($xapikey) && preg_match('/^\*+$/', $xapikey)) {
                 $xapikey = '';
             }
-            $response = $this->managementHelper->getMerchantAccountWithApikey($xapikey);
+            $response = $this->managementHelper->getMerchantAccountAndClientKey($xapikey);
             $currentMerchantAccount = $this->_adyenHelper->getAdyenMerchantAccount('adyen_cc');
             $resultJson = $this->resultJsonFactory->create();
             $resultJson->setData(

--- a/Helper/ManagementHelper.php
+++ b/Helper/ManagementHelper.php
@@ -90,7 +90,7 @@ class ManagementHelper
         }
         return [
             'clientKey' => $responseMe['clientKey'],
-            'associatedMerchantAccounts' => $associatedMerchantAccounts,
+            'associatedMerchantAccounts' => $associatedMerchantAccounts
         ];
     }
 

--- a/Helper/ManagementHelper.php
+++ b/Helper/ManagementHelper.php
@@ -76,7 +76,7 @@ class ManagementHelper
         $responseMe = $management->me->retrieve();
         $associatedMerchantAccounts = [];
         $page = 1;
-        $pageSize = 2;
+        $pageSize = 100;
         //get the associated merchant accounts using get /merchants.
         $responseMerchants = $management->merchantAccount->list(["pageSize" => $pageSize]);
         while (count($associatedMerchantAccounts) < $responseMerchants['itemsTotal']) {

--- a/Helper/ManagementHelper.php
+++ b/Helper/ManagementHelper.php
@@ -76,16 +76,19 @@ class ManagementHelper
         $responseMe = $management->me->retrieve();
         $associatedMerchantAccounts = [];
         $page = 1;
-        $pageSize = 100;
+        $pageSize = 2;
         //get the associated merchant accounts using get /merchants.
         $responseMerchants = $management->merchantAccount->list(["pageSize" => $pageSize]);
-        foreach ($responseMerchants['data'] as $value) {
-            array_push($associatedMerchantAccounts, $value['id']);
-        }
-        while (isset($responseMerchants['_links']['next'])) {
-            $responseMerchants = $management->merchantAccount->list(["pageSize" => $pageSize, "pageNumber" => ++$page]);
-            foreach ($responseMerchants['data'] as $value) {
-                array_push($associatedMerchantAccounts, $value['id']);
+        while (count($associatedMerchantAccounts) < $responseMerchants['itemsTotal']) {
+            $associatedMerchantAccounts = array_merge(
+                $associatedMerchantAccounts,
+                array_column($responseMerchants['data'], 'id')
+            );
+            ++$page;
+            if (isset($responseMerchants['_links']['next'])) {
+                $responseMerchants = $management->merchantAccount->list(
+                    ["pageSize" => $pageSize, "pageNumber" => $page]
+                );
             }
         }
         return [

--- a/Helper/ManagementHelper.php
+++ b/Helper/ManagementHelper.php
@@ -79,12 +79,12 @@ class ManagementHelper
         $pageSize = 100;
         //get the associated merchant accounts using get /merchants.
         $responseMerchants = $management->merchantAccount->list(["pageSize" => $pageSize]);
-        foreach ($responseMerchants['data'] as &$value) {
+        foreach ($responseMerchants['data'] as $value) {
             array_push($associatedMerchantAccounts, $value['id']);
         }
         while (isset($responseMerchants['_links']['next'])) {
             $responseMerchants = $management->merchantAccount->list(["pageSize" => $pageSize, "pageNumber" => ++$page]);
-            foreach ($responseMerchants['data'] as &$value) {
+            foreach ($responseMerchants['data'] as $value) {
                 array_push($associatedMerchantAccounts, $value['id']);
             }
         }

--- a/Helper/ManagementHelper.php
+++ b/Helper/ManagementHelper.php
@@ -63,19 +63,34 @@ class ManagementHelper
 
     /**
      * @param string $xapikey
+     * @param bool|null $demoMode
      * @return array
      * @throws AdyenException
      * @throws NoSuchEntityException
      */
-    public function getMerchantAccountWithApikey(string $xapikey, ?bool $demoMode = null): array
+    public function getMerchantAccountAndClientKey(string $xapikey, ?bool $demoMode = null): array
     {
         $storeId = $this->storeManager->getStore()->getId();
         $client = $this->adyenHelper->initializeAdyenClient($storeId, $xapikey, $demoMode);
         $management = new Management($client);
-        $response = $management->me->retrieve();
+        $responseMe = $management->me->retrieve();
+        $associatedMerchantAccounts = [];
+        $page = 1;
+        $pageSize = 100;
+        //get the associated merchant accounts using get /merchants.
+        $responseMerchants = $management->merchantAccount->list(["pageSize" => $pageSize]);
+        foreach ($responseMerchants['data'] as &$value) {
+            array_push($associatedMerchantAccounts, $value['id']);
+        }
+        while (isset($responseMerchants['_links']['next'])) {
+            $responseMerchants = $management->merchantAccount->list(["pageSize" => $pageSize, "pageNumber" => ++$page]);
+            foreach ($responseMerchants['data'] as &$value) {
+                array_push($associatedMerchantAccounts, $value['id']);
+            }
+        }
         return [
-            'clientKey' => $response['clientKey'],
-            'associatedMerchantAccounts' => $response['associatedMerchantAccounts'],
+            'clientKey' => $responseMe['clientKey'],
+            'associatedMerchantAccounts' => $associatedMerchantAccounts,
         ];
     }
 


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
For ticket PW-6297 we built the config to use the /me endpoint to fetch merchant accounts and client key fields.
However, when a API Credential has access to "All associated merchant accounts" , the 'associatedMerchantAccounts' fields in response to "GET /me" is empty. This is the reason why we would like to move to /merchants endpoint

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
Tested with pagination by decreasing the number of merchants per page 
and without pagination
