### PR TITLE
[PW-6725] Limit Ideal Issuer selector dropdown to not overlap Order Summary section

### DIFF
--- a/view/frontend/layout/checkout_index_index.xml
+++ b/view/frontend/layout/checkout_index_index.xml
@@ -13,6 +13,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/layout_generic.xsd">
     <head>
         <css src="Adyen_Payment::css/adyen.css"/>
+        <css src="Adyen_Payment::css/styles.css"/>
     </head>
     <body>
         <referenceBlock name="checkout.root">

--- a/view/frontend/web/css/styles.css
+++ b/view/frontend/web/css/styles.css
@@ -9,5 +9,5 @@
  */
 
 .adyen-checkout__dropdown__button {
-    width: auto !important;
+    width: auto;
 }

--- a/view/frontend/web/css/styles.css
+++ b/view/frontend/web/css/styles.css
@@ -1,0 +1,13 @@
+/**
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2022 Adyen NV (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+.adyen-checkout__dropdown__button {
+    width: auto !important;
+}


### PR DESCRIPTION
**Description**
On the checkout page for selecting the payment method, Ideal Issuer dropdown selector overlaps Order Summary section. This fix is implementing a new css file in `/view/frontend/web` of the project and prevents the overlapping of the dropdown selector element.

**Tested scenarios**
Proceed to payment method section with a Dutch address, select Ideal and make sure the dropdown element is not overlapping the `payment-method-content` div. 