### PR TITLE
[PW-6737] - Update recurring request builder (v7)

### DIFF
--- a/Helper/Requests.php
+++ b/Helper/Requests.php
@@ -380,16 +380,23 @@ class Requests extends AbstractHelper
     public function buildCardRecurringData(int $storeId, $payment)
     {
         $request = [];
+        $storePaymentMethod = false;
 
-        $storedPaymentMethodsEnabled = $this->adyenHelper->getAdyenOneclickConfigData('active', $storeId);
         // Initialize the request body with the current state data
         // Multishipping checkout uses the cc_number field for state data
         $stateData = $this->stateData->getStateData($payment->getOrder()->getQuoteId()) ?:
             (json_decode($payment->getCcNumber(), true) ?: []);
 
-        $request['storePaymentMethod'] = (bool)($stateData['storePaymentMethod'] ?? $storedPaymentMethodsEnabled);
+        // If PayByLink
+        // Else, if option to store token exists, get the value from the checkbox
+        if ($payment->getMethod() === AdyenPayByLinkConfigProvider::CODE) {
+            $request['storePaymentMethodMode'] = 'askForConsent';
+        } elseif (array_key_exists('storePaymentMethod', $stateData)) {
+            $storePaymentMethod = (bool)($stateData['storePaymentMethod']);
+            $request['storePaymentMethod'] = $storePaymentMethod;
+        }
 
-        if ($storedPaymentMethodsEnabled) {
+        if ($storePaymentMethod) {
             if ($this->vaultHelper->isCardVaultEnabled()) {
                 $request['recurringProcessingModel'] = 'Subscription';
             } else {

--- a/Helper/Requests.php
+++ b/Helper/Requests.php
@@ -377,7 +377,7 @@ class Requests extends AbstractHelper
      * @param $payment
      * @return array
      */
-    public function buildCardRecurringData(int $storeId, $payment)
+    public function buildCardRecurringData(int $storeId, $payment): array
     {
         $request = [];
         $storePaymentMethod = false;

--- a/Helper/Requests.php
+++ b/Helper/Requests.php
@@ -392,7 +392,7 @@ class Requests extends AbstractHelper
         if ($payment->getMethod() === AdyenPayByLinkConfigProvider::CODE) {
             $request['storePaymentMethodMode'] = 'askForConsent';
         } elseif (array_key_exists('storePaymentMethod', $stateData)) {
-            $storePaymentMethod = (bool)($stateData['storePaymentMethod']);
+            $storePaymentMethod = $stateData['storePaymentMethod'];
             $request['storePaymentMethod'] = $storePaymentMethod;
         }
 

--- a/Test/Unit/Helper/RequestsTest.php
+++ b/Test/Unit/Helper/RequestsTest.php
@@ -1,0 +1,56 @@
+<?php declare(strict_types=1);
+
+namespace Adyen\Payment\Helper;
+
+use Magento\Sales\Model\Order;
+use Magento\Sales\Model\Order\Payment;
+use PHPUnit\Framework\TestCase;
+
+class RequestsTest extends TestCase
+{
+    private $sut;
+    private $paymentMock;
+
+    public function testGuestNoStorePaymentMethod()
+    {
+        $this->setMockObjects([]);
+        $this->assertEmpty($this->sut->buildCardRecurringData(1, $this->paymentMock));
+    }
+
+    public function testStorePaymentMethodFalse()
+    {
+        $this->setMockObjects(['storePaymentMethod' => false]);
+        $storePaymentMethodValue = $this->sut->buildCardRecurringData(1, $this->paymentMock)['storePaymentMethod'];
+
+        $this->assertFalse($storePaymentMethodValue);
+    }
+
+    public function testStorePaymentMethodTrue()
+    {
+        $this->setMockObjects(['storePaymentMethod' => true]);
+        $storePaymentMethodValue = $this->sut->buildCardRecurringData(1, $this->paymentMock)['storePaymentMethod'];
+
+        $this->assertTrue($storePaymentMethodValue);
+    }
+
+    private function setMockObjects(array $stateDataArray): void
+    {
+        // Model\Order\Payment\Interceptor
+        $stateDataMock = $this->createMock(StateData::class);
+        $stateDataMock->method('getStateData')->willReturn($stateDataArray);
+
+        $orderMock = $this->createMock(Order::class);
+        $orderMock->method('getQuoteId')->willReturn(1);
+        $this->paymentMock = $this->createMock(Payment::class);
+        $this->paymentMock->method('getOrder')->willReturn($orderMock);
+
+        $this->sut = new Requests(
+            $this->createMock(Data::class),
+            $this->createMock(Config::class),
+            $this->createMock(Address::class),
+            $stateDataMock,
+            $this->createMock(PaymentMethods::class),
+            $this->createMock(Vault::class)
+        );
+    }
+}

--- a/Test/Unit/Helper/RequestsTest.php
+++ b/Test/Unit/Helper/RequestsTest.php
@@ -8,49 +8,77 @@ use PHPUnit\Framework\TestCase;
 
 class RequestsTest extends TestCase
 {
+    /** @var Requests $sut */
     private $sut;
+
+    /** @var Payment $paymentMock */
     private $paymentMock;
 
-    public function testGuestNoStorePaymentMethod()
+    public function testBuildCardRecurringGuestNoStorePaymentMethod()
     {
-        $this->setMockObjects([]);
+        $this->setMockObjects([], false, '');
         $this->assertEmpty($this->sut->buildCardRecurringData(1, $this->paymentMock));
     }
 
-    public function testStorePaymentMethodFalse()
+    public function testBuildCardRecurringStorePaymentMethodFalse()
     {
-        $this->setMockObjects(['storePaymentMethod' => false]);
-        $storePaymentMethodValue = $this->sut->buildCardRecurringData(1, $this->paymentMock)['storePaymentMethod'];
+        $this->setMockObjects(['storePaymentMethod' => false], false, '');
+        $request = $this->sut->buildCardRecurringData(1, $this->paymentMock);
 
-        $this->assertFalse($storePaymentMethodValue);
+        $this->assertFalse($request['storePaymentMethod']);
     }
 
-    public function testStorePaymentMethodTrue()
+    public function testBuildCardRecurringStorePaymentMethodTrueVault()
     {
-        $this->setMockObjects(['storePaymentMethod' => true]);
-        $storePaymentMethodValue = $this->sut->buildCardRecurringData(1, $this->paymentMock)['storePaymentMethod'];
+        $this->setMockObjects(['storePaymentMethod' => true], true, '');
+        $request = $this->sut->buildCardRecurringData(1, $this->paymentMock);
 
-        $this->assertTrue($storePaymentMethodValue);
+        $this->assertTrue($request['storePaymentMethod']);
+        $this->assertEquals(Recurring::SUBSCRIPTION, $request['recurringProcessingModel']);
     }
 
-    private function setMockObjects(array $stateDataArray): void
+    public function testBuildCardRecurringStorePaymentMethodTrueAdyenCardOnFile()
+    {
+        $this->setMockObjects(['storePaymentMethod' => true], false, Recurring::CARD_ON_FILE);
+        $request = $this->sut->buildCardRecurringData(1, $this->paymentMock);
+
+        $this->assertTrue($request['storePaymentMethod']);
+        $this->assertEquals(Recurring::CARD_ON_FILE, $request['recurringProcessingModel']);
+    }
+
+    public function testBuildCardRecurringStorePaymentMethodTrueAdyenSubscription()
+    {
+        $this->setMockObjects(['storePaymentMethod' => true], false, Recurring::SUBSCRIPTION);
+        $request = $this->sut->buildCardRecurringData(1, $this->paymentMock);
+
+        $this->assertTrue($request['storePaymentMethod']);
+        $this->assertEquals(Recurring::SUBSCRIPTION, $request['recurringProcessingModel']);
+    }
+
+    private function setMockObjects(array $stateDataArray, bool $vaultEnabled, string $adyenTokenType): void
     {
         // Model\Order\Payment\Interceptor
         $stateDataMock = $this->createMock(StateData::class);
         $stateDataMock->method('getStateData')->willReturn($stateDataArray);
 
+        $vaultHelperMock = $this->createMock(Vault::class);
+        $vaultHelperMock->method('isCardVaultEnabled')->willReturn($vaultEnabled);
+
+        $configHelperMock = $this->createMock(Config::class);
+        $configHelperMock->method('getCardRecurringType')->willReturn($adyenTokenType);
+
+        $this->sut = new Requests(
+            $this->createMock(Data::class),
+            $configHelperMock,
+            $this->createMock(Address::class),
+            $stateDataMock,
+            $this->createMock(PaymentMethods::class),
+            $vaultHelperMock
+        );
+
         $orderMock = $this->createMock(Order::class);
         $orderMock->method('getQuoteId')->willReturn(1);
         $this->paymentMock = $this->createMock(Payment::class);
         $this->paymentMock->method('getOrder')->willReturn($orderMock);
-
-        $this->sut = new Requests(
-            $this->createMock(Data::class),
-            $this->createMock(Config::class),
-            $this->createMock(Address::class),
-            $stateDataMock,
-            $this->createMock(PaymentMethods::class),
-            $this->createMock(Vault::class)
-        );
     }
 }


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
This PR will update the logic used to build the recurring data related to cards. Guest users will not be able to create tokens, while for logged in users, a token will only be created if the checkbox is ticket.

**Tested scenarios**
* `storePaymentMethod = false` for guest
* `storePaymentMethod = false` if logged in doesn't select the checkbox
* `storePaymentMethod = true` if logged in user selects the checkbox