### PR TITLE
[PW-6325] - Use formattedBillingAddress for AmazonPay for the virtual products

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/adyen-hpp-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-hpp-method.js
@@ -750,6 +750,20 @@ define(
                             phoneNumber: formattedShippingAddress.telephone
                         };
                     }
+                    else if (formattedBillingAddress &&
+                        formattedBillingAddress.telephone) {
+                        configuration.addressDetails = {
+                            name: formattedBillingAddress.firstName +
+                                ' ' +
+                                formattedBillingAddress.lastName,
+                            addressLine1: formattedBillingAddress.street,
+                            addressLine2: formattedBillingAddress.houseNumber,
+                            city: formattedBillingAddress.city,
+                            postalCode: formattedBillingAddress.postalCode,
+                            countryCode: formattedBillingAddress.country,
+                            phoneNumber: formattedBillingAddress.telephone
+                        };
+                    }
                 }
 
                 return configuration;


### PR DESCRIPTION

<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Use `formattedBillingAddress` for AmazonPay for the virtual product `addressDetails`

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
AmazonPay