### PR TITLE
[PW-3658] - Override the payment method name with the SEPA Direct Debit

### DIFF
--- a/Block/Info/Cc.php
+++ b/Block/Info/Cc.php
@@ -31,7 +31,14 @@ class Cc extends AbstractInfo
 
         if (isset($types[$ccType])) {
             return $types[$ccType]['name'];
-        } else {
+        }
+        // TODO::Refactor this block after tokenization of the alternative payment methods.
+        // This elseif block should be removed after the tokenization of the alternative payment methods (In progress: PW-6764). More general approach is required.
+        // Also remove `sepadirectdebit` from translation files.
+        elseif ($ccType == 'sepadirectdebit') {
+            return __('sepadirectdebit');
+        }
+        else {
             return __('Unknown');
         }
     }

--- a/i18n/en_US.csv
+++ b/i18n/en_US.csv
@@ -56,3 +56,4 @@
 "Select debit or credit card","Select debit or credit card"
 "Credit","Credit"
 "Debit","Debit"
+"sepadirectdebit", "SEPA Direct Debit"

--- a/i18n/nl_NL.csv
+++ b/i18n/nl_NL.csv
@@ -53,3 +53,4 @@
 "Continue to Adyen App", "Doorgaan naar Adyen-app"
 "Do not use Installments", "Gebruik geen wederkerende betalingen"
 "(Please provide a card with the type from the list above)", "(Please provide a card with the type from the list above)"
+"sepadirectdebit", "SEPA Direct Debit"

--- a/view/adminhtml/templates/info/adyen_cc.phtml
+++ b/view/adminhtml/templates/info/adyen_cc.phtml
@@ -43,7 +43,7 @@ $_isDemoMode = $block->isDemoMode();
 
 <?php if ($block->getCcTypeName() != ""): ?>
     <div>
-        <?= $block->escapeHtml(__('Credit Card Type: %1', $block->getCcTypeName())); ?><br/>
+        <?= $block->escapeHtml(__('Payment Method: %1', $block->getCcTypeName())); ?><br/>
     </div>
 <?php endif; ?>
 <?php if ($_info->getCcLast4() != ""): ?>


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->
**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Transactions completed with recurring SEPA Direct Debit were shown as `Credit Card` on confirmation e-mail and order preview on Magento backend.

This property was overridden by this change. 

However this is a temporary solution since the all the `OneClick` payment methods are under the `CreditCard` type. After tokenising `Alternative Payment Methods` with a more general approach, this should be changed also. 

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- SEPA Direct Debit
- Recurring with SEPA Direct Debit
- Cards Payment