### PR TITLE
[PW-6696v7] - Update contractType saved when creating token on v7

### DIFF
--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -42,6 +42,7 @@ class Config
     const XML_ADYEN_ONECLICK = 'adyen_oneclick';
     const XML_ADYEN_HPP = 'adyen_hpp';
     const XML_ADYEN_HPP_VAULT = 'adyen_hpp_vault';
+    const XML_ADYEN_CC_VAULT = 'adyen_cc_vault';
     const XML_PAYMENT_ORIGIN_URL = 'payment_origin_url';
     const XML_PAYMENT_RETURN_URL = 'payment_return_url';
     const XML_STATUS_FRAUD_MANUAL_REVIEW = 'fraud_manual_review_status';
@@ -240,6 +241,15 @@ class Config
             Config::XML_ADYEN_ABSTRACT_PREFIX,
             $storeId
         );
+    }
+
+    /**
+     * @param $storeId
+     * @return string|null
+     */
+    public function getCardRecurringActive($storeId): ?string
+    {
+        return $this->getConfigData('active', self::XML_ADYEN_ONECLICK, $storeId, true);
     }
 
     /**

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -1647,28 +1647,6 @@ class Data extends AbstractHelper
     }
 
     /**
-     * For backwards compatibility get the recurringType used for HPP + current billing agreements
-     *
-     * @param null|int|string $storeId
-     * @return null|string
-     */
-    public function getRecurringTypeFromOneclickRecurringSetting($storeId = null)
-    {
-        $enableOneclick = $this->getAdyenAbstractConfigDataFlag('enable_oneclick', $storeId);
-        $adyenCCVaultActive = $this->getAdyenCcVaultConfigDataFlag('active', $storeId);
-
-        if ($enableOneclick && $adyenCCVaultActive) {
-            return RecurringType::ONECLICK_RECURRING;
-        } elseif ($enableOneclick && !$adyenCCVaultActive) {
-            return RecurringType::ONECLICK;
-        } elseif (!$enableOneclick && $adyenCCVaultActive) {
-            return RecurringType::ONECLICK_RECURRING;
-        } else {
-            return RecurringType::NONE;
-        }
-    }
-
-    /**
      * Get icon from variant
      *
      * @param $variant

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -899,7 +899,8 @@ class Data extends AbstractHelper
 
             // check if contractType is supporting the selected contractType for OneClick payments
             $allowedContractTypes = $agreementData['contractTypes'];
-            if (in_array(RecurringType::ONECLICK , $allowedContractTypes) || in_array(Recurring::CARD_ON_FILE, $allowedContractTypes)) {
+            // RecurringType::ONECLICK is kept in the if block to still display tokens that were created before changes
+            if (in_array(RecurringType::ONECLICK, $allowedContractTypes) || in_array(Recurring::CARD_ON_FILE, $allowedContractTypes)) {
                 // check if AgreementLabel is set and if contract has an recurringType
                 if ($billingAgreement->getAgreementLabel()) {
                     // for Ideal use sepadirectdebit because it is

--- a/Helper/Recurring.php
+++ b/Helper/Recurring.php
@@ -49,19 +49,26 @@ class Recurring
     private $config;
 
     /**
+     * @var Vault
+     */
+    private $vaultHelper;
+
+    /**
      * Recurring constructor.
      */
     public function __construct(
         AdyenLogger $adyenLogger,
         AgreementFactory $agreementFactory,
         Agreement $billingAgreementResourceModel,
-        Config $config
+        Config $config,
+        Vault $vaultHelper
     )
     {
         $this->adyenLogger = $adyenLogger;
         $this->billingAgreementFactory = $agreementFactory;
         $this->billingAgreementResourceModel = $billingAgreementResourceModel;
         $this->config = $config;
+        $this->vaultHelper = $vaultHelper;
     }
 
     /**
@@ -161,5 +168,37 @@ class Recurring
             $order->addRelatedObject($comment);
             $order->save();
         }
+    }
+
+
+    /**
+     * Get the recurring type to be assigned to a token based on the admin settings
+     *
+     * @param null|int|string $storeId
+     * @return null|string
+     */
+    public function getRecurringTypeFromSetting($storeId = null): ?string
+    {
+        $vaultEnabled = $this->vaultHelper->isCardVaultEnabled($storeId);
+        $adyenTokensEnabled = $this->areAdyenTokensEnabled($storeId);
+
+        if ($vaultEnabled) {
+            return self::SUBSCRIPTION;
+        } elseif ($adyenTokensEnabled) {
+            return $this->config->getCardRecurringType($storeId);
+        }
+
+        return null;
+    }
+
+    /**
+     * Check if Adyen tokens are enabled
+     *
+     * @param null $storeId
+     * @return bool
+     */
+    public function areAdyenTokensEnabled($storeId = null): bool
+    {
+        return $this->config->getCardRecurringMode($storeId) === self::MODE_ADYEN_TOKENIZATION;
     }
 }

