### PR TITLE
[PW-6808] Remove unnecessary security config options

### DIFF
--- a/Controller/Process/Json.php
+++ b/Controller/Process/Json.php
@@ -258,7 +258,7 @@ class Json extends Action
         }
 
         // Validate if Ip check is enabled and if the notification comes from a verified IP
-        if ($this->configHelper->getNotificationsIpCheck() && !$this->isIpValid()) {
+        if (!$this->isIpValid()) {
             $this->adyenLogger->addAdyenNotification(
                 "Notification has been rejected because the IP address could not be verified"
             );
@@ -266,8 +266,7 @@ class Json extends Action
         }
 
         // Validate the Hmac calculation
-        $hasHmacCheck = $this->configHelper->getNotificationsHmacCheck() &&
-            $this->hmacSignature->isHmacSupportedEventCode($response);
+        $hasHmacCheck = $this->hmacSignature->isHmacSupportedEventCode($response);
         if ($hasHmacCheck && !$this->notificationReceiver->validateHmac(
             $response,
             $this->configHelper->getNotificationsHmacKey()

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -26,8 +26,6 @@ class Config
     const XML_NOTIFICATIONS_PASSWORD = "notification_password";
     const XML_WEBHOOK_URL = "webhook_url";
     const XML_NOTIFICATIONS_CAN_CANCEL_FIELD = "notifications_can_cancel";
-    const XML_NOTIFICATIONS_HMAC_CHECK = "notifications_hmac_check";
-    const XML_NOTIFICATIONS_IP_CHECK = "notifications_ip_check";
     const XML_NOTIFICATIONS_HMAC_KEY_LIVE = "notification_hmac_key_live";
     const XML_NOTIFICATIONS_HMAC_KEY_TEST = "notification_hmac_key_test";
     const XML_CHARGED_CURRENCY = "charged_currency";
@@ -159,38 +157,6 @@ class Config
     {
         return (bool)$this->getConfigData(
             self::XML_NOTIFICATIONS_CAN_CANCEL_FIELD,
-            self::XML_ADYEN_ABSTRACT_PREFIX,
-            $storeId,
-            true
-        );
-    }
-
-    /**
-     * Retrieve flag for notifications_hmac_check
-     *
-     * @param int $storeId
-     * @return bool
-     */
-    public function getNotificationsHmacCheck($storeId = null)
-    {
-        return (bool)$this->getConfigData(
-            self::XML_NOTIFICATIONS_HMAC_CHECK,
-            self::XML_ADYEN_ABSTRACT_PREFIX,
-            $storeId,
-            true
-        );
-    }
-
-    /**
-     * Retrieve flag for notifications_ip_check
-     *
-     * @param int $storeId
-     * @return bool
-     */
-    public function getNotificationsIpCheck($storeId = null)
-    {
-        return (bool)$this->getConfigData(
-            self::XML_NOTIFICATIONS_IP_CHECK,
             self::XML_ADYEN_ABSTRACT_PREFIX,
             $storeId,
             true

--- a/etc/adminhtml/system/adyen_required_settings.xml
+++ b/etc/adminhtml/system/adyen_required_settings.xml
@@ -161,35 +161,6 @@
                 <field id="configuration_mode">manual</field>
             </depends>
         </field>-->
-        <field id="notifications_hmac_check" translate="label" type="select" sortOrder="110" showInDefault="1" showInWebsite="1" showInStore="1">
-            <label>Check notification's HMAC signature</label>
-            <depends>
-                <field id="configuration_mode">manual</field>
-            </depends>
-            <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-            <config_path>payment/adyen_abstract/notifications_hmac_check</config_path>
-            <comment>
-                <![CDATA[
-                If enabled notifications will be accepted only when the HMAC
-                signature is verified. To learn more about these settings refer to
-                <a target="_blank" href="https://docs.adyen.com/plugins/magento-2/set-up-the-plugin-in-magento">Adyen documentation</a>.
-                ]]>
-            </comment>
-        </field>
-        <field id="notifications_ip_check" translate="label" type="select" sortOrder="120" showInDefault="1" showInWebsite="1" showInStore="1">
-            <label>Check notification's IP address</label>
-            <depends>
-                <field id="configuration_mode">manual</field>
-            </depends>
-            <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-            <config_path>payment/adyen_abstract/notifications_ip_check</config_path>
-            <comment>
-                <![CDATA[
-                If enabled notifications will be accepted only when the IP address matches Adyen's servers. To learn more about these settings refer to
-                <a target="_blank" href="https://docs.adyen.com/plugins/magento-2/set-up-the-plugin-in-magento">Adyen documentation</a>.
-                ]]>
-            </comment>
-        </field>
         <field id="live_endpoint_url_prefix" translate="label" type="text" sortOrder="130" showInDefault="1"
                showInWebsite="1" showInStore="0">
             <label>Live endpoint prefix</label>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -990,8 +990,6 @@
             <argument name="environment" xsi:type="array">
                 <item name="payment/adyen_abstract/demo_mode" xsi:type="string">1</item>
                 <item name="payment/adyen_abstract/debug" xsi:type="string">1</item>
-                <item name="payment/adyen_abstract/notifications_ip_check" xsi:type="string">1</item>
-                <item name="payment/adyen_abstract/notifications_hmac_check" xsi:type="string">1</item>
             </argument>
             <argument name="sensitive" xsi:type="array">
                 <item name="payment/adyen_abstract/merchant_account" xsi:type="string">1</item>


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Remove config options for checking HMAC signature and IP address, perform these checks by default. The checks are always performed and there are not part of the magento admin panel.
Remove the following config fields from required settings. 
- notifications_ip_check
- notifications_hmac_check

**Tested scenarios**
It is hard to test with our local environments as the IP now it is always invalid