### PR TITLE
[PW-6807] Create/update webhooks using management API

### DIFF
--- a/Model/Config/Backend/WebhookCredentials.php
+++ b/Model/Config/Backend/WebhookCredentials.php
@@ -32,6 +32,7 @@ use Magento\Framework\Data\Collection\AbstractDb;
 use Magento\Framework\Model\Context;
 use Magento\Framework\Model\ResourceModel\AbstractResource;
 use Magento\Framework\Registry;
+use Magento\Framework\UrlInterface;
 
 class WebhookCredentials extends Value
 {
@@ -44,6 +45,11 @@ class WebhookCredentials extends Value
      */
     private $configHelper;
 
+    /**
+     * @var UrlInterface
+     */
+    private $url;
+
     public function __construct(
         Context $context,
         Registry $registry,
@@ -51,41 +57,34 @@ class WebhookCredentials extends Value
         TypeListInterface $cacheTypeList,
         ManagementHelper $managementApiHelper,
         Config $configHelper,
+        UrlInterface $url,
         AbstractResource $resource = null,
         AbstractDb $resourceCollection = null,
         array $data = []
     ) {
         $this->managementApiHelper = $managementApiHelper;
         $this->configHelper = $configHelper;
+        $this->url = $url;
         parent::__construct($context, $registry, $config, $cacheTypeList, $resource, $resourceCollection, $data);
     }
 
     public function beforeSave()
     {
-        $username = $this->getValue();
-        $password = $this->getFieldsetDataValue('notification_password');
-        $url = $this->getFieldsetDataValue('webhook_url');
-        $mode = (int) $this->getFieldsetDataValue('demo_mode') ? 'test' : 'live';
-        $apiKey = $this->getFieldsetDataValue('api_key_' . $mode);
-        if (preg_match('/^\*+$/', $apiKey)) {
-            // API key contains '******', set to the previously saved config value
-            $apiKey = $this->configHelper->getApiKey($mode);
-        }
-        $merchantAccount = $this->getFieldsetDataValue('merchant_account');
+        if ($this->getFieldsetDataValue('configuration_mode')=='auto') {
+            $username = $this->getValue();
+            $password = $this->getFieldsetDataValue('notification_password');
 
-        // (re)configure webhook credentials if any changes have been made
-        $originalPassword = $this->configHelper->getNotificationsPassword();
-        if (preg_match('/^\*+$/', $password)) {
-            // Password contains '******', set to the previously saved config value
-            $password = $originalPassword;
-        }
-        $usernameChanged = $username !== $this->configHelper->getNotificationsUsername();
-        $passwordChanged = $password !== $originalPassword;
-        $urlChanged = $this->getFieldsetDataValue('webhook_url') !== (string) $this->configHelper->getWebhookUrl();
+            $webhookUrl = $this->url->getBaseUrl() . 'adyen/process/json';
+            $mode = (int)$this->getFieldsetDataValue('demo_mode') ? 'test' : 'live';
+            $apiKey = $this->getFieldsetDataValue('api_key_' . $mode);
+            if (preg_match('/^\*+$/', $apiKey)) {
+                // API key contains '******', set to the previously saved config value
+                $apiKey = $this->configHelper->getApiKey($mode);
+            }
+            $merchantAccount = $this->getFieldsetDataValue('merchant_account');
 
-        if ($usernameChanged || $passwordChanged || $urlChanged) {
             $this->managementApiHelper
-                ->setupWebhookCredentials($apiKey, $merchantAccount, $username, $password, $url, 'test' === $mode);
+                ->setupWebhookCredentials($apiKey, $merchantAccount, $username, $password, $webhookUrl, 'test' === $mode);
         }
 
         return parent::beforeSave();

--- a/Model/Config/Source/ConfigurationMode.php
+++ b/Model/Config/Source/ConfigurationMode.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Adyen\Payment\Model\Config\Source;
+
+class ConfigurationMode implements \Magento\Framework\Option\ArrayInterface
+{
+    /**
+     * @return array
+     */
+    public function toOptionArray()
+    {
+        $modes = $this->getModes();
+
+        foreach ($modes as $code => $label) {
+            $options[] = ['value' => $code, 'label' => $label];
+        }
+        return $options;
+    }
+
+    private function getModes()
+    {
+        return [
+            'manual' => 'Manual',
+            'auto' => 'Automated'
+        ];
+    }
+}

--- a/etc/adminhtml/system/adyen_required_settings.xml
+++ b/etc/adminhtml/system/adyen_required_settings.xml
@@ -30,7 +30,7 @@
 
         <label><![CDATA[Required Settings]]></label>
         <frontend_model>Magento\Config\Block\System\Config\Form\Fieldset</frontend_model>
-        <field id="api_key_test" translate="label" type="obscure" sortOrder="10" showInDefault="1" showInWebsite="1"
+        <field id="api_key_test" translate="label" type="obscure" sortOrder="5" showInDefault="1" showInWebsite="1"
                showInStore="0">
             <label>API key for Test</label>
             <tooltip>If you don't know your Api-Key, log in to your Test Customer Area. Navigate to Developers => API
@@ -40,7 +40,7 @@
             <config_path>payment/adyen_abstract/api_key_test</config_path>
             <comment model="Adyen\Payment\Model\Comment\ApiKeyEnding"/>
         </field>
-        <field id="api_key_live" translate="label" type="obscure" sortOrder="20" showInDefault="1" showInWebsite="1"
+        <field id="api_key_live" translate="label" type="obscure" sortOrder="10" showInDefault="1" showInWebsite="1"
                showInStore="0">
             <label>API key for Live</label>
             <tooltip>If you don't know your Api-Key, you can find it in your Live Customer Area. Navigate to Developers
@@ -50,13 +50,20 @@
             <config_path>payment/adyen_abstract/api_key_live</config_path>
             <comment model="Adyen\Payment\Model\Comment\ApiKeyEnding"/>
         </field>
-        <field id="demo_mode" translate="label" type="select" sortOrder="30" showInDefault="1" showInWebsite="1"
+        <field id="demo_mode" translate="label" type="select" sortOrder="20" showInDefault="1" showInWebsite="1"
                showInStore="1">
             <label>Test/Production Mode</label>
             <source_model>Adyen\Payment\Model\Config\Source\DemoMode</source_model>
             <config_path>payment/adyen_abstract/demo_mode</config_path>
             <tooltip>
                 <![CDATA[ In the test mode you must use test cards. See section Documentation & Support for the link to the test cards]]></tooltip>
+        </field>
+        <field id="configuration_mode" translate="label" type="select" sortOrder="30" showInDefault="1"
+               showInWebsite="1"
+               showInStore="1">
+            <label>Configuration Mode</label>
+            <source_model>Adyen\Payment\Model\Config\Source\ConfigurationMode</source_model>
+            <config_path>payment/adyen_abstract/configuration_mode</config_path>
         </field>
         <field id="adyen_get_merchant_accounts" translate="label comment" type="button" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1">
             <frontend_model>Adyen\Payment\Model\Config\Adminhtml\MerchantAccounts</frontend_model>
@@ -120,14 +127,6 @@
             <backend_model>Magento\Config\Model\Config\Backend\Encrypted</backend_model>
             <config_path>payment/adyen_abstract/notification_password</config_path>
             <tooltip>Set a password of your choice. </tooltip>
-        </field>
-        <field id="webhook_url" translate="label" type="text" sortOrder="100" showInDefault="1"
-               showInWebsite="1" showInStore="1">
-            <label>Webhook URL</label>
-            <frontend_model>Adyen\Payment\Model\Config\Adminhtml\WebhookCredentials</frontend_model>
-            <config_path>payment/adyen_abstract/webhook_url</config_path>
-            <validate>validate-url</validate>
-            <tooltip>Set the webhook URL. </tooltip>
         </field>
         <field id="adyen_webhook_test" translate="label comment" type="button" sortOrder="105" showInDefault="1" showInWebsite="1" showInStore="1">
             <frontend_model>Adyen\Payment\Model\Config\Adminhtml\WebhookTest</frontend_model>


### PR DESCRIPTION
Create webhook based on config mode auto or manual when save the config form

<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Create new webhook on save config in magento admin if the config mode is set to `auto`. In this case magento uses the provided username and password in order to make a `POST /merchants/{id}/webhooks` and create a webhook based on the base url.

**Tested scenarios**
Save config in auto config mode and creates a new webhook url with the provided credentials

