### PR TITLE
Shopper reference not unique for recurring payments

### DIFF
--- a/Helper/Requests.php
+++ b/Helper/Requests.php
@@ -51,8 +51,6 @@ class Requests extends AbstractHelper
      */
     private $vaultHelper;
 
-    private $shopperReference;
-
     /**
      * Requests constructor.
      *
@@ -443,13 +441,13 @@ class Requests extends AbstractHelper
     public function getShopperReference($customerId, $orderIncrementId): string
     {
         if ($customerId) {
-            $this->shopperReference = str_pad($customerId, 3, '0', STR_PAD_LEFT);
+            $shopperReference = str_pad($customerId, 3, '0', STR_PAD_LEFT);
         } else {
             $uuid = Uuid::generateV4();
             $guestCustomerId = $orderIncrementId . $uuid;
-            $this->shopperReference = $guestCustomerId;
+            $shopperReference = $guestCustomerId;
         }
 
-        return $this->shopperReference;
+        return $shopperReference;
     }
 }

--- a/Helper/Requests.php
+++ b/Helper/Requests.php
@@ -442,14 +442,12 @@ class Requests extends AbstractHelper
      */
     public function getShopperReference($customerId, $orderIncrementId): string
     {
-        if (!$this->shopperReference) {
-            if ($customerId) {
-                $this->shopperReference = str_pad($customerId, 3, '0', STR_PAD_LEFT);
-            } else {
-                $uuid = Uuid::generateV4();
-                $guestCustomerId = $orderIncrementId . $uuid;
-                $this->shopperReference = $guestCustomerId;
-            }
+        if ($customerId) {
+            $this->shopperReference = str_pad($customerId, 3, '0', STR_PAD_LEFT);
+        } else {
+            $uuid = Uuid::generateV4();
+            $guestCustomerId = $orderIncrementId . $uuid;
+            $this->shopperReference = $guestCustomerId;
         }
 
         return $this->shopperReference;


### PR DESCRIPTION
**Description**
`CustomerDataBuilder` includes shared `Requests` helper which can lead into serious issues where previously generated shopper reference is used for another quote which might be linked with different customer ID. 

This will result in `803: PaymentDetail not found` error. The issue normally does not affect frontend sessions, but causes problems when generating recurring orders from backend for multiple customers, e.g. for product subscriptions.  

**Tested scenarios**
1. Save card details in Magento Vault for two different customers.
2. During single application execution create new carts for both customers, set payments with their saved card tokens and finally submit quotes using cart management service.