### PR TITLE
[PW-6704] Move MOTO to Configure payment methods section

### DIFF
--- a/etc/adminhtml/system/adyen_advanced_settings.xml
+++ b/etc/adminhtml/system/adyen_advanced_settings.xml
@@ -24,6 +24,5 @@
         <include path="Adyen_Payment::system/adyen_security.xml"/>
         <include path="Adyen_Payment::system/adyen_pwa.xml"/>
         <include path="Adyen_Payment::system/adyen_additional_payment_settings.xml"/>
-        <include path="Adyen_Payment::system/adyen_moto_settings.xml"/>
     </group>
 </include>

--- a/etc/adminhtml/system/adyen_configure_payment_methods.xml
+++ b/etc/adminhtml/system/adyen_configure_payment_methods.xml
@@ -23,5 +23,6 @@
         <include path="Adyen_Payment::system/adyen_pos_cloud.xml"/>
         <include path="Adyen_Payment::system/adyen_pay_by_link.xml"/>
         <include path="Adyen_Payment::system/adyen_giving.xml"/>
+        <include path="Adyen_Payment::system/adyen_moto_settings.xml"/>
     </group>
 </include>

--- a/etc/adminhtml/system/adyen_moto_settings.xml
+++ b/etc/adminhtml/system/adyen_moto_settings.xml
@@ -11,7 +11,7 @@
  */
 -->
 <include xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_include.xsd">
-    <group id="adyen_moto_advanced_settings" translate="label" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="100">
+    <group id="adyen_moto_advanced_settings" translate="label" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="600">
         <label>MOTO settings</label>
         <frontend_model>Magento\Config\Block\System\Config\Form\Fieldset</frontend_model>
         <field id="enable_moto" translate="label" type="select" sortOrder="10" showInDefault="1"


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
The MOTO is a payment method so it should be part of Configure payment methods section rather than Advanced settings

