### PR TITLE
[PW-6548] Float passed instead of int for shipping taxation in PBL fix

### DIFF
--- a/Gateway/Request/CheckoutDataBuilder.php
+++ b/Gateway/Request/CheckoutDataBuilder.php
@@ -340,7 +340,7 @@ class CheckoutDataBuilder implements BuilderInterface
                 'taxAmount' => $formattedTaxAmount,
                 'description' => $order->getShippingDescription(),
                 'quantity' => 1,
-                'taxPercentage' => ($formattedTaxAmount / $formattedPriceExcludingTax) * 100 * 100
+                'taxPercentage' => (int) ($formattedTaxAmount / $formattedPriceExcludingTax) * 100 * 100
             ];
         }
 

--- a/Gateway/Request/CheckoutDataBuilder.php
+++ b/Gateway/Request/CheckoutDataBuilder.php
@@ -340,7 +340,7 @@ class CheckoutDataBuilder implements BuilderInterface
                 'taxAmount' => $formattedTaxAmount,
                 'description' => $order->getShippingDescription(),
                 'quantity' => 1,
-                'taxPercentage' => (int) ($formattedTaxAmount / $formattedPriceExcludingTax) * 100 * 100
+                'taxPercentage' => (int) round(($formattedTaxAmount / $formattedPriceExcludingTax) * 100 * 100)
             ];
         }
 


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
The PBL link could not be correctly created as the shipping tax was still in a Float format where it should be an Integer. Added a round and a cast.

**Tested scenarios**
- [x] PBL

**Fixed issue**:  <!-- #-prefixed issue number -->
Closes #1449