### PR TITLE
[PW-6857] Add UnscheduledCardOnFile for alternative payment methods

### DIFF
--- a/Helper/PaymentMethods/ApplePayPaymentMethod.php
+++ b/Helper/PaymentMethods/ApplePayPaymentMethod.php
@@ -50,4 +50,9 @@ class ApplePayPaymentMethod implements PaymentMethodInterface
     {
         return true;
     }
+
+    public function supportsUnscheduledCardOnFile(): bool
+    {
+        return true;
+    }
 }

--- a/Helper/PaymentMethods/GooglePayPaymentMethod.php
+++ b/Helper/PaymentMethods/GooglePayPaymentMethod.php
@@ -50,4 +50,9 @@ class GooglePayPaymentMethod implements PaymentMethodInterface
     {
         return true;
     }
+
+    public function supportsUnscheduledCardOnFile(): bool
+    {
+        return true;
+    }
 }

--- a/Helper/PaymentMethods/PayPalPaymentMethod.php
+++ b/Helper/PaymentMethods/PayPalPaymentMethod.php
@@ -50,4 +50,9 @@ class PayPalPaymentMethod implements PaymentMethodInterface
     {
         return false;
     }
+
+    public function supportsUnscheduledCardOnFile(): bool
+    {
+        return true;
+    }
 }

--- a/Helper/PaymentMethods/PaymentMethodInterface.php
+++ b/Helper/PaymentMethods/PaymentMethodInterface.php
@@ -9,6 +9,7 @@
  * This file is open source and available under the MIT license.
  * See the LICENSE file for more info.
  */
+
 namespace Adyen\Payment\Helper\PaymentMethods;
 
 interface PaymentMethodInterface
@@ -26,4 +27,6 @@ interface PaymentMethodInterface
     public function supportsAutoCapture(): bool;
 
     public function isWalletPaymentMethod(): bool;
+
+    public function supportsUnscheduledCardOnFile(): bool;
 }

--- a/Helper/PaymentMethods/SepaPaymentMethod.php
+++ b/Helper/PaymentMethods/SepaPaymentMethod.php
@@ -55,4 +55,9 @@ class SepaPaymentMethod implements PaymentMethodInterface
     {
         return false;
     }
+
+    public function supportsUnscheduledCardOnFile(): bool
+    {
+        return true;
+    }
 }

--- a/Helper/Recurring.php
+++ b/Helper/Recurring.php
@@ -23,6 +23,7 @@ class Recurring
 
     const CARD_ON_FILE = 'CardOnFile';
     const SUBSCRIPTION = 'Subscription';
+    const UNSCHEDULED_CARD_ON_FILE = 'UnscheduledCardOnFile';
 
     /** @var AdyenLogger */
     private $adyenLogger;
@@ -66,7 +67,8 @@ class Recurring
     {
         return [
             self::CARD_ON_FILE,
-            self::SUBSCRIPTION
+            self::SUBSCRIPTION,
+            self::UNSCHEDULED_CARD_ON_FILE
         ];
     }
 

--- a/Helper/Vault.php
+++ b/Helper/Vault.php
@@ -245,6 +245,8 @@ class Vault
         $currentRecurringTokenSetting = $this->config->getAlternativePaymentMethodTokenType($storeId);
         if ($currentRecurringTokenSetting === Recurring::CARD_ON_FILE) {
             $methodSupportsRecurring = $adyenPaymentMethod->supportsCardOnFile();
+        } elseif ($currentRecurringTokenSetting === Recurring::UNSCHEDULED_CARD_ON_FILE) {
+            $methodSupportsRecurring = $adyenPaymentMethod->supportsUnscheduledCardOnFile();
         } else {
             $methodSupportsRecurring = $adyenPaymentMethod->supportsSubscription();
         }


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
After PW-6764 and PW-6790 it is possible in the plugin to tokenize Paypal (Subscription), SEPA (Subscription), GooglePay (CardOnFile/Subscription) and ApplePay (CardOnFile/Subscription).
With this pr we add `UnshceduledCardOnFile` for the aforementioned payment methods. Not for tokens created using `adyen_cc` but only `adyen_hpp`.

The branch that is used is `recurring-changes`
**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- Tested that after the token has been created, the correct tokenType is saved in vault_payment_token.details
- Verified that this token will NOT be visible for instantPurchase OR in the checkout page (since it is not a CardOnFile token)

