### PR TITLE
[PW-6564] Removed redundant automatic 'pay' to prevent being invoices not being linked

### DIFF
--- a/Observer/BeforeShipmentObserver.php
+++ b/Observer/BeforeShipmentObserver.php
@@ -113,7 +113,7 @@ class BeforeShipmentObserver extends AbstractDataAssignObserver
             $pspReference = $order->getPayment()->getAdyenPspReference();
             $invoice->setTransactionId($pspReference);
             $invoice->setRequestedCaptureCase(Invoice::CAPTURE_ONLINE);
-            $invoice->register()->pay();
+            $invoice->register();
             $this->invoiceRepository->save($invoice);
         } catch (Throwable $e) {
             $this->logger->error($e);


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
When an OpenInvoice was automatically captured on shipment, the created invoice would already be payed. This prevents the InvoiceObserver from linking the adyen_invoice to magento's invoice, which causes a crash later. This automatic 'pay()' can be removed as it also happens on line 196 in Helper/Invoice.php.

**Tested scenarios**
- [x] Automatic invoice on capture for openinvoice method (klarna)

**Fixed issue**:  <!-- #-prefixed issue number -->
Closes #1467