### PR TITLE
[PW-6743] - Hide ApplePay on non Safari browsers

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/adyen-hpp-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-hpp-method.js
@@ -788,7 +788,8 @@ define(
                         self.checkoutComponent,
                         paymentMethod.methodIdentifier,
                         configuration,
-                        containerId
+                        containerId,
+                        result
                     );
 
                 } catch (err) {


### PR DESCRIPTION
**Description**
ApplePay was shown on Chrome however this payment method can be used with Safari only from browsers.

Related constructor updated.

**Tested scenarios**
- Check Google Chrome
- Check Safari