### PR TITLE
[PW-6544] Replaced 'Processing' with 'Pending Payment' in invoicing flow

### DIFF
--- a/Helper/Webhook.php
+++ b/Helper/Webhook.php
@@ -72,7 +72,7 @@ class Webhook
      * Indicative matrix for possible states to enter after given event
      */
     const STATE_TRANSITION_MATRIX = [
-        'payment_pre_authorized' => [Order::STATE_NEW, Order::STATE_PROCESSING],
+        'payment_pre_authorized' => [Order::STATE_NEW, Order::STATE_PENDING_PAYMENT],
         'payment_authorized' => [Order::STATE_PROCESSING]
     ];
 

--- a/Model/Config/Source/PreAuthorized.php
+++ b/Model/Config/Source/PreAuthorized.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2022 Adyen BV (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\Payment\Model\Config\Source;
+
+/**
+ * Order Statuses source model
+ */
+class PreAuthorized extends \Magento\Sales\Model\Config\Source\Order\Status
+{
+    /**
+     * @var string[]
+     */
+    protected $_stateStatuses = [
+        \Magento\Sales\Model\Order::STATE_PENDING_PAYMENT,
+        \Magento\Sales\Model\Order::STATE_NEW
+    ];
+}
+

--- a/Observer/InvoiceObserver.php
+++ b/Observer/InvoiceObserver.php
@@ -122,11 +122,11 @@ class InvoiceObserver implements ObserverInterface
         );
 
         if (empty($status)) {
-            $status = $this->statusResolver->getOrderStatusByState($order, Order::STATE_PROCESSING);
+            $status = $this->statusResolver->getOrderStatusByState($order, Order::STATE_PENDING_PAYMENT);
         }
 
         // Set order to PROCESSING to allow further invoices to be generated
-        $order->setState(Order::STATE_PROCESSING);
+        $order->setState(Order::STATE_PENDING_PAYMENT);
         $order->setStatus($status);
 
         $this->logger->addAdyenDebug(

--- a/etc/adminhtml/system/adyen_order_processing.xml
+++ b/etc/adminhtml/system/adyen_order_processing.xml
@@ -59,7 +59,7 @@
         <field id="payment_pre_authorized" translate="label" type="select" sortOrder="61" showInDefault="1" showInWebsite="1" showInStore="0">
             <label>Order status: payment authorisation</label>
             <tooltip>Status given to orders after authorisation confirmed by an AUTHORISATION webhook from Adyen. Note: an authorisation status via the result URL does not yet trigger this status.</tooltip>
-            <source_model>Magento\Sales\Model\Config\Source\Order\Status\Newprocessing</source_model>
+            <source_model>Adyen\Payment\Model\Config\Source\PreAuthorized</source_model>
             <config_path>payment/adyen_abstract/payment_pre_authorized</config_path>
         </field>
         <field id="payment_authorized" translate="label" type="select" sortOrder="62" showInDefault="1" showInWebsite="1" showInStore="0">


### PR DESCRIPTION
**Description**
As pointed out in the discussion in https://github.com/Adyen/adyen-magento2/pull/1390. There was the possibility of an order being closed where it shouldn't when the order was shipped before the invoice was captured.
Since 8.1.0 an invoice will always set and orders' status to Processing to allow for quick multiple captures (without having to wait for the first one to be captured). If the order would be shipped, Magento's flow sees the closed state as the only option due to https://github.com/magento/magento2/blob/b092dd6df013e8b1e77e8b5d639148ed76a7172a/app/code/Magento/Sales/Model/ResourceModel/Order/Handler/State.php#L33
By introducing the 'Pending Payment' state, the order will be set to Pending Payment after it has been invoiced. This allows for a quick second capture (in case of partial payment) and allows for Shipping the order (it will stay in Pending Payment). It will move to Processing if the full amount has been captured. 

**Tested scenarios**
- [x] Partial Payment
- [x] Normal Payment
- [x] Shipping before capture
- [x] Shipping after capture  

**Additional notes**
Most likely this will make the 'maintain state' option redundant (from #1390), we will leave this in for now. But might remove this later.

**Fixed issue**:  <!-- #-prefixed issue number -->
 #1390
 #1276 