### PR TITLE
[PW-6615] use getContent from request interface to get request body

### DIFF
--- a/Controller/Process/Json.php
+++ b/Controller/Process/Json.php
@@ -137,7 +137,7 @@ class Json extends Action
         }
 
         // Read JSON encoded notification body
-        $notificationItems = json_decode(file_get_contents('php://input'), true);
+        $notificationItems = json_decode($this->getRequest()->getContent(), true);
 
         // Check notification mode
         if (!isset($notificationItems['live'])) {


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Avoid usage of `php://input` and use getContent to get request body in notifications endpoint
**Tested scenarios**
- sent webhook to endpoint via postman
- added xss injection to webhook request to test for sanitization in admin UI
