### PR TITLE
[PW-6734] - PBL expiry date validation updated

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     
     strategy:
       matrix:
-        php-version: [7.3, 7.4]
+        php-version: [7.3, 7.4, 8.1]
     
     steps:
     - uses: actions/checkout@v2

--- a/Gateway/Request/ExpiryDateDataBuilder.php
+++ b/Gateway/Request/ExpiryDateDataBuilder.php
@@ -41,8 +41,8 @@ class ExpiryDateDataBuilder implements BuilderInterface
     {
         $paymentFormFields = $this->request->getParam('payment');
         $expiryDate = date_create_from_format(
-            AdyenPayByLinkConfigProvider::DATE_FORMAT,
-            $paymentFormFields["adyen_pbl_expires_at"]
+            AdyenPayByLinkConfigProvider::DATE_TIME_FORMAT,
+            $paymentFormFields["adyen_pbl_expires_at"] . ' 23:59:59'
         );
 
         $request['body']['expiresAt'] = $expiryDate->format(DATE_ATOM);

--- a/Gateway/Validator/PayByLinkValidator.php
+++ b/Gateway/Validator/PayByLinkValidator.php
@@ -22,12 +22,12 @@ class PayByLinkValidator extends AbstractValidator
     public function validate(array $validationSubject)
     {
         $payment = $validationSubject['payment'];
-        $expiresAt = $payment->getAdyenPblExpiresAt();
+        $expiresAt = $payment->getAdyenPblExpiresAt() . ' 23:59:59';
         if (!is_null($expiresAt) && $expiryDate = date_create_from_format(
-                AdyenPayByLinkConfigProvider::DATE_FORMAT,
+                AdyenPayByLinkConfigProvider::DATE_TIME_FORMAT,
                 $expiresAt
             )) {
-            $daysToExpire = (new \DateTime())->diff($expiryDate)->format("%r%a");
+            $daysToExpire = ($expiryDate->getTimestamp() - time()) / 86400;
             if (
                 $daysToExpire <= AdyenPayByLinkConfigProvider::MIN_EXPIRY_DAYS ||
                 $daysToExpire >= AdyenPayByLinkConfigProvider::MAX_EXPIRY_DAYS

--- a/Model/Ui/AdyenPayByLinkConfigProvider.php
+++ b/Model/Ui/AdyenPayByLinkConfigProvider.php
@@ -21,6 +21,7 @@ class AdyenPayByLinkConfigProvider implements ConfigProviderInterface
     const MAX_EXPIRY_DAYS = 70;
     const DAYS_TO_EXPIRE_CONFIG_PATH = 'payment/adyen_pay_by_link/days_to_expire';
     const DATE_FORMAT = 'd-m-Y';
+    const DATE_TIME_FORMAT = 'd-m-Y H:i:s';
     const EXPIRES_AT_KEY = 'payByLinkExpiresAt';
     const URL_KEY = 'payByLinkUrl';
     const ID_KEY = 'payByLinkId';

--- a/Test/Unit/Gateway/Validator/PayByLinkValidatorTest.php
+++ b/Test/Unit/Gateway/Validator/PayByLinkValidatorTest.php
@@ -105,7 +105,7 @@ class PayByLinkValidatorTest extends TestCase
                     AdyenPayByLinkConfigProvider::DATE_FORMAT,
                     strtotime($today . ' + ' . (AdyenPayByLinkConfigProvider::MIN_EXPIRY_DAYS) . ' days')
                 ),
-                false
+                true
             ],
         ];
     }

--- a/Test/Unit/Helper/DataTest.php
+++ b/Test/Unit/Helper/DataTest.php
@@ -1,6 +1,5 @@
 <?php
 /**
- *
  * Adyen Payment module (https://www.adyen.com/)
  *
  * Copyright (c) 2015 Adyen BV (https://www.adyen.com/)
@@ -11,10 +10,35 @@
 
 namespace Adyen\Payment\Tests\Helper;
 
-class DataTest extends \PHPUnit\Framework\TestCase
+use Adyen\Payment\Helper\Data;
+use Adyen\Payment\Helper\Locale;
+use Adyen\Payment\Logger\AdyenLogger;
+use Adyen\Payment\Model\ResourceModel\Billing\Agreement\CollectionFactory as BillingAgreementCollectionFactory;
+use Adyen\Payment\Model\ResourceModel\Notification\CollectionFactory as NotificationCollectionFactory;
+use Magento\Directory\Model\Config\Source\Country;
+use Magento\Framework\App\CacheInterface;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\App\Helper\Context;
+use Magento\Framework\App\ProductMetadata;
+use Magento\Framework\Component\ComponentRegistrarInterface;
+use Magento\Framework\Config\DataInterface;
+use Magento\Framework\Encryption\EncryptorInterface;
+use Magento\Framework\Locale\ResolverInterface;
+use Magento\Framework\Module\ModuleListInterface;
+use Magento\Framework\Serialize\SerializerInterface;
+use Magento\Framework\View\Asset\Repository;
+use Magento\Framework\View\Asset\Source;
+use Magento\Sales\Api\OrderManagementInterface;
+use Magento\Sales\Model\Order\Status\HistoryFactory;
+use Magento\Store\Model\StoreManager;
+use Magento\Tax\Model\Calculation;
+use Magento\Tax\Model\Config;
+use PHPUnit\Framework\TestCase;
+
+class DataTest extends TestCase
 {
     /**
-     * @var \Adyen\Payment\Helper\Data
+     * @var Data
      */
     private $dataHelper;
 
