### PR TITLE
[PW-6711] - JS error on payment methods with no component 

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/adyen-hpp-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-hpp-method.js
@@ -243,7 +243,7 @@ define(
                         var innerSelf = this;
 
                         // Skip in case of pms without a component (giftcards)
-                        if (innerSelf.component !== undefined) {
+                        if (innerSelf.component) {
                             innerSelf.component.showValidation();
                             if (innerSelf.component.state.isValid === false) {
                                 return false;
@@ -258,7 +258,7 @@ define(
                             additionalData.brand_code = selectedAlternativePaymentMethodType();
 
                             let stateData;
-                            if ('component' in innerSelf) {
+                            if (innerSelf.component) {
                                 stateData = innerSelf.component.data;
                             } else {
                                 if (paymentMethod.methodGroup === paymentMethod.methodIdentifier){


### PR DESCRIPTION
…tring

<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
Checks in the `adyen-hpp-method.js` file which are utilizing the component object, should be updated, since as of now, `innerSelf.component` will be set to `false` if no component is set, instead of undefined.

**Tested scenarios**
- [x] Giftcard succesful payment
- [x] Failed giftcard payment
- [x] iDeal successful payment
- [x] PayPal successful payment