### PR TITLE
[PW-6783] - Implement handleReject() for HPP methods.

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/adyen-hpp-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-hpp-method.js
@@ -313,6 +313,7 @@ define(
                         self.isPlaceOrderActionAllowed(true);
                         fullScreenLoader.stopLoader();
                         self.showErrorMessage(response);
+                        component.handleReject(response);
                     }
                 ).done(
                     function(orderId) {


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
If a user is blocked from the Customer Area due to fraud risk, the payment is getting refused as expected. But, PayPal pop-up window is staying active with an empty spinner. In order to close this window `handleReject()` method was implemented from `component`.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- PayPal
- Ideal
- Generic Gift Card