### PR TITLE
[PW- 6531] Implement webhook test in admin

### DIFF
--- a/Controller/Adminhtml/Configuration/WebhookTest.php
+++ b/Controller/Adminhtml/Configuration/WebhookTest.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Payment Module
+ *
+ * Copyright (c) 2022 Adyen N.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\Payment\Controller\Adminhtml\Configuration;
+
+use Adyen\Payment\Helper\ManagementHelper;
+use Magento\Backend\App\Action;
+use Magento\Backend\App\Action\Context;
+use Magento\Framework\Controller\Result\JsonFactory;
+
+class WebhookTest extends Action
+{
+    /**
+     * @var ManagementHelper
+     */
+    private $managementApiHelper;
+
+    /**
+     * @var \Adyen\Payment\Helper\Data
+     */
+    protected $adyenHelper;
+
+    /**
+     * @var JsonFactory
+     */
+    protected $resultJsonFactory;
+
+    public function __construct(
+        Context $context,
+        ManagementHelper $managementApiHelper,
+        \Adyen\Payment\Helper\Data $adyenHelper,
+        JsonFactory $resultJsonFactory
+    ) {
+        parent::__construct($context);
+        $this->managementApiHelper = $managementApiHelper;
+        $this->adyenHelper =$adyenHelper;
+        $this->resultJsonFactory = $resultJsonFactory;
+    }
+
+    /**
+     * @return \Magento\Framework\App\ResponseInterface|\Magento\Framework\Controller\ResultInterface|mixed|string
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     */
+    public function execute()
+    {
+        $merchantAccount = $this->adyenHelper->getAdyenMerchantAccount('adyen_cc');
+        $response = $this->managementApiHelper->webhookTest($merchantAccount);
+        $resultJson = $this->resultJsonFactory->create();
+        if (isset($response['data']) && in_array(
+                'success',
+                array_column(
+                    $response['data'],
+                    'status'
+                ),
+                true
+            )) {
+            $resultJson->setData(
+                [
+                    'messages' => $response,
+                    'statusCode' => 'Success'
+                ]
+            );
+        } else {
+            $resultJson->setData(
+                [
+                    'messages' => $response,
+                    'statusCode' => 'Failed'
+                ]
+            );
+        }
+        return $resultJson;
+    }
+}

--- a/Controller/Adminhtml/Configuration/WebhookTest.php
+++ b/Controller/Adminhtml/Configuration/WebhookTest.php
@@ -66,29 +66,13 @@ class WebhookTest extends Action
     {
         $merchantAccount = $this->adyenHelper->getAdyenMerchantAccount('adyen_cc');
         $response = $this->managementApiHelper->webhookTest($merchantAccount);
+        $success = isset($response['data']) && 
+            in_array('success', array_column($response['data'], 'status'), true);
         $resultJson = $this->resultJsonFactory->create();
-        if (isset($response['data']) && in_array(
-                'success',
-                array_column(
-                    $response['data'],
-                    'status'
-                ),
-                true
-            )) {
-            $resultJson->setData(
-                [
-                    'messages' => $response,
-                    'statusCode' => 'Success'
-                ]
-            );
-        } else {
-            $resultJson->setData(
-                [
-                    'messages' => $response,
-                    'statusCode' => 'Failed'
-                ]
-            );
-        }
+        $resultJson->setData([
+            'messages' => $response,
+            'statusCode' => $success ? 'Success' : 'Failed'
+        ]);
         return $resultJson;
     }
 }

--- a/Helper/ManagementHelper.php
+++ b/Helper/ManagementHelper.php
@@ -167,4 +167,24 @@ class ManagementHelper
 
         return new Management($client);
     }
