### PR TITLE
PW-6780: Fix call to undefined method in backend orders

### DIFF
--- a/Gateway/Request/CcBackendAuthorizationDataBuilder.php
+++ b/Gateway/Request/CcBackendAuthorizationDataBuilder.php
@@ -13,6 +13,7 @@ namespace Adyen\Payment\Gateway\Request;
 
 use Adyen\Payment\Helper\StateData;
 use Adyen\Payment\Observer\AdyenCcDataAssignObserver;
+use Magento\Backend\Model\Session\Quote;
 use Magento\Payment\Gateway\Data\PaymentDataObject;
 use Magento\Payment\Gateway\Helper\SubjectReader;
 use Magento\Payment\Gateway\Request\BuilderInterface;
@@ -23,10 +24,17 @@ class CcBackendAuthorizationDataBuilder implements BuilderInterface
      * @var StateData
      */
     private $stateData;
+    /**
+     * @var Quote
+     */
+    private $quote;
 
-    public function __construct(StateData $stateData)
-    {
+    public function __construct(
+        StateData $stateData,
+        Quote $quote
+    ) {
         $this->stateData = $stateData;
+        $this->quote = $quote;
     }
 
     /**
@@ -38,8 +46,7 @@ class CcBackendAuthorizationDataBuilder implements BuilderInterface
         /** @var PaymentDataObject $paymentDataObject */
         $paymentDataObject = SubjectReader::readPayment($buildSubject);
         $payment = $paymentDataObject->getPayment();
-        $order = $paymentDataObject->getOrder();
-        $requestBody = $this->stateData->getStateData($order->getQuoteId());
+        $requestBody = $this->stateData->getStateData($this->quote->getQuoteId());
 
         // if installments is set add it into the request
         $installments = $payment->getAdditionalInformation(AdyenCcDataAssignObserver::NUMBER_OF_INSTALLMENTS) ?: 0;


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**

When using our module together with Braintree the following error occurs in admin area: 

```
Error: Call to undefined method PayPal\Braintree\Gateway\Data\Order\OrderAdapter::getQuoteId() 
```

This happens because both modules define different preferences for the same class (`Magento\Payment\Gateway\Data\Order\OrderAdapter`):

```xml
<preference for="Magento\Payment\Gateway\Data\Order\OrderAdapter" type="Adyen\Payment\Gateway\Data\Order\OrderAdapter"/>
```

Braintree:
```xml
<preference for="Magento\Payment\Gateway\Data\Order\OrderAdapter" type="PayPal\Braintree\Gateway\Data\Order\OrderAdapter"/>
```

To avoid this conflict, we are going to fetch quote ID from session via another class. Using session because the order creation is still in progress (not committed to database).  

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
* Admin orders
* Frontend 3DS card

Fixes #1168 