### PR TITLE
[PW-6767] - Dotpay "Back to shop" throws an error

### DIFF
--- a/Controller/Process/Result.php
+++ b/Controller/Process/Result.php
@@ -193,7 +193,10 @@ class Result extends \Magento\Framework\App\Action\Action
             $session->getQuote()->setIsActive($setQuoteAsActive)->save();
 
             // Prevent action component to redirect page with the payment method Dotpay Bank transfer / postal
-            if ("dotpay" == $this->_order->getPayment()->getAdditionalInformation('brand_code')) {
+            if (
+                $this->_order->getPayment()->getAdditionalInformation('brand_code') == 'dotpay' &&
+                $this->_order->getPayment()->getAdditionalInformation('resultCode') == 'Received'
+            ) {
                 $this->payment->unsAdditionalInformation('action');
                 $this->_order->save();
             }

--- a/Controller/Process/Result.php
+++ b/Controller/Process/Result.php
@@ -191,6 +191,13 @@ class Result extends \Magento\Framework\App\Action\Action
         if ($result) {
             $session = $this->_session;
             $session->getQuote()->setIsActive($setQuoteAsActive)->save();
+
+            // Prevent action component to redirect page with the payment method Dotpay Bank transfer / postal
+            if ("dotpay" == $this->_order->getPayment()->getAdditionalInformation('brand_code')) {
+                $this->payment->unsAdditionalInformation('action');
+                $this->_order->save();
+            }
+
             // Add OrderIncrementId to redirect parameters for headless support.
             $redirectParams = $this->_adyenHelper->getAdyenAbstractConfigData('custom_success_redirect_path')
                 ? ['_query' => ['utm_nooverride' => '1', 'order_increment_id' => $this->_order->getIncrementId()]]

--- a/Controller/Process/Result.php
+++ b/Controller/Process/Result.php
@@ -22,6 +22,8 @@ use Magento\Sales\Model\Order;
 class Result extends \Magento\Framework\App\Action\Action
 {
 
+    const BRAND_CODE_DOTPAY = 'dotpay';
+    const RESULT_CODE_RECEIVED = 'Received';
     const DETAILS_ALLOWED_PARAM_KEYS = [
         'MD',
         'PaReq',
@@ -194,8 +196,8 @@ class Result extends \Magento\Framework\App\Action\Action
 
             // Prevent action component to redirect page with the payment method Dotpay Bank transfer / postal
             if (
-                $this->_order->getPayment()->getAdditionalInformation('brand_code') == 'dotpay' &&
-                $this->_order->getPayment()->getAdditionalInformation('resultCode') == 'Received'
+                $this->_order->getPayment()->getAdditionalInformation('brand_code') == self::BRAND_CODE_DOTPAY &&
+                $this->_order->getPayment()->getAdditionalInformation('resultCode') == self::RESULT_CODE_RECEIVED
             ) {
                 $this->payment->unsAdditionalInformation('action');
                 $this->_order->save();


### PR DESCRIPTION
**Description**
Dotpay Bank Transfer / Postal payment method throws an error when a shopper clicks to the `Back to Shop` button. (This button is not responsible to redirect shopper to the Checkout page like other LPMs but to the success page.)

Dotpay Bank Transfer / Postal payment method returns `Received` resultCode when the redirect url is created. This method actually is a manual way to transfer the transaction to the Dotpay, there is not an actual `Authorisation`. Therefore, it waits for a `Notification` to complete the order.

However, `Action Component` on the success page fetches action again, since [this condition](https://github.com/Adyen/adyen-magento2/blob/6df3276aa2807f5f3804c649fbcb5b3852da1b38/Block/Checkout/Success.php#L117) catches it.

In order to prevent the `Action Component` RE-redirect the shopper, `action` is unset after the redirect on the `Result` controller.