### PR TITLE
[PW-6794] - Remove incompatible method from AdyenLogger v7

### DIFF
--- a/Logger/AdyenLogger.php
+++ b/Logger/AdyenLogger.php
@@ -91,20 +91,6 @@ class AdyenLogger extends Logger
     }
 
     /**
-     * Adds a log record.
-     *
-     * @param integer $level The logging level
-     * @param string $message The log message
-     * @param array $context The log context
-     * @return Boolean Whether the record has been processed
-     */
-    public function addRecord($level, $message, array $context = []): bool
-    {
-        $context['is_exception'] = $message instanceof \Exception;
-        return parent::addRecord($level, $message, $context);
-    }
-
-    /**
      * Adds a log record at the INFO level.
      *
      * This method allows for compatibility with common interfaces.


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Due to the Monolog dependency version changes in 2.4.4, unit tests have started to fail for plugin version 7.

Remove [this](https://github.com/Adyen/adyen-magento2/commit/f47193a61108cf51764f68d3abe6c93c61a9b9a0#diff-9fdbd8251d6e3b0e40b3ef969725206396cef8d0a53d3f3160f448ed9dd840daL89) override method in `AdyenLogger`.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

**Fixed issue**:  <!-- #-prefixed issue number -->