### PR TITLE
Prevent optional parameter being declared before required one

### DIFF
--- a/Model/Cron.php
+++ b/Model/Cron.php
@@ -2085,7 +2085,7 @@ class Cron
      * @param $storeId
      * @return mixed
      */
-    protected function _getConfigData($field, $paymentMethodCode = 'adyen_cc', $storeId)
+    protected function _getConfigData($field, $paymentMethodCode = 'adyen_cc', $storeId = null)
     {
         $path = 'payment/' . $paymentMethodCode . '/' . $field;
         return $this->_scopeConfig->getValue($path, \Magento\Store\Model\ScopeInterface::SCOPE_STORE, $storeId);


### PR DESCRIPTION
**Description**
Version 7 is not currently compatible with Magento 2.4.4 due to deprecated functionality existing.
The `$storeId` parameter of the `\Adyen\Payment\Model\Cron->_getConfigData()` function is declared after the optional `$paymentMethodCode` parameter, but does not provide a default value. This results in errors when attempting to run Magento commands, such as `bin/magento setup:upgrade`:

```
Cache types config flushed successfully
Cache cleared successfully
File system cleanup:
/app/generated/code/Composer
/app/generated/code/Fastly
/app/generated/code/Magento
/app/generated/code/PayPal
/app/generated/code/Psr
/app/generated/code/Symfony
The directory '/app/generated/metadata/' doesn't exist - skipping cleanup
Updating modules:
Deprecated Functionality: Optional parameter $paymentMethodCode declared before required parameter $storeId is implicitly treated as a required parameter in /app/vendor/adyen/module-payment/Model/Cron.php on line 2088
ERROR: 1
```

By adding `null` as the default for the `$storeId` parameter, the issue is resolved, as it is now considered an optional parameter, even if it is always provided.

An alternative would be to change the ordering of the parameters, but this would also require all calls to the function be changed.

**Fixed issue**:  #1264 (already marked as closed, but issue not completely fixed)