### PR TITLE
Fix configuration being returned as an array of empty payment methods configs

### DIFF
--- a/etc/schema.graphqls
+++ b/etc/schema.graphqls
@@ -59,7 +59,7 @@ type AdyenPaymentMethodsArray {
     type: String @doc(description: "The unique payment method code.")
     brand: String @doc(description: "Brand for the selected gift card. For example: plastix, hmclub.")
     brands: [String] @doc(description: "List of possible brands. For example: visa, mc.")
-    configuration: [AdyenPaymentMethodsConfiguration] @doc(description: "The configuration of the payment method.")
+    configuration: AdyenPaymentMethodsConfiguration @doc(description: "The configuration of the payment method.")
     details: [AdyenPaymentMethodsDetails] @doc(description: "All input details to be provided to complete the payment with this payment method.")
     issuers: [AdyenPaymentMethodsIssuers] @doc(description: "Payment method issuer list.")
 }


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
* The `configuration` field of a payment method returned by the GraphQl API is currently an array looking like this:
```
[
    {"merchantId":null,"merchantName":null,"__typename":"AdyenPaymentMethodsConfiguration"}, 
    {"merchantId":null,"merchantName":null,"__typename":"AdyenPaymentMethodsConfiguration"}
]
```
* This is because the resolver provides the field as a single configuration `{"merchantId":"<id>","merchantName":"<name>"}` but the schema declares it as an array of AdyenPaymentMethodsConfiguration Types.

<!-- Please provide a description of the changes proposed in the Pull Request -->
* To fix this I've adjusted the schema to be in line with the data that is returned.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
* Tested with an Apple Pay method in PWA-Studio.