@@ -27,33 +51,30 @@ class DataTest extends \PHPUnit\Framework\TestCase
 
     public function setUp(): void
     {
-        $context = $this->getSimpleMock(\Magento\Framework\App\Helper\Context::class);
-        $encryptor = $this->getSimpleMock(\Magento\Framework\Encryption\EncryptorInterface::class);
-        $dataStorage = $this->getSimpleMock(\Magento\Framework\Config\DataInterface::class);
-        $country = $this->getSimpleMock(\Magento\Directory\Model\Config\Source\Country::class);
-        $moduleList = $this->getSimpleMock(\Magento\Framework\Module\ModuleListInterface::class);
-        $billingAgreementCollectionFactory = $this->getSimpleMock(\Adyen\Payment\Model\ResourceModel
-                                                                  \Billing\Agreement\CollectionFactory::class);
-        $assetRepo = $this->getSimpleMock(\Magento\Framework\View\Asset\Repository::class);
-        $assetSource = $this->getSimpleMock(\Magento\Framework\View\Asset\Source::class);
-        $notificationFactory = $this->getSimpleMock(\Adyen\Payment\Model\ResourceModel
-                                                    \Notification\CollectionFactory::class);
-        $taxConfig = $this->getSimpleMock(\Magento\Tax\Model\Config::class);
-        $taxCalculation = $this->getSimpleMock(\Magento\Tax\Model\Calculation::class);
-        $productMetadata = $this->getSimpleMock(\Magento\Framework\App\ProductMetadata::class);
-        $adyenLogger = $this->getSimpleMock(\Adyen\Payment\Logger\AdyenLogger::class);
-        $storeManager = $this->getSimpleMock(\Magento\Store\Model\StoreManager::class);
-        $cache = $this->getSimpleMock(\Magento\Framework\App\CacheInterface::class);
-        $localeResolver = $this->getSimpleMock(\Magento\Framework\Locale\ResolverInterface::class);
-        $config = $this->getSimpleMock(\Magento\Framework\App\Config\ScopeConfigInterface::class);
-        $serializer = $this->getSimpleMock(\Magento\Framework\Serialize\SerializerInterface::class);
-        $componentRegistrar = $this->getSimpleMock(\Magento\Framework
-                                                   \Component\ComponentRegistrarInterface::class);
-        $localeHelper = $this->getSimpleMock(\Adyen\Payment\Helper\Locale::class);
-        $orderManagement = $this->getSimpleMock(\Magento\Sales\Api\OrderManagementInterface::class);
-        $orderStatusHistoryFactory = $this->getSimpleMock(\Magento\Sales\Model\Order\Status\HistoryFactory::class);
+        $context = $this->getSimpleMock(Context::class);
+        $encryptor = $this->getSimpleMock(EncryptorInterface::class);
+        $dataStorage = $this->getSimpleMock(DataInterface::class);
+        $country = $this->getSimpleMock(Country::class);
+        $moduleList = $this->getSimpleMock(ModuleListInterface::class);
+        $billingAgreementCollectionFactory = $this->getSimpleMock(BillingAgreementCollectionFactory::class);
+        $assetRepo = $this->getSimpleMock(Repository::class);
+        $assetSource = $this->getSimpleMock(Source::class);
+        $notificationFactory = $this->getSimpleMock(NotificationCollectionFactory::class);
+        $taxConfig = $this->getSimpleMock(Config::class);
+        $taxCalculation = $this->getSimpleMock(Calculation::class);
+        $productMetadata = $this->getSimpleMock(ProductMetadata::class);
+        $adyenLogger = $this->getSimpleMock(AdyenLogger::class);
+        $storeManager = $this->getSimpleMock(StoreManager::class);
+        $cache = $this->getSimpleMock(CacheInterface::class);
+        $localeResolver = $this->getSimpleMock(ResolverInterface::class);
+        $config = $this->getSimpleMock(ScopeConfigInterface::class);
+        $serializer = $this->getSimpleMock(SerializerInterface::class);
+        $componentRegistrar = $this->getSimpleMock(ComponentRegistrarInterface::class);
+        $localeHelper = $this->getSimpleMock(Locale::class);
+        $orderManagement = $this->getSimpleMock(OrderManagementInterface::class);
+        $orderStatusHistoryFactory = $this->getSimpleMock(HistoryFactory::class);
 
-        $this->dataHelper = new \Adyen\Payment\Helper\Data(
+        $this->dataHelper = new Data(
             $context,
             $encryptor,
             $dataStorage,
@@ -110,7 +131,8 @@ class DataTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($expectedResult, $pspSearchUrl);
     }
 
-    public function testGetPspReferenceWithNoAdditions(){
+    public function testGetPspReferenceWithNoAdditions()
+    {
         $this->assertEquals(
             ['pspReference' => '852621234567890A', 'suffix' => ''],
             $this->dataHelper->parseTransactionId('852621234567890A')

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "ext-json": "*"
   },
   "require-dev": {
-    "phpunit/phpunit": "~6.5.0",
+    "phpunit/phpunit": "^9",
     "magento/magento-coding-standard": "*",
     "squizlabs/php_codesniffer": "~3.5.3"
   },


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
PBL expiry date was being set with the date coming from the `DatePicker` plus the current `H:i:s`. But, it was ambiguous, since the link could be expired in the middle of the day.

Now, the link will be available at the end of the selected day.

Also, `(new \DateTime())->diff($expiryDate)->format("%r%a")` wasn't giving enough information. [1 Day + 13 Hours + ...] was being considered as `1 Day` which caused incorrect validation result.

**Additional Changes for Test Pipeline**
- PHP 8.1 added to test matrix.
- Unit tests updated.
- PHPUnit version changed. 

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
 - PBL order creation with the expiry dates at the edge cases (0, 1, 70, 100, -15 days)