### PR TITLE
[PW-6425v7] Enable auto capture for Afterpay transactions

### DIFF
--- a/Gateway/Request/CheckoutDataBuilder.php
+++ b/Gateway/Request/CheckoutDataBuilder.php
@@ -126,8 +126,6 @@ class CheckoutDataBuilder implements BuilderInterface
 
         if ($this->adyenHelper->isPaymentMethodOpenInvoiceMethod(
                 $payment->getAdditionalInformation(AdyenHppDataAssignObserver::BRAND_CODE)
-            ) || $this->adyenHelper->isPaymentMethodAfterpayTouchMethod(
-                $payment->getAdditionalInformation(AdyenHppDataAssignObserver::BRAND_CODE)
             ) || $this->adyenHelper->isPaymentMethodOneyMethod(
                 $payment->getAdditionalInformation(AdyenHppDataAssignObserver::BRAND_CODE)
             ) || $payment->getMethod() == AdyenPayByLinkConfigProvider::CODE

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -996,47 +996,12 @@ class Data extends AbstractHelper
     }
 
     /**
-     * Excludes AfterPay (NL/BE) from the open invoice list.
-     * AfterPay variants should be excluded (not afterpaytouch)as an option for auto capture.
-     * @param $paymentMethod
-     * @return bool
-     */
-    public function isPaymentMethodOpenInvoiceMethodValidForAutoCapture($paymentMethod)
-    {
-        if (strpos($paymentMethod, self::AFTERPAY_TOUCH) !== false ||
-            strpos($paymentMethod, self::KLARNA) !== false ||
-            strpos($paymentMethod, self::RATEPAY) !== false ||
-            strpos($paymentMethod, self::FACILYPAY) !== false ||
-            strpos($paymentMethod, self::AFFIRM) !== false ||
-            strpos($paymentMethod, self::CLEARPAY) !== false ||
-            strpos($paymentMethod, self::ZIP) !== false ||
-            strpos($paymentMethod, self::PAYBRIGHT) !== false
-        ) {
-            return true;
-        }
-
-        return false;
-    }
-    /**
      * @param $paymentMethod
      * @return bool
      */
     public function isPaymentMethodRatepayMethod($paymentMethod)
     {
         if (strpos($paymentMethod, self::RATEPAY) !== false) {
-            return true;
-        }
-
-        return false;
-    }
-
-    /**
-     * @param $paymentMethod
-     * @return bool
-     */
-    public function isPaymentMethodAfterpayTouchMethod($paymentMethod)
-    {
-        if (strpos($paymentMethod, self::AFTERPAY_TOUCH) !== false) {
             return true;
         }
 

--- a/Model/Cron.php
+++ b/Model/Cron.php
@@ -1744,7 +1744,7 @@ class Cron
 
             // if auto capture mode for openinvoice is turned on then use auto capture
             if ($captureModeOpenInvoice == true &&
-                $this->_adyenHelper->isPaymentMethodOpenInvoiceMethodValidForAutoCapture($this->_paymentMethod)
+                $this->_adyenHelper->isPaymentMethodOpenInvoiceMethod($this->_paymentMethod)
             ) {
                 $this->_adyenLogger->addAdyenNotificationCronjob(
                     'This payment method is configured to be working as auto capture '

--- a/etc/adminhtml/system/adyen_advanced_order_processing.xml
+++ b/etc/adminhtml/system/adyen_advanced_order_processing.xml
@@ -40,7 +40,7 @@
         </field>
         <field id="auto_capture_openinvoice" translate="label" type="select" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
             <label>Use auto-capture for OpenInvoice payments</label>
-            <tooltip>Applicable for Klarna, Afterpay Touch, Ratepay, FacilyPay/Oney, Affirm, Clearpay, Zip and PayBright. By default, Open Invoice methods are set to manual capture. If you want auto capture you need to contact magento@adyen.com. After approval has been given you can set this option to 'Yes'.</tooltip>
+            <tooltip>Applicable for Klarna, Afterpay, Afterpay Touch, Ratepay, FacilyPay/Oney, Affirm, Clearpay, Zip and PayBright. By default, Open Invoice methods are set to manual capture. If you want auto capture you need to contact magento@adyen.com. After approval has been given you can set this option to 'Yes'.</tooltip>
             <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
             <config_path>payment/adyen_abstract/auto_capture_openinvoice</config_path>
         </field>

--- a/etc/adminhtml/system/adyen_getting_started.xml
+++ b/etc/adminhtml/system/adyen_getting_started.xml
@@ -34,7 +34,7 @@
                                 <li>In the test environment you need to use test cards. Test cards can be found <a target="_blank" href="http://adyen.com/test-card-numbers">here</a>.</li>
                                 <li>The Adyen Customer Area can be found on <a target="_blank" href="https://ca-test.adyen.com">https://ca-test.adyen.com</a> for test or <a target="_blank" href="https://ca-live.adyen.com">https://ca-live.adyen.com</a> for live.</li>
                             </ul>
-                            <p>If you have any further questions, please visit the <a target="_blank" href="http://www.adyen.com">Adyen</a> website or email <a href="mailto:magento@adyen.com">magento@adyen.com</a>.</p>
+                            <p>If you have any further questions, please visit the <a target="_blank" href="http://www.adyen.com">Adyen</a> website or reach out to our support team by filling out the <a href="https://ca-test.adyen.com/ca/ca/contactUs/support.shtml?topic=magento&form=magento" target="_blank">support form</a>.</p>
                             ]]></comment>
         <field id="version" translate="label" type="label" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="0">
             <label>Extension version</label>


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
Enable the auto capture for AfterPay transactions.

**Tested scenarios**
Complete the immediate capture AfterPay transaction with auto-capture for invoice payment methods enabled, checked whether the transaction was successful and the order updated upon the processing of the notifications by cronjob.

Complete manual capture AfterPay transaction with auto-capture for invoice payment method disabled, captured the payment manually within Magento with invoicing it, payment was successfully settled.