### PR TITLE
PW-6854: Set shopper locale from store locale [v7]

### DIFF
--- a/Helper/Requests.php
+++ b/Helper/Requests.php
@@ -174,7 +174,7 @@ class Requests extends AbstractHelper
                 $request['countryCode'] = $countryId;
             }
 
-            $request['shopperLocale'] = $this->adyenHelper->getCurrentLocaleCode($storeId);
+            $request['shopperLocale'] = $this->adyenHelper->getStoreLocale($storeId);
         }
 
         return $request;


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
We are setting shopper locale from the **current**  store. This is not working in the admin area, where a store can be selected when creating an order.  

The `\Adyen\Payment\Helper\Data::getCurrentLocaleCode` method returns the current store locale or possibly an overwritten value from a plugin setting ("Language locale" field under "Adyen Payments > Configure payment methods > Alternative Payment Methods > Advanced Settings"). While forcing a locale this way may be possible, it's better to make use of the builtin  store locale configuration.    

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
* admin order
* frontend order

v8: #1597 