### PR TITLE
[PW-6654] - Remove 1 EUR minimum limit from validation

### DIFF
--- a/Model/Config/Backend/DonationAmounts.php
+++ b/Model/Config/Backend/DonationAmounts.php
@@ -28,8 +28,6 @@ use Magento\Store\Model\StoreManagerInterface;
  */
 class DonationAmounts extends Value
 {
-    const MIN_DONATION_IN_EUR = 1;
-
     /**
      * @var Data
      */
@@ -62,9 +60,7 @@ class DonationAmounts extends Value
         ) {
             throw new \Magento\Framework\Validator\Exception(
                 new Phrase(
-                    'The Adyen Giving donation amounts are not valid, ' .
-                    'please enter amounts higher than ' . self::MIN_DONATION_IN_EUR . 'EUR separated by commas. ' .
-                    'Also, make sure that there is a currency rate for EUR in your Magento system.'
+                    'The Adyen Giving donation amounts are not valid, please enter amounts higher than zero separated by commas.'
                 )
             );
         }
@@ -73,17 +69,14 @@ class DonationAmounts extends Value
 
     public function validateDonationAmounts($amounts = array())
     {
-
-        $baseCurrencyRate = $this->storeManager->getStore()->getBaseCurrency()->getRate('EUR');
-
-        // Fail if the field is empty, the array is associative, or if there isn't a currency rate for EUR
-        if (empty($amounts) || array_values($amounts) !== $amounts || !$baseCurrencyRate) {
+        // Fail if the field is empty, the array is associative
+        if (empty($amounts) || array_values($amounts) !== $amounts) {
             return false;
         }
 
         foreach ($amounts as $amount) {
-            // Fail if one of the amounts is empty, not numeric, or less than the minimum donation amount
-            if ($amount === '' || !is_numeric($amount) || $amount * $baseCurrencyRate < self::MIN_DONATION_IN_EUR) {
+            // Fail if one of the amounts is empty, not numeric, or less than zero
+            if ($amount === '' || !is_numeric($amount) || $amount <= 0) {
                 return false;
             }
         }


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Previously, Adyen Giving was expecting an amount greater or equal to 1 EUR (or equivalent in foreign currency). Now, `Adyen Giving` supports all amounts and all currencies suitable for the payment methods that offer donation. 

Limitation of 1 EUR or equivalent is removed from the validation method. Now all of the currencies and any amount can be used for Adyen Giving without configuring a `Currency Rate` from Magento 2.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
Configuring Adyen Giving without a `Currency Rate` for EUR.