### PR TITLE
[PW-6724] Separator line between Credit Card and the next payment method

### DIFF
--- a/view/frontend/web/css/styles.css
+++ b/view/frontend/web/css/styles.css
@@ -11,3 +11,7 @@
 .adyen-checkout__dropdown__button {
     width: auto;
 }
+
+.payment-method:nth-of-type(3) {
+    border-bottom: 1px solid #ccc;
+}


### PR DESCRIPTION
**Description**
Add the border line between Credit Card and the next payment method in the checkout page.

**Tested scenarios**
Proceed to the checkout page and observer the separator line between the Credit Card payment method and the next payment method available in the list of payment methods.