### PR TITLE
[PW-6821] - Add check to InvoiceObserver to verify if the order was made with Adyen payment method

### DIFF
--- a/Helper/PaymentMethods.php
+++ b/Helper/PaymentMethods.php
@@ -156,14 +156,23 @@ class PaymentMethods extends AbstractHelper
     }
 
     /**
+     * @return array
+     */
+    public function getAdyenPaymentCodes(): array
+    {
+        return [self::ADYEN_HPP, self::ADYEN_CC, self::ADYEN_ONE_CLICK];
+    }
+
+    /**
      * @param string $methodCode
      * @return bool
      */
     public function isAdyenPayment(string $methodCode): bool
     {
-        if($methodCode !== self::ADYEN_HPP || $methodCode !== self::ADYEN_CC || $methodCode !== self::ADYEN_ONE_CLICK) {
+        if(in_array($methodCode, $this->getAdyenPaymentCodes())) {
             return false;
         }
+
         return true;
     }
 

--- a/Observer/InvoiceObserver.php
+++ b/Observer/InvoiceObserver.php
@@ -102,17 +102,11 @@ class InvoiceObserver implements ObserverInterface
         $payment = $order->getPayment();
         $method = $payment->getMethod();
 
-        // If invoice has already been paid or full amount is finalized, exit observer
-         // $this->paymentMethodsHelper->isAdyenPayment($method) !== true ||
-//            if ($this->paymentMethodsHelper->isAdyenPayment($method) || $invoice->wasPayCalled() || $this->adyenOrderPaymentHelper->isFullAmountFinalized($order)) {
-//                return;
-//            }
+        // If payment is not originating from Adyen or invoice has already been paid or full amount is finalized, exit observer
+        if (!$this->paymentMethodsHelper->isAdyenPayment($method) || $invoice->wasPayCalled() || $this->adyenOrderPaymentHelper->isFullAmountFinalized($order)) {
+            return;
+        }
 
-            if($this->paymentMethodsHelper->isAdyenPayment($method)) {
-                $this->logger->addAdyenNotificationCronjob(
-                    sprintf('Please work', $invoice->getEntityId())
-                );
-            }
 
         $this->logger->addAdyenDebug(
             sprintf('Event sales_order_invoice_save_after for invoice %s will be handled', $invoice->getEntityId()),


### PR DESCRIPTION
**Description**
When an order is placed by any payment method, the invoice observer listens doesn't check to see if the Adyen payment method was selected. This PR is adding a check to identify whether the payment method is Adyen payment method.

**Tested scenarios**
- created an order with manual capture with Adyen payment method to make sure the logger creates an entry in debug.log
- created an order with non-Adyen payment method to see whether it breaks out of the execute() function of the InvoiceObserver and doesn't write in debug.log