+
+    /**
+     * @param string $merchantId
+     * @return mixed|string
+     * @throws NoSuchEntityException
+     */
+    public function webhookTest(string $merchantId)
+    {
+        //this is what we send from the BO too
+        $params = ['types' => ['AUTHORISATION']];
+        $storeId = $this->storeManager->getStore()->getId();
+        $webhookId = $this->configHelper->getWebhookId($storeId);
+        try {
+            $client = $this->adyenHelper->initializeAdyenClient();
+            $management = new Management($client);
+            return $management->merchantWebhooks->test($merchantId, $webhookId, $params);
+        } catch (AdyenException $e) {
+            return $e->getMessage();
+        }
+    }
 }

--- a/Helper/ManagementHelper.php
+++ b/Helper/ManagementHelper.php
@@ -188,7 +188,7 @@ class ManagementHelper
      */
     public function webhookTest(string $merchantId)
     {
-        //this is what we send from the costumer area too
+        //this is what we send from the customer area too
         $params = ['types' => ['AUTHORISATION']];
         $storeId = $this->storeManager->getStore()->getId();
         $webhookId = $this->configHelper->getWebhookId($storeId);

--- a/Helper/ManagementHelper.php
+++ b/Helper/ManagementHelper.php
@@ -188,7 +188,7 @@ class ManagementHelper
      */
     public function webhookTest(string $merchantId)
     {
-        //this is what we send from the BO too
+        //this is what we send from the costumer area too
         $params = ['types' => ['AUTHORISATION']];
         $storeId = $this->storeManager->getStore()->getId();
         $webhookId = $this->configHelper->getWebhookId($storeId);

--- a/Model/Config/Adminhtml/WebhookTest.php
+++ b/Model/Config/Adminhtml/WebhookTest.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ *                       ######
+ *                       ######
+ * ############    ####( ######  #####. ######  ############   ############
+ * #############  #####( ######  #####. ######  #############  #############
+ *        ######  #####( ######  #####. ######  #####  ######  #####  ######
+ * ###### ######  #####( ######  #####. ######  #####  #####   #####  ######
+ * ###### ######  #####( ######  #####. ######  #####          #####  ######
+ * #############  #############  #############  #############  #####  ######
+ *  ############   ############  #############   ############  #####  ######
+ *                                      ######
+ *                               #############
+ *                               ############
+ *
+ * Adyen Payment Module
+ *
+ * Copyright (c) 2022 Adyen N.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\Payment\Model\Config\Adminhtml;
+
+class WebhookTest extends \Magento\Config\Block\System\Config\Form\Field
+{
+    protected $_template = 'Adyen_Payment::config/webhook_test.phtml';
+
+    public function render(\Magento\Framework\Data\Form\Element\AbstractElement $element)
+    {
+        // Remove scope label
+        $element->unsScope()->unsCanUseWebsiteValue()->unsCanUseDefaultValue();
+        return parent::render($element);
+    }
+
+    protected function _getElementHtml(\Magento\Framework\Data\Form\Element\AbstractElement $element)
+    {
+        return $this->_toHtml();
+    }
+
+    public function getAjaxUrl()
+    {
+        return $this->getUrl('adyen/configuration/webhooktest');
+    }
+
+    public function getButtonHtml()
+    {
+        $button = $this->getLayout()->createBlock(
+            'Magento\Backend\Block\Widget\Button'
+        )->setData(
+            [
+                'id' => 'adyen_webhook_test',
+                'label' => __('Test webhook url'),
+            ]
+        );
+
+        return $button->toHtml();
+    }
+
+    public function getDisabledButtonHtml()
+    {
+        $button = $this->getLayout()->createBlock(
+            'Magento\Backend\Block\Widget\Button'
+        )->setData(
+            [
+                'id' => 'adyen_webhook_test',
+                'label' => __('Test'),
+                'disabled' => true
+            ]
+        );
+
+        return $button->toHtml();
+    }
+}

--- a/etc/adminhtml/system/adyen_required_settings.xml
+++ b/etc/adminhtml/system/adyen_required_settings.xml
@@ -129,6 +129,9 @@
             <validate>validate-url</validate>
             <tooltip>Set the webhook URL. </tooltip>
         </field>
+        <field id="adyen_webhook_test" translate="label comment" type="button" sortOrder="105" showInDefault="1" showInWebsite="1" showInStore="1">
+            <frontend_model>Adyen\Payment\Model\Config\Adminhtml\WebhookTest</frontend_model>
+        </field>
         <field id="notifications_hmac_check" translate="label" type="select" sortOrder="110" showInDefault="1" showInWebsite="1" showInStore="1">
             <label>Check notification's HMAC signature</label>
             <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>

--- a/view/adminhtml/templates/config/webhook_test.phtml
+++ b/view/adminhtml/templates/config/webhook_test.phtml
@@ -24,7 +24,6 @@
                         //add html response
                         progressSpan.find('.processing').hide();
                         let resultText = '';
-                        debugger;
                         if (response.responseJSON === null) {
                             resultText = "No response";
                         } else {

--- a/view/adminhtml/templates/config/webhook_test.phtml
+++ b/view/adminhtml/templates/config/webhook_test.phtml
@@ -1,0 +1,65 @@
+<script>
+    require([
+            'jquery',
+            'prototype'
+        ],
+        function(jQuery)
+        {
+            jQuery('#adyen_webhook_test_errors').hide();
+            let progressSpan = jQuery('#webhook_progress');
+            jQuery('#adyen_webhook_test').click(function () {
+
+                new Ajax.Request('<?php echo $block->getAjaxUrl() ?>', {
+                    parameters: {},
+                    type: "POST",
+                    loaderArea:     false,
+                    asynchronous:   true,
+                    onCreate: function() {
+                        progressSpan.find('.configured').hide();
+                        progressSpan.find('.processing').show();
+                        jQuery('#adyen_webhook_test_message').text('');
+                        jQuery("#adyen_webhook_test").prop('disabled', true);
+                    },
+                    onSuccess: function (response) {
+                        //add html response
+                        progressSpan.find('.processing').hide();
+                        let resultText = '';
+                        debugger;
+                        if (response.responseJSON === null) {
+                            resultText = "No response";
+                        } else {
+                            resultText = response.responseJSON.statusCode;
+                            if(resultText==='Success'){
+                                progressSpan.find('.configured').show();
+                            }
+                        }
+                        jQuery('#adyen_webhook_test_message').text(resultText);
+                    },
+                    onFailure: function(response)
+                    {
+                        progressSpan.find('.processing').hide();
+                        jQuery('#adyen_webhook_test_message').text("Failed").show();
+                    },
+                    onComplete: function()
+                    {
+                        jQuery("#adyen_webhook_test").prop('disabled', false);
+                    }
+                });
+            });
+
+        });
+</script>
+
+<?php echo $block->getButtonHtml() ?>
+<span class="adyen_webhook_test_config" id="webhook_progress">
+    <img class="processing" hidden="hidden" alt="Configuring" style="margin:0 5px" src="<?php echo $block->getViewFileUrl('images/process_spinner.gif') ?>"/>
+    <img class="configured" hidden="hidden" alt="Configured" style="margin:-3px 5px" src="<?php echo $block->getViewFileUrl('images/rule_component_apply.gif') ?>"/>
+    <span id="adyen_webhook_test_message"></span>
+    <div id="adyen_webhook_test_errors" class="message-system-inner">
+        <div class="message message-warning"></div>
+    </div>
+</span>
+<!--if we want to add a note under the button-->
+<p class="note">
+    <span><?php echo __('Sends sample notifications to test if the webhook is set up correctly.'); ?></span>
+</p>


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
The management api provides the functionality to test the webhook url that it is configured. It sends sample notifications to test if the webhook is set up correctly. In this pr we added this functionality which is available in the required setting of admin menu. To make this request, your API credential must have the following [roles](https://docs.adyen.com/development-resources/api-credentials#api-permissions):
- Management API—Webhooks read and write 

For more information please check the [documentation](https://docs.adyen.com/api-explorer/#/ManagementService/v1/post/merchants/{id}/webhooks/{webhookId}/test)

**Tested scenarios**
Tested with both success and failed webhook