--- a/Helper/Vault.php
+++ b/Helper/Vault.php
@@ -101,13 +101,14 @@ class Vault
 
     /**
      * Check if one click is enabled AND Magento Vault is set
+     * intval() is required since "" is returned if config doesn't exist
      *
      * @param null $storeId
      * @return bool
      */
     public function isCardVaultEnabled($storeId = null): bool
     {
-        return $this->config->getCardRecurringActive($storeId) && $this->config->getCardRecurringMode($storeId) === Recurring::MODE_MAGENTO_VAULT;
+        return intval($this->config->getCardRecurringActive($storeId)) && ($this->config->getCardRecurringMode($storeId) === Recurring::MODE_MAGENTO_VAULT);
     }
 
     /**

--- a/Helper/Vault.php
+++ b/Helper/Vault.php
@@ -100,14 +100,14 @@ class Vault
     }
 
     /**
-     * Check if Magento Vault is enabled
+     * Check if one click is enabled AND Magento Vault is set
      *
      * @param null $storeId
      * @return bool
      */
     public function isCardVaultEnabled($storeId = null): bool
     {
-        return $this->config->getCardRecurringMode($storeId) === Recurring::MODE_MAGENTO_VAULT;
+        return $this->config->getCardRecurringActive($storeId) && $this->config->getCardRecurringMode($storeId) === Recurring::MODE_MAGENTO_VAULT;
     }
 
     /**

--- a/Model/Billing/Agreement.php
+++ b/Model/Billing/Agreement.php
@@ -26,6 +26,7 @@ namespace Adyen\Payment\Model\Billing;
 use Adyen\Payment\Helper\Config;
 use Adyen\Payment\Helper\Data;
 use Adyen\Payment\Helper\PaymentMethods;
+use Adyen\Payment\Helper\Recurring;
 use Magento\Framework\Data\Collection\AbstractDb;
 use Magento\Framework\Model\Context;
 use Magento\Framework\Model\ResourceModel\AbstractResource;
@@ -43,6 +44,9 @@ class Agreement extends \Magento\Paypal\Model\Billing\Agreement
 
     /** @var Config */
     private $configHelper;
+
+    /** @var Recurring */
+    private $recurringHelper;
 
     /**
      * Agreement constructor.
@@ -65,6 +69,7 @@ class Agreement extends \Magento\Paypal\Model\Billing\Agreement
         CollectionFactory $billingAgreementFactory,
         DateTimeFactory $dateFactory,
         Config $configHelper,
+        Recurring $recurringHelper,
         AbstractResource $resource = null,
         AbstractDb $resourceCollection = null,
         array $data = []
@@ -82,6 +87,7 @@ class Agreement extends \Magento\Paypal\Model\Billing\Agreement
 
         $this->adyenHelper = $adyenHelper;
         $this->configHelper = $configHelper;
+        $this->recurringHelper = $recurringHelper;
     }
 
     /**
@@ -246,21 +252,7 @@ class Agreement extends \Magento\Paypal\Model\Billing\Agreement
         if (!empty($contractDetail['pos_payment'])) {
             $recurringType = $this->adyenHelper->getAdyenPosCloudConfigData('recurring_type', $storeId);
         } else {
-            $recurringType = $this->adyenHelper->getRecurringTypeFromOneclickRecurringSetting($storeId);
-
-            // for bcmc and maestro recurring is not allowed so don't set this
-            if ($recurringType === \Adyen\Payment\Model\RecurringType::ONECLICK_RECURRING &&
-                ($contractDetail['paymentMethod'] === "bcmc" || $contractDetail['paymentMethod'] === "maestro")
-            ) {
-                $recurringType = \Adyen\Payment\Model\RecurringType::ONECLICK;
-            }
-
-            // if shopper decides to not store the card don't save it as oneclick
-            if (!$storeOneClick &&
-                $recurringType === \Adyen\Payment\Model\RecurringType::ONECLICK_RECURRING
-            ) {
-                $recurringType = \Adyen\Payment\Model\RecurringType::RECURRING;
-            }
+            $recurringType = $this->recurringHelper->getRecurringTypeFromSetting($storeId);
         }
 
         $agreementData = [
@@ -271,6 +263,8 @@ class Agreement extends \Magento\Paypal\Model\Billing\Agreement
                 'expiryYear' => $expiryDate[1]
             ],
             'variant' => $variant,
+            // contractTypes should be changed from an array to a single value in the future. It has not been done yet
+            // to ensure past tokens are still operational.
             'contractTypes' => explode(',', $recurringType)
         ];
 

--- a/Observer/VaultConfigObserver.php
+++ b/Observer/VaultConfigObserver.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2021 Adyen BV (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\Payment\Observer;
+
+use Adyen\Payment\Helper\Config;
+use Adyen\Payment\Helper\Vault;
+use Magento\Framework\App\Config\Storage\WriterInterface;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+
+class VaultConfigObserver implements ObserverInterface
+{
+
+    /**
+     * @var Vault
+     */
+    private $vaultHelper;
+
+    /**
+     * @var Config
+     */
+    private $configHelper;
+
+    /**
+     * @var WriterInterface
+     */
+    private $configWriter;
+
+    /**
+     * VaultConfigObserver constructor.
+     * @param Vault $vaultHelper
+     * @param Config $configHelper
+     * @param WriterInterface $configWriter
+     */
+    public function __construct(
+        Vault $vaultHelper,
+        Config $configHelper,
+        WriterInterface $configWriter
+    ) {
+        $this->vaultHelper = $vaultHelper;
+        $this->configHelper = $configHelper;
+        $this->configWriter = $configWriter;
+    }
+
+    /**
+     * Execute when there is a change in the payment section in the admin backend (adyen config is in this section)
+     *
+     * The payment/adyen_cc_vault/active is required for vault to be used.
+     * Whenever there's a change in the payment section, check if based on these settings vault should be active. If so,
+     * set it to active, else deactivate it
+     *
+     * @param Observer $observer
+     */
+    public function execute(Observer $observer)
+    {
+        $storeId = $observer->getData('store');
+
+        if (empty($store)) {
+            $storeId = null;
+        }
+
+        // Get the settings based on the merchant config
+        $vaultEnabledConfig = $this->vaultHelper->isCardVaultEnabled($storeId);
+        // Get the value of the payment/adyen_cc_vault/active config
+        $vaultActiveConfig = $this->configHelper->getConfigData('active', Config::XML_ADYEN_CC_VAULT, $storeId, true);
+
+        // If they are not equal, update the payment/adyen_cc_vault/active config
+        if ($vaultEnabledConfig !== $vaultActiveConfig) {
+            $this->configWriter->save(
+                'payment/' . Config::XML_ADYEN_CC_VAULT . '/active',
+                intval($vaultEnabledConfig),
+            );
+        }
+    }
+}

--- a/Observer/VaultConfigObserver.php
+++ b/Observer/VaultConfigObserver.php
@@ -3,7 +3,7 @@
  *
  * Adyen Payment module (https://www.adyen.com/)
  *
- * Copyright (c) 2021 Adyen BV (https://www.adyen.com/)
+ * Copyright (c) 2022 Adyen N.V. (https://www.adyen.com/)
  * See LICENSE.txt for license details.
  *
  * Author: Adyen <magento@adyen.com>

--- a/Observer/VaultConfigObserver.php
+++ b/Observer/VaultConfigObserver.php
@@ -64,7 +64,7 @@ class VaultConfigObserver implements ObserverInterface
     {
         $storeId = $observer->getData('store');
 
-        if (empty($store)) {
+        if (empty($storeId)) {
             $storeId = null;
         }
 

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -67,6 +67,7 @@
                 <group>adyen</group>
             </adyen_cc>
             <adyen_cc_vault>
+                <active>1</active>
                 <model>AdyenPaymentCcVaultFacade</model>
                 <title>Stored Cards (Adyen)</title>
                 <instant_purchase>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -67,7 +67,6 @@
                 <group>adyen</group>
             </adyen_cc>
             <adyen_cc_vault>
-                <active>1</active>
                 <model>AdyenPaymentCcVaultFacade</model>
                 <title>Stored Cards (Adyen)</title>
                 <instant_purchase>

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -50,4 +50,7 @@
     <event name="sales_order_invoice_save_after">
         <observer name="adyen_invoice_save_after" instance="Adyen\Payment\Observer\InvoiceObserver" />
     </event>
+    <event name="admin_system_config_changed_section_payment">
+        <observer name="adyen_admin_vault_config_change" instance="Adyen\Payment\Observer\VaultConfigObserver"/>
+    </event>
 </config>


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Currently in the the old `ONECLICK`, `ONECLICK,RECURRING` and `RECURRING` are saved as a contractType.
This should be updated to save either `Subscription` or `CardOnFile` to use the newer values.

However when getting the tokens to be displayed in the checkout, we should still check of the old `ONECLICK` value to ensure that the older token is still displayed.

Also create new observer to update the `payment/adyen_cc_vault/active` config based on the choices on the configuration page.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

- Create Adyen token and process payment using it.
- Use previously created token (w/ONECLICK) contractType and process payment using it
- Create token using Magento Vault
- Process payment using vault token