### PR TITLE
[PW-6706] - Add capture, cancel, refund and void commands to MOTO

### DIFF
--- a/Block/Adminhtml/System/Config/Field/Moto.php
+++ b/Block/Adminhtml/System/Config/Field/Moto.php
@@ -35,7 +35,7 @@ class Moto extends \Magento\Config\Block\System\Config\Form\Field\FieldArray\Abs
     {
         $this->addColumn(
             'merchant_account',
-            ['label' => __('MOTO merchant account'), 'class' => 'required-entry', 'style' => 'width:130px']
+            ['label' => __('Merchant Account'), 'class' => 'required-entry', 'style' => 'width:130px']
         );
         $this->addColumn(
             'client_key',
@@ -53,7 +53,7 @@ class Moto extends \Magento\Config\Block\System\Config\Form\Field\FieldArray\Abs
         $this->addColumn(
             'demo_mode',
             [
-                'label' => __('Test/Live Mode'),
+                'label' => __('Mode'),
                 'renderer' => $this->getEnviromentModeRenderer()
             ]
         );

--- a/Block/Form/Moto.php
+++ b/Block/Form/Moto.php
@@ -289,4 +289,9 @@ class Moto extends \Magento\Payment\Block\Form\Cc
 
         return $this->chargedCurrency->getQuoteAmountCurrency($quote);
     }
+
+    public function getMotoMerchantAccounts()
+    {
+        return $this->configHelper->getMotoMerchantAccounts();
+    }
 }

--- a/Block/Form/Moto.php
+++ b/Block/Form/Moto.php
@@ -1,0 +1,292 @@
+<?php
+/**
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2022 Adyen N.V. (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\Payment\Block\Form;
+
+use Adyen\Payment\Helper\ChargedCurrency;
+use Adyen\Payment\Helper\Config;
+use Adyen\Payment\Helper\Data;
+use Adyen\Payment\Helper\Installments;
+use Adyen\Payment\Helper\Recurring;
+use Adyen\Payment\Helper\Vault;
+use Adyen\Payment\Logger\AdyenLogger;
+use Magento\Backend\Model\Session\Quote;
+use Magento\Customer\Model\Session;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\View\Element\Template\Context;
+
+class Moto extends \Magento\Payment\Block\Form\Cc
+{
+    /**
+     * @var string
+     */
+    protected $_template = 'Adyen_Payment::form/moto.phtml';
+
+    /**
+     * @var Data
+     */
+    protected $adyenHelper;
+
+    /**
+     * @var \Magento\Framework\App\State
+     */
+    protected $appState;
+
+    /**
+     * @var \Magento\Checkout\Model\Session
+     */
+    protected $checkoutSession;
+
+    /**
+     * @var Installments
+     */
+    private $installmentsHelper;
+
+    /**
+     * @var Installments
+     */
+    private $chargedCurrency;
+
+    /**
+     * @var Quote
+     */
+    private $backendCheckoutSession;
+
+    /**
+     * @var AdyenLogger
+     */
+    private $adyenLogger;
+
+    /**
+     * @var Config
+     */
+    private $configHelper;
+
+    /**
+     * @var Session
+     */
+    private $customerSession;
+
+    /**
+     * @var Vault
+     */
+    private $vaultHelper;
+
+    /**
+     * Cc constructor.
+     *
+     * @param Context $context
+     * @param \Magento\Payment\Model\Config $paymentConfig
+     * @param Data $adyenHelper
+     * @param \Magento\Checkout\Model\Session $checkoutSession
+     * @param Quote $backendCheckoutSession
+     * @param Installments $installmentsHelper
+     * @param ChargedCurrency $chargedCurrency
+     * @param AdyenLogger $adyenLogger
+     * @param Config $configHelper
+     * @param Session $customerSession
+     * @param Vault $vaultHelper
+     * @param array $data
+     */
+    public function __construct(
+        Context $context,
+        \Magento\Payment\Model\Config $paymentConfig,
+        Data $adyenHelper,
+        \Magento\Checkout\Model\Session $checkoutSession,
+        Quote $backendCheckoutSession,
+        Installments $installmentsHelper,
+        ChargedCurrency $chargedCurrency,
+        AdyenLogger $adyenLogger,
+        Config $configHelper,
+        Session $customerSession,
+        Vault $vaultHelper,
+        array $data = []
+    ) {
+        parent::__construct($context, $paymentConfig);
+        $this->adyenHelper = $adyenHelper;
+        $this->appState = $context->getAppState();
+        $this->checkoutSession = $checkoutSession;
+        $this->backendCheckoutSession = $backendCheckoutSession;
+        $this->installmentsHelper = $installmentsHelper;
+        $this->chargedCurrency = $chargedCurrency;
+        $this->adyenLogger = $adyenLogger;
+        $this->configHelper = $configHelper;
+        $this->customerSession = $customerSession;
+        $this->vaultHelper = $vaultHelper;
+    }
+
+    /**
+     * @return string
+     * @throws \Adyen\AdyenException
+     */
+    public function getClientKey()
+    {
+        return $this->adyenHelper->getClientKey();
+    }
+
+    /**
+     * @return string
+     */
+    public function getCheckoutEnvironment()
+    {
+        return $this->adyenHelper->getCheckoutEnvironment($this->checkoutSession->getQuote()->getStore()->getId());
+    }
+
+    /**
+     * Retrieve has verification configuration
+     *
+     * @return bool
+     */
+    public function hasVerification()
+    {
+        // On Backend always use MOTO
+        if ($this->appState->getAreaCode() === \Magento\Backend\App\Area\FrontNameResolver::AREA_CODE) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLocale()
+    {
+        return $this->adyenHelper->getStoreLocale($this->checkoutSession->getQuote()->getStore()->getId());
+    }
+
+    /**
+     * Retrieve available credit card type codes by alt code
+     *
+     * @return array
+     */
+    public function getCcAvailableTypesByAlt()
+    {
+        $types = [];
+        $ccTypes = $this->adyenHelper->getAdyenCcTypes();
+
+        $availableTypes = $this->adyenHelper->getAdyenCcConfigData('cctypes');
+        if ($availableTypes) {
+            $availableTypes = explode(',', $availableTypes);
+            foreach (array_keys($ccTypes) as $code) {
+                if (in_array($code, $availableTypes)) {
+                    $types[$ccTypes[$code]['code_alt']] = $code;
+                }
+            }
+        }
+
+        return $types;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isVaultEnabled(): bool
+    {
+        return $this->vaultHelper->isCardVaultEnabled();
+    }
+
+    /**
+     * @return string
+     */
+    public function getFormattedInstallments()
+    {
+        try {
+            $quoteAmountCurrency = $this->getQuoteAmountCurrency();
+            return $this->installmentsHelper->formatInstallmentsConfig(
+                $this->adyenHelper->getAdyenCcConfigData('installments',
+                    $this->_storeManager->getStore()->getId()
+                ),
+                $this->adyenHelper->getAdyenCcTypes(),
+                $quoteAmountCurrency->getAmount()
+            );
+        } catch (\Throwable $e) {
+            $this->adyenLogger->error(
+                'There was an error fetching the installments config: ' . $e->getMessage()
+            );
+            return '{}';
+        }
+    }
+
+    /**
+     * @return bool
+     */
+    public function getHasHolderName()
+    {
+        return (bool)$this->configHelper->getHasHolderName();
+    }
+
+    /**
+     * @return bool
+     */
+    public function getHolderNameRequired()
+    {
+        return $this->configHelper->getHolderNameRequired() && $this->configHelper->getHasHolderName();
+    }
+
+    /**
+     * @return bool
+     */
+    public function getEnableStoreDetails(): bool
+    {
+        $enableOneclick = (bool)$this->adyenHelper->getAdyenAbstractConfigData('enable_oneclick');
+        $enableVault = $this->isVaultEnabled();
+        $loggedIn = $this->customerSession->isLoggedIn();
+        return ($enableOneclick || $enableVault) && $loggedIn;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getEnableRisk()
+    {
+        try {
+            return $this->appState->getAreaCode() !== \Magento\Backend\App\Area\FrontNameResolver::AREA_CODE;
+        } catch (LocalizedException $exception) {
+            // Suppress exception, assume that risk should be enabled
+            return true;
+        }
+    }
+
+    /**
+     * @return string
+     */
+    public function getAmount()
+    {
+        try {
+            $quoteAmountCurrency = $this->getQuoteAmountCurrency();
+            $value = $quoteAmountCurrency->getAmount();
+            $currency = $quoteAmountCurrency->getCurrencyCode();
+            $amount = array("value" => $value, "currency" => $currency);
+
+            return json_encode($amount);
+
+        } catch (\Throwable $e) {
+            $this->adyenLogger->error(
+                'There was an error fetching the amount for installments config: ' . $e->getMessage()
+            );
+            return '{}';
+        }
+    }
+
+    /**
+     * @return \Adyen\Payment\Model\AdyenAmountCurrency
+     * @throws LocalizedException
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     */
+    protected function getQuoteAmountCurrency(): \Adyen\Payment\Model\AdyenAmountCurrency
+    {
+        $quote = $this->_appState->getAreaCode() == \Magento\Framework\App\Area::AREA_ADMINHTML ?
+            $this->backendCheckoutSession->getQuote() :
+            $this->checkoutSession->getQuote();
+
+        return $this->chargedCurrency->getQuoteAmountCurrency($quote);
+    }
+}

--- a/Block/Form/Moto.php
+++ b/Block/Form/Moto.php
@@ -94,7 +94,6 @@ class Moto extends \Magento\Payment\Block\Form\Cc
      * @param Config $configHelper
      * @param Session $customerSession
      * @param Vault $vaultHelper
-     * @param array $data
      */
     public function __construct(
         Context $context,
@@ -107,8 +106,7 @@ class Moto extends \Magento\Payment\Block\Form\Cc
         AdyenLogger $adyenLogger,
         Config $configHelper,
         Session $customerSession,
-        Vault $vaultHelper,
-        array $data = []
+        Vault $vaultHelper
     ) {
         parent::__construct($context, $paymentConfig);
         $this->adyenHelper = $adyenHelper;

--- a/Block/Info/Moto.php
+++ b/Block/Info/Moto.php
@@ -42,4 +42,15 @@ class Moto extends AbstractInfo
             return __('Unknown');
         }
     }
+
+    /**
+     *
+     * Return related MOTO merchant account of the order
+     *
+     * @return string
+     */
+    public function getMotoMerchantAccount()
+    {
+        return $this->getInfo()->getAdditionalInformation('motoMerchantAccount');
+    }
 }

--- a/Block/Info/Moto.php
+++ b/Block/Info/Moto.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2022 Adyen N.V. (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\Payment\Block\Info;
+
+class Moto extends AbstractInfo
+{
+    /**
+     * @var string
+     */
+    protected $_template = 'Adyen_Payment::info/adyen_moto.phtml';
+
+    /**
+     * Return credit card type
+     *
+     * @return string
+     * @throws \Magento\Framework\Exception\LocalizedException
+     */
+    public function getCcTypeName()
+    {
+        $types = $this->_adyenHelper->getAdyenCcTypes();
+        $ccType = $this->getInfo()->getCcType();
+
+        if (isset($types[$ccType])) {
+            return $types[$ccType]['name'];
+        }
+        // TODO::Refactor this block after tokenization of the alternative payment methods.
+        // This elseif block should be removed after the tokenization of the alternative payment methods (In progress: PW-6764). More general approach is required.
+        // Also remove `sepadirectdebit` from translation files.
+        elseif ($ccType == 'sepadirectdebit') {
+            return __('sepadirectdebit');
+        }
+        else {
+            return __('Unknown');
+        }
+    }
+}

--- a/Gateway/Http/Client/TransactionMotoCancel.php
+++ b/Gateway/Http/Client/TransactionMotoCancel.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2022 Adyen N.V. (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\Payment\Gateway\Http\Client;
+
+use Adyen\Service\Modification;
+use Magento\Payment\Gateway\Http\ClientInterface;
+
+/**
+ * Class TransactionSale
+ */
+class TransactionMotoCancel implements ClientInterface
+{
+    /**
+     * @var \Adyen\Payment\Helper\Data
+     */
+    private $adyenHelper;
+
+    /**
+     * PaymentRequest constructor.
+     * @param \Adyen\Payment\Helper\Data $adyenHelper
+     */
+    public function __construct(
+        \Adyen\Payment\Helper\Data $adyenHelper
+    ) {
+        $this->adyenHelper = $adyenHelper;
+    }
+
+    /**
+     * @param \Magento\Payment\Gateway\Http\TransferInterface $transferObject
+     * @return null
+     */
+    public function placeRequest(\Magento\Payment\Gateway\Http\TransferInterface $transferObject)
+    {
+        $request = $transferObject->getBody();
+
+        $client = $this->adyenHelper->initializeAdyenMotoClient($request['merchantAccount']);
+        $service = new Modification($client);
+
+        try {
+            $response = $service->cancel($request);
+        } catch (\Adyen\AdyenException $e) {
+            $response['error'] = $e->getMessage();
+        }
+        return $response;
+    }
+}

--- a/Gateway/Http/Client/TransactionMotoCapture.php
+++ b/Gateway/Http/Client/TransactionMotoCapture.php
@@ -1,0 +1,133 @@
+<?php
+/**
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2022 Adyen N.V. (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\Payment\Gateway\Http\Client;
+
+use Adyen\AdyenException;
+use Adyen\Payment\Api\Data\OrderPaymentInterface;
+use Adyen\Payment\Helper\Data;
+use Adyen\Payment\Helper\Requests;
+use Adyen\Payment\Logger\AdyenLogger;
+use Adyen\Service\Modification;
+use Magento\Payment\Gateway\Http\ClientInterface;
+use Magento\Payment\Gateway\Http\TransferInterface;
+
+/**
+ * Class TransactionSale
+ */
+class TransactionMotoCapture implements ClientInterface
+{
+    const MULTIPLE_AUTHORIZATIONS = 'multiple_authorizations';
+    const FORMATTED_CAPTURE_AMOUNT = 'formatted_capture_amount';
+    const CAPTURE_AMOUNT = 'capture_amount';
+    const ORIGINAL_REFERENCE = 'original_reference';
+    const CAPTURE_RECEIVED = '[capture-received]';
+
+    /**
+     * @var Data
+     */
+    private $adyenHelper;
+
+    /**
+     * @var AdyenLogger
+     */
+    private $adyenLogger;
+
+    /**
+     * PaymentRequest constructor.
+     * @param Data $adyenHelper
+     * @param AdyenLogger $adyenLogger
+     */
+    public function __construct(
+        Data $adyenHelper,
+        AdyenLogger $adyenLogger
+    ) {
+        $this->adyenHelper = $adyenHelper;
+        $this->adyenLogger = $adyenLogger;
+    }
+
+    /**
+     * @param TransferInterface $transferObject
+     * @return null
+     * @throws AdyenException
+     */
+    public function placeRequest(TransferInterface $transferObject)
+    {
+        $request = $transferObject->getBody();
+
+        $client = $this->adyenHelper->initializeAdyenMotoClient($request['merchantAccount']);
+        $service = new Modification($client);
+
+        if (array_key_exists(self::MULTIPLE_AUTHORIZATIONS, $request)) {
+            return $this->placeMultipleCaptureRequests($service, $request);
+        }
+
+        try {
+            $response = $service->capture($request);
+            $response = $this->copyParamsToResponse($response, $request);
+        } catch (AdyenException $e) {
+            $response['error'] = $e->getMessage();
+        }
+
+        return $response;
+    }
+
+    /**
+     * @param Modification $service
+     * @param $requestContainer
+     * @return array
+     */
+    private function placeMultipleCaptureRequests(Modification $service, $requestContainer)
+    {
+        $response = [];
+        foreach ($requestContainer[self::MULTIPLE_AUTHORIZATIONS] as $request) {
+            try {
+                // Copy merchant account from parent array to every request array
+                $request[Requests::MERCHANT_ACCOUNT] = $requestContainer[Requests::MERCHANT_ACCOUNT];
+                $singleResponse = $service->capture($request);
+                $singleResponse[self::FORMATTED_CAPTURE_AMOUNT] = $request['modificationAmount']['currency'] . ' ' .
+                $this->adyenHelper->originalAmount(
+                    $request['modificationAmount']['value'],
+                    $request['modificationAmount']['currency']
+                );
+                $singleResponse = $this->copyParamsToResponse($singleResponse, $request);
+                $response[self::MULTIPLE_AUTHORIZATIONS][] = $singleResponse;
+            } catch (AdyenException $e) {
+                $message = sprintf(
+                    'Exception occurred when attempting to capture multiple authorizations.
+                    Authorization with pspReference %s: %s',
+                    $request[OrderPaymentInterface::PSPREFRENCE],
+                    $e->getMessage()
+                );
+
+                $this->adyenLogger->error($message);
+                $response[self::MULTIPLE_AUTHORIZATIONS]['error'] = $message;
+            }
+        }
+
+        return $response;
+    }
+
+    /**
+     * Copy data from the request to the response. This data will be used later when handling the response
+     *
+     * @param array $response
+     * @param array $request
+     * @return array
+     */
+    private function copyParamsToResponse(array $response, array $request): array
+    {
+        $response[self::CAPTURE_AMOUNT] = $request['modificationAmount']['value'];
+        $response[self::ORIGINAL_REFERENCE] = $request['originalReference'];
+
+        return $response;
+    }
+}

--- a/Gateway/Http/Client/TransactionMotoPayment.php
+++ b/Gateway/Http/Client/TransactionMotoPayment.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2022 Adyen N.V. (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\Payment\Gateway\Http\Client;
+
+use Adyen\Payment\Model\PaymentResponse;
+use Adyen\Payment\Model\PaymentResponseFactory;
+use Magento\Payment\Gateway\Http\ClientInterface;
+use Adyen\Payment\Model\ApplicationInfo;
+
+class TransactionMotoPayment implements ClientInterface
+{
+
+    /**
+     * @var \Adyen\Payment\Helper\Data
+     */
+    private $adyenHelper;
+
+    /**
+     * @var ApplicationInfo
+     */
+    private $applicationInfo;
+
+    /**
+     * @var PaymentResponseFactory
+     */
+    private $paymentResponseFactory;
+
+    /**
+     * @var \Adyen\Payment\Model\ResourceModel\PaymentResponse
+     */
+    private $paymentResponseResourceModel;
+
+    /**
+     * TransactionPayment constructor.
+     * @param \Adyen\Payment\Helper\Data $adyenHelper
+     * @param ApplicationInfo $applicationInfo
+     */
+    public function __construct(
+        \Adyen\Payment\Helper\Data $adyenHelper,
+        \Adyen\Payment\Model\ApplicationInfo $applicationInfo,
+        PaymentResponseFactory $paymentResponseFactory,
+        \Adyen\Payment\Model\ResourceModel\PaymentResponse $paymentResponseResourceModel
+    ) {
+        $this->adyenHelper = $adyenHelper;
+        $this->applicationInfo = $applicationInfo;
+        $this->paymentResponseFactory = $paymentResponseFactory;
+        $this->paymentResponseResourceModel = $paymentResponseResourceModel;
+    }
+
+    /**
+     * @param \Magento\Payment\Gateway\Http\TransferInterface $transferObject
+     * @return array|mixed|string
+     * @throws \Adyen\AdyenException
+     */
+    public function placeRequest(\Magento\Payment\Gateway\Http\TransferInterface $transferObject)
+    {
+        $request = $transferObject->getBody();
+
+        // If the payments call is already done return the request
+        if (!empty($request['resultCode'])) {
+            //Initiate has already a response
+            return $request;
+        }
+
+        $client = $this->adyenHelper->initializeAdyenMotoClient($request['merchantAccount']);
+        $service = $this->adyenHelper->createAdyenCheckoutService($client);
+
+        $requestOptions = [];
+
+        try {
+            $response = $service->payments($request, $requestOptions);
+
+            // Store the /payments response in the database in case it is needed in order to finish the payment
+            /** @var PaymentResponse $paymentResponse */
+            $paymentResponse = $this->paymentResponseFactory->create();
+            $paymentResponse->setResponse(json_encode($response));
+            $paymentResponse->setResultCode($response['resultCode']);
+            $paymentResponse->setMerchantReference($request["reference"]);
+
+            $this->paymentResponseResourceModel->save($paymentResponse);
+        } catch (\Adyen\AdyenException $e) {
+            $response['error'] = $e->getMessage();
+            $response['errorCode'] = $e->getAdyenErrorCode();
+        }
+
+        return $response;
+    }
+}

--- a/Gateway/Http/Client/TransactionMotoRefund.php
+++ b/Gateway/Http/Client/TransactionMotoRefund.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2022 Adyen N.V. (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\Payment\Gateway\Http\Client;
+
+use Magento\Payment\Gateway\Http\ClientInterface;
+
+/**
+ * Class TransactionSale
+ */
+class TransactionMotoRefund implements ClientInterface
+{
+    /**
+     * @var \Adyen\Payment\Helper\Data
+     */
+    private $adyenHelper;
+
+    /**
+     * PaymentRequest constructor.
+     * @param \Adyen\Payment\Helper\Data $adyenHelper
+     */
+    public function __construct(
+        \Adyen\Payment\Helper\Data $adyenHelper
+    ) {
+        $this->adyenHelper = $adyenHelper;
+    }
+
+    /**
+     * @param \Magento\Payment\Gateway\Http\TransferInterface $transferObject
+     * @return null
+     */
+    public function placeRequest(\Magento\Payment\Gateway\Http\TransferInterface $transferObject)
+    {
+        $requests = $transferObject->getBody();
+        $responses = [];
+
+        foreach ($requests as $request) {
+            // call lib
+
+            $client = $this->adyenHelper->initializeAdyenMotoClient($request['merchantAccount']);
+            $service = new \Adyen\Service\Modification($client);
+            try {
+                $responses[] = $service->refund($request);
+            } catch (\Adyen\AdyenException $e) {
+                $responses[] = ['error' => $e->getMessage()];
+            }
+        }
+        return $responses;
+    }
+}

--- a/Gateway/Request/MotoAuthorizationDataBuilder.php
+++ b/Gateway/Request/MotoAuthorizationDataBuilder.php
@@ -18,7 +18,7 @@ use Magento\Payment\Gateway\Data\PaymentDataObject;
 use Magento\Payment\Gateway\Helper\SubjectReader;
 use Magento\Payment\Gateway\Request\BuilderInterface;
 
-class CcBackendAuthorizationDataBuilder implements BuilderInterface
+class MotoAuthorizationDataBuilder implements BuilderInterface
 {
     /**
      * @var StateData

--- a/Gateway/Request/MotoMerchantAccountDataBuilder.php
+++ b/Gateway/Request/MotoMerchantAccountDataBuilder.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2022 Adyen N.V. (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\Payment\Gateway\Request;
+
+use Magento\Payment\Gateway\Request\BuilderInterface;
+
+class MotoMerchantAccountDataBuilder implements BuilderInterface
+{
+    /**
+     * @var \Adyen\Payment\Helper\Requests
+     */
+    private $adyenRequestsHelper;
+
+    /**
+     * MerchantAccountDataBuilder constructor.
+     *
+     * @param \Adyen\Payment\Helper\Requests $adyenRequestsHelper
+     */
+    public function __construct(
+        \Adyen\Payment\Helper\Requests $adyenRequestsHelper
+    ) {
+        $this->adyenRequestsHelper = $adyenRequestsHelper;
+    }
+
+    /**
+     * @param array $buildSubject
+     * @return array
+     */
+    public function build(array $buildSubject)
+    {
+        /** @var \Magento\Payment\Gateway\Data\PaymentDataObject $paymentDataObject */
+        $paymentDataObject = \Magento\Payment\Gateway\Helper\SubjectReader::readPayment($buildSubject);
+        $order = $paymentDataObject->getOrder();
+        $payment = $paymentDataObject->getPayment();
+
+        $motoMerchantAccount = $payment->getAdditionalInformation('motoMerchantAccount');
+        $request['body'] = $this->adyenRequestsHelper->buildMotoMerchantAccountData($motoMerchantAccount);
+
+        return $request;
+    }
+}

--- a/Gateway/Request/MotoMerchantAccountDataBuilder.php
+++ b/Gateway/Request/MotoMerchantAccountDataBuilder.php
@@ -39,7 +39,6 @@ class MotoMerchantAccountDataBuilder implements BuilderInterface
     {
         /** @var \Magento\Payment\Gateway\Data\PaymentDataObject $paymentDataObject */
         $paymentDataObject = \Magento\Payment\Gateway\Helper\SubjectReader::readPayment($buildSubject);
-        $order = $paymentDataObject->getOrder();
         $payment = $paymentDataObject->getPayment();
 
         $motoMerchantAccount = $payment->getAdditionalInformation('motoMerchantAccount');

--- a/Gateway/Request/MotoRefundDataBuilder.php
+++ b/Gateway/Request/MotoRefundDataBuilder.php
@@ -1,0 +1,269 @@
+<?php
+/**
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2022 Adyen N.V. (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\Payment\Gateway\Request;
+
+use Adyen\Payment\Helper\ChargedCurrency;
+use Magento\Payment\Gateway\Request\BuilderInterface;
+
+/**
+ * Class CustomerDataBuilder
+ */
+class MotoRefundDataBuilder implements BuilderInterface
+{
+    /**
+     * @var \Adyen\Payment\Helper\Data
+     */
+    private $adyenHelper;
+
+    /**
+     * @var \Adyen\Payment\Model\ResourceModel\Order\Payment\CollectionFactory
+     */
+    private $orderPaymentCollectionFactory;
+
+    /**
+     * @var \Adyen\Payment\Model\ResourceModel\Invoice\CollectionFactory
+     */
+    protected $adyenInvoiceCollectionFactory;
+
+    /**
+     * @var ChargedCurrency
+     */
+    private $chargedCurrency;
+
+    /**
+     * RefundDataBuilder constructor.
+     *
+     * @param \Adyen\Payment\Helper\Data $adyenHelper
+     * @param \Adyen\Payment\Model\ResourceModel\Order\Payment\CollectionFactory $orderPaymentCollectionFactory
+     * @param ChargedCurrency $chargedCurrency
+     */
+    public function __construct(
+        \Adyen\Payment\Helper\Data $adyenHelper,
+        \Adyen\Payment\Model\ResourceModel\Order\Payment\CollectionFactory $orderPaymentCollectionFactory,
+        \Adyen\Payment\Model\ResourceModel\Invoice\CollectionFactory $adyenInvoiceCollectionFactory,
+        ChargedCurrency $chargedCurrency
+    ) {
+        $this->adyenHelper = $adyenHelper;
+        $this->orderPaymentCollectionFactory = $orderPaymentCollectionFactory;
+        $this->adyenInvoiceCollectionFactory = $adyenInvoiceCollectionFactory;
+        $this->chargedCurrency = $chargedCurrency;
+    }
+
+    /**
+     * @param array $buildSubject
+     * @return array
+     */
+    public function build(array $buildSubject)
+    {
+        /** @var \Magento\Payment\Gateway\Data\PaymentDataObject $paymentDataObject */
+        $paymentDataObject = \Magento\Payment\Gateway\Helper\SubjectReader::readPayment($buildSubject);
+
+        $order = $paymentDataObject->getOrder();
+        $payment = $paymentDataObject->getPayment();
+        $orderAmountCurrency = $this->chargedCurrency->getOrderAmountCurrency($payment->getOrder(), false);
+
+        // Construct AdyenAmountCurrency from creditmemo
+        $creditMemo = $payment->getCreditMemo();
+        $creditMemoAmountCurrency = $this->chargedCurrency->getCreditMemoAmountCurrency($creditMemo, false);
+
+        $pspReference = $payment->getCcTransId();
+        $currency = $creditMemoAmountCurrency->getCurrencyCode();
+        $amount = $creditMemoAmountCurrency->getAmount();
+        $storeId = $order->getStoreId();
+        $method = $payment->getMethod();
+        $merchantAccount = $payment->getAdditionalInformation('motoMerchantAccount');
+
+        // check if it contains a partial payment
+        $orderPaymentCollection = $this->orderPaymentCollectionFactory
+            ->create()
+            ->addFieldToFilter('payment_id', $payment->getId());
+
+        // partial refund if multiple payments check refund strategy
+        if ($orderPaymentCollection->getSize() > 1) {
+            $refundStrategy = $this->adyenHelper->getAdyenAbstractConfigData(
+                'partial_payments_refund_strategy',
+                $order->getStoreId()
+            );
+            $ratio = null;
+
+            if ($refundStrategy == "1") {
+                // Refund in ascending order
+                $orderPaymentCollection->addPaymentFilterAscending($payment->getId());
+            } elseif ($refundStrategy == "2") {
+                // Refund in descending order
+                $orderPaymentCollection->addPaymentFilterDescending($payment->getId());
+            } elseif ($refundStrategy == "3") {
+                // refund based on ratio
+                $ratio = $amount / $orderAmountCurrency->getAmount();
+                $orderPaymentCollection->addPaymentFilterAscending($payment->getId());
+            }
+
+            // loop over payment methods and refund them all
+            $requestBody = [];
+            foreach ($orderPaymentCollection as $partialPayment) {
+                // could be that not all the partial payments need a refund
+                if ($amount > 0) {
+                    if ($ratio) {
+                        // refund based on ratio calculate refund amount
+                        $modificationAmount = $ratio * (
+                                $partialPayment->getAmount() - $partialPayment->getTotalRefunded()
+                            );
+                    } else {
+                        // total authorised amount of the partial payment
+                        $partialPaymentAmount = $partialPayment->getAmount() - $partialPayment->getTotalRefunded();
+
+                        // if rest amount is zero go to next payment
+                        if (!$partialPaymentAmount > 0) {
+                            continue;
+                        }
+
+                        // if refunded amount is greater than partial payment amount do a full refund
+                        if ($amount >= $partialPaymentAmount) {
+                            $modificationAmount = $partialPaymentAmount;
+                        } else {
+                            $modificationAmount = $amount;
+                        }
+                        // update amount with rest of the available amount
+                        $amount = $amount - $partialPaymentAmount;
+                    }
+
+                    $modificationAmountObject = [
+                        'currency' => $currency,
+                        'value' => $this->adyenHelper->formatAmount($modificationAmount, $currency)
+                    ];
+
+                    $requestBody[] = [
+                        "modificationAmount" => $modificationAmountObject,
+                        "reference" => $payment->getOrder()->getIncrementId(),
+                        "originalReference" => $partialPayment->getPspreference(),
+                        "merchantAccount" => $merchantAccount
+                    ];
+                }
+            }
+        } else {
+            //format the amount to minor units
+            $amount = $this->adyenHelper->formatAmount($amount, $currency);
+            $modificationAmount = ['currency' => $currency, 'value' => $amount];
+
+            $requestBody = [
+                [
+                    "modificationAmount" => $modificationAmount,
+                    "reference" => $payment->getOrder()->getIncrementId(),
+                    "originalReference" => $pspReference,
+                    "merchantAccount" => $merchantAccount
+                ]
+            ];
+
+            $brandCode = $payment->getAdditionalInformation(
+                \Adyen\Payment\Observer\AdyenHppDataAssignObserver::BRAND_CODE
+            );
+
+            if ($this->adyenHelper->isPaymentMethodOpenInvoiceMethod($brandCode)) {
+                $openInvoiceFields = $this->getOpenInvoiceData($payment);
+
+                //There is only one payment, so we add the fields to the first(and only) result
+                $requestBody[0]["additionalData"] = $openInvoiceFields;
+            }
+        }
+        $request['clientConfig'] = ["storeId" => $payment->getOrder()->getStoreId()];
+        $request['body'] = $requestBody;
+        return $request;
+    }
+
+    /**
+     * @param \Magento\Payment\Model\InfoInterface $payment
+     * @return array|mixed
+     */
+    protected function getOpenInvoiceData($payment)
+    {
+        $formFields = [];
+        $count = 0;
+
+        // Construct AdyenAmountCurrency from creditmemo
+        /**
+         * @var \Magento\Sales\Model\Order\Creditmemo $creditMemo
+         */
+        $creditMemo = $payment->getCreditMemo();
+
+        foreach ($creditMemo->getItems() as $refundItem) {
+            $numberOfItems = (int)$refundItem->getQty();
+            if ($numberOfItems == 0) {
+                continue;
+            }
+
+            ++$count;
+            $itemAmountCurrency = $this->chargedCurrency->getCreditMemoItemAmountCurrency($refundItem);
+
+            $formFields = $this->adyenHelper->createOpenInvoiceLineItem(
+                $formFields,
+                $count,
+                $refundItem->getName(),
+                $itemAmountCurrency->getAmount(),
+                $itemAmountCurrency->getCurrencyCode(),
+                $itemAmountCurrency->getTaxAmount(),
+                $itemAmountCurrency->getAmount() + $itemAmountCurrency->getTaxAmount(),
+                $refundItem->getOrderItem()->getTaxPercent(),
+                $numberOfItems,
+                $payment,
+                $refundItem->getId()
+            );
+        }
+
+        // Shipping cost
+        $shippingAmountCurrency = $this->chargedCurrency->getCreditMemoShippingAmountCurrency($creditMemo);
+        if ($shippingAmountCurrency->getAmount() > 0) {
+            ++$count;
+            $formFields = $this->adyenHelper->createOpenInvoiceLineShipping(
+                $formFields,
+                $count,
+                $payment->getOrder(),
+                $shippingAmountCurrency->getAmount(),
+                $shippingAmountCurrency->getTaxAmount(),
+                $shippingAmountCurrency->getCurrencyCode(),
+                $payment
+            );
+        }
+
+        // Adjustment
+        $adjustmentAmountCurrency = $this->chargedCurrency->getCreditMemoAdjustmentAmountCurrency($creditMemo);
+        if ($adjustmentAmountCurrency->getAmount() != 0) {
+            $positive = $adjustmentAmountCurrency->getAmount() > 0 ? 'Positive' : '';
+            $negative = $adjustmentAmountCurrency->getAmount() < 0 ? 'Negative' : '';
+            $description = "Adjustment - " . implode(' | ', array_filter([$positive, $negative]));
+
+            ++$count;
+            $formFields = $this->adyenHelper->createOpenInvoiceLineAdjustment(
+                $formFields,
+                $count,
+                $description,
+                $adjustmentAmountCurrency->getAmount(),
+                $adjustmentAmountCurrency->getCurrencyCode(),
+                $payment
+            );
+        }
+
+        $formFields['openinvoicedata.numberOfLines'] = $count;
+
+        //Retrieve acquirerReference from the adyen_invoice
+        $invoiceId = $creditMemo->getInvoice()->getId();
+        $invoices = $this->adyenInvoiceCollectionFactory->create()
+            ->addFieldToFilter('invoice_id', $invoiceId);
+
+        $invoice = $invoices->getFirstItem();
+
+        if ($invoice) {
+            $formFields['acquirerReference'] = $invoice->getAcquirerReference();
+        }
+
+        return $formFields;
+    }
+}

--- a/Gateway/Request/ShopperInteractionDataBuilder.php
+++ b/Gateway/Request/ShopperInteractionDataBuilder.php
@@ -12,6 +12,7 @@
 namespace Adyen\Payment\Gateway\Request;
 
 use Adyen\Payment\Model\Ui\AdyenCcConfigProvider;
+use Adyen\Payment\Model\Ui\AdyenMotoConfigProvider;
 use Adyen\Payment\Model\Ui\AdyenOneclickConfigProvider;
 use Adyen\Payment\Model\Ui\AdyenPayByLinkConfigProvider;
 use Magento\Framework\Exception\LocalizedException;
@@ -57,7 +58,7 @@ class ShopperInteractionDataBuilder implements BuilderInterface
         // Ecommerce is the default shopperInteraction
         $shopperInteraction = 'Ecommerce';
 
-        if ($paymentMethod == AdyenCcConfigProvider::CODE &&
+        if ($paymentMethod == AdyenMotoConfigProvider::CODE &&
             $this->appState->getAreaCode() == \Magento\Framework\App\Area::AREA_ADMINHTML) {
             // Backend CC orders are MOTO
             $shopperInteraction = "Moto";

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -13,6 +13,7 @@ namespace Adyen\Payment\Helper;
 
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\Encryption\EncryptorInterface;
+use Magento\Framework\Serialize\SerializerInterface;
 
 class Config
 {
@@ -35,10 +36,12 @@ class Config
     const XML_ADYEN_HPP = 'adyen_hpp';
     const XML_ADYEN_HPP_VAULT = 'adyen_hpp_vault';
     const XML_ADYEN_CC_VAULT = 'adyen_cc_vault';
+    const XML_ADYEN_MOTO = 'adyen_moto';
     const XML_PAYMENT_ORIGIN_URL = 'payment_origin_url';
     const XML_PAYMENT_RETURN_URL = 'payment_return_url';
     const XML_STATUS_FRAUD_MANUAL_REVIEW = 'fraud_manual_review_status';
     const XML_STATUS_FRAUD_MANUAL_REVIEW_ACCEPT = 'fraud_manual_review_accept_status';
+    const XML_MOTO_MERCHANT_ACCOUNTS = 'moto_merchant_accounts';
 
     /**
      * @var ScopeConfigInterface
@@ -50,6 +53,12 @@ class Config
      */
     private $encryptor;
 
+
+    /**
+     * @var SerializerInterface
+     */
+    private $serializer;
+
     /**
      * Config constructor.
      *
@@ -58,10 +67,13 @@ class Config
      */
     public function __construct(
         ScopeConfigInterface $scopeConfig,
-        EncryptorInterface $encryptor
-    ) {
+        EncryptorInterface $encryptor,
+        SerializerInterface $serializer
+    )
+    {
         $this->scopeConfig = $scopeConfig;
         $this->encryptor = $encryptor;
+        $this->serializer = $serializer;
     }
 
     /**
@@ -75,6 +87,21 @@ class Config
             self::XML_ADYEN_ABSTRACT_PREFIX,
             $storeId
         );
+    }
+
+    /**
+     * @param $storeId
+     * @return bool|mixed
+     */
+    public function getMotoMerchantAccounts($storeId = null)
+    {
+        $serializedData = $this->getConfigData(
+            self::XML_MOTO_MERCHANT_ACCOUNTS,
+            self::XML_ADYEN_MOTO,
+            $storeId
+        );
+
+        return $this->serializer->unserialize($serializedData);
     }
 
     /**

--- a/Helper/Requests.php
+++ b/Helper/Requests.php
@@ -95,6 +95,18 @@ class Requests extends AbstractHelper
     }
 
     /**
+     * @param $motoMerchantAccount
+     * @return array
+     */
+    public function buildMotoMerchantAccountData($motoMerchantAccount)
+    {
+        // Assign merchant account to request object
+        $request[self::MERCHANT_ACCOUNT] = $motoMerchantAccount;
+
+        return $request;
+    }
+
+    /**
      * @param int $customerId
      * @param $billingAddress
      * @param $storeId

--- a/Observer/AdyenMotoDataAssignObserver.php
+++ b/Observer/AdyenMotoDataAssignObserver.php
@@ -99,15 +99,15 @@ class AdyenMotoDataAssignObserver extends AbstractDataAssignObserver
 
         // JSON decode state data from the frontend or fetch it from the DB entity with the quote ID
         if (!empty($additionalData[self::STATE_DATA])) {
-            $stateData = json_decode($additionalData[self::STATE_DATA], true);
+            $orderStateData = json_decode($additionalData[self::STATE_DATA], true);
         } else {
-            $stateData = $this->stateDataCollection->getStateDataArrayWithQuoteId($paymentInfo->getData('quote_id'));
+            $orderStateData = $this->stateDataCollection->getStateDataArrayWithQuoteId($paymentInfo->getData('quote_id'));
         }
         // Get validated state data array
-        if (!empty($stateData)) {
-            $stateData = $this->checkoutStateDataValidator->getValidatedAdditionalData($stateData);
+        if (!empty($orderStateData)) {
+            $orderStateData = $this->checkoutStateDataValidator->getValidatedAdditionalData($orderStateData);
             // Set stateData in a service and remove from payment's additionalData
-            $this->stateData->setStateData($stateData, $paymentInfo->getData('quote_id'));
+            $this->stateData->setStateData($orderStateData, $paymentInfo->getData('quote_id'));
         }
 
         unset($additionalData[self::STATE_DATA]);

--- a/Observer/AdyenMotoDataAssignObserver.php
+++ b/Observer/AdyenMotoDataAssignObserver.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2022 Adyen N.V. (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\Payment\Observer;
+
+use Adyen\Payment\Helper\StateData;
+use Adyen\Payment\Model\ResourceModel\StateData\Collection;
+use Magento\Framework\Event\Observer;
+use Magento\Payment\Observer\AbstractDataAssignObserver;
+use Magento\Quote\Api\Data\PaymentInterface;
+use \Adyen\Service\Validator\CheckoutStateDataValidator;
+use \Adyen\Service\Validator\DataArrayValidator;
+
+class AdyenMotoDataAssignObserver extends AbstractDataAssignObserver
+{
+    const CC_TYPE = 'cc_type';
+    const NUMBER_OF_INSTALLMENTS = 'number_of_installments';
+    const STORE_CC = 'store_cc';
+    const GUEST_EMAIL = 'guestEmail';
+    const COMBO_CARD_TYPE = 'combo_card_type';
+    const STATE_DATA = 'stateData';
+    const STORE_PAYMENT_METHOD = 'storePaymentMethod';
+    const MERCHANT_ACCOUNT = 'merchantAccount';
+
+    /**
+     * Approved root level keys from additional data array
+     *
+     * @var array
+     */
+    private static $approvedAdditionalDataKeys = [
+        self::STATE_DATA,
+        self::GUEST_EMAIL,
+        self::COMBO_CARD_TYPE,
+        self::NUMBER_OF_INSTALLMENTS,
+        self::CC_TYPE,
+        self::MERCHANT_ACCOUNT
+    ];
+
+    /**
+     * @var CheckoutStateDataValidator
+     */
+    protected $checkoutStateDataValidator;
+
+    /**
+     * @var Collection
+     */
+    protected $stateDataCollection;
+
+    /**
+     * @var StateData
+     */
+    private $stateData;
+
+    /**
+     * AdyenCcDataAssignObserver constructor.
+     * @param CheckoutStateDataValidator $checkoutStateDataValidator
+     * @param Collection $stateDataCollection
+     * @param StateData $stateData
+     */
+    public function __construct(
+        CheckoutStateDataValidator $checkoutStateDataValidator,
+        Collection $stateDataCollection,
+        StateData $stateData
+    ) {
+        $this->checkoutStateDataValidator = $checkoutStateDataValidator;
+        $this->stateDataCollection = $stateDataCollection;
+        $this->stateData = $stateData;
+    }
+
+    /**
+     * @param Observer $observer
+     * @return void
+     */
+    public function execute(Observer $observer)
+    {
+        // Get request fields
+        $data = $this->readDataArgument($observer);
+        $paymentInfo = $this->readPaymentModelArgument($observer);
+
+        // Get additional data array
+        $additionalData = $data->getData(PaymentInterface::KEY_ADDITIONAL_DATA);
+        if (!is_array($additionalData)) {
+            return;
+        }
+
+        // Get a validated additional data array
+        $additionalData = DataArrayValidator::getArrayOnlyWithApprovedKeys(
+            $additionalData,
+            self::$approvedAdditionalDataKeys
+        );
+
+        // JSON decode state data from the frontend or fetch it from the DB entity with the quote ID
+        if (!empty($additionalData[self::STATE_DATA])) {
+            $stateData = json_decode($additionalData[self::STATE_DATA], true);
+        } else {
+            $stateData = $this->stateDataCollection->getStateDataArrayWithQuoteId($paymentInfo->getData('quote_id'));
+        }
+        // Get validated state data array
+        if (!empty($stateData)) {
+            $stateData = $this->checkoutStateDataValidator->getValidatedAdditionalData($stateData);
+            // Set stateData in a service and remove from payment's additionalData
+            $this->stateData->setStateData($stateData, $paymentInfo->getData('quote_id'));
+        }
+
+        unset($additionalData[self::STATE_DATA]);
+
+        // Set additional data in the payment
+        foreach ($additionalData as $key => $data) {
+            $paymentInfo->setAdditionalInformation($key, $data);
+        }
+
+        // set ccType
+        if (!empty($additionalData[self::CC_TYPE])) {
+            $paymentInfo->setCcType($additionalData[self::CC_TYPE]);
+        }
+
+        // set storeCc
+        if (!empty($stateData[self::STORE_PAYMENT_METHOD])) {
+            $paymentInfo->setAdditionalInformation(self::STORE_CC, $stateData[self::STORE_PAYMENT_METHOD]);
+        }
+
+        // set MOTO merchant account
+        if (!empty($stateData[self::MERCHANT_ACCOUNT])) {
+            $paymentInfo->setAdditionalInformation(self::MERCHANT_ACCOUNT, $stateData[self::MERCHANT_ACCOUNT]);
+        }
+    }
+}

--- a/Observer/AdyenMotoDataAssignObserver.php
+++ b/Observer/AdyenMotoDataAssignObserver.php
@@ -28,7 +28,7 @@ class AdyenMotoDataAssignObserver extends AbstractDataAssignObserver
     const COMBO_CARD_TYPE = 'combo_card_type';
     const STATE_DATA = 'stateData';
     const STORE_PAYMENT_METHOD = 'storePaymentMethod';
-    const MERCHANT_ACCOUNT = 'merchantAccount';
+    const MOTO_MERCHANT_ACCOUNT = 'motoMerchantAccount';
 
     /**
      * Approved root level keys from additional data array
@@ -41,7 +41,7 @@ class AdyenMotoDataAssignObserver extends AbstractDataAssignObserver
         self::COMBO_CARD_TYPE,
         self::NUMBER_OF_INSTALLMENTS,
         self::CC_TYPE,
-        self::MERCHANT_ACCOUNT
+        self::MOTO_MERCHANT_ACCOUNT
     ];
 
     /**
@@ -128,8 +128,8 @@ class AdyenMotoDataAssignObserver extends AbstractDataAssignObserver
         }
 
         // set MOTO merchant account
-        if (!empty($stateData[self::MERCHANT_ACCOUNT])) {
-            $paymentInfo->setAdditionalInformation(self::MERCHANT_ACCOUNT, $stateData[self::MERCHANT_ACCOUNT]);
+        if (!empty($stateData[self::MOTO_MERCHANT_ACCOUNT])) {
+            $paymentInfo->setAdditionalInformation(self::MOTO_MERCHANT_ACCOUNT, $stateData[self::MOTO_MERCHANT_ACCOUNT]);
         }
     }
 }

--- a/Observer/AdyenMotoDataAssignObserver.php
+++ b/Observer/AdyenMotoDataAssignObserver.php
@@ -123,13 +123,13 @@ class AdyenMotoDataAssignObserver extends AbstractDataAssignObserver
         }
 
         // set storeCc
-        if (!empty($stateData[self::STORE_PAYMENT_METHOD])) {
-            $paymentInfo->setAdditionalInformation(self::STORE_CC, $stateData[self::STORE_PAYMENT_METHOD]);
+        if (!empty($orderStateData[self::STORE_PAYMENT_METHOD])) {
+            $paymentInfo->setAdditionalInformation(self::STORE_CC, $orderStateData[self::STORE_PAYMENT_METHOD]);
         }
 
         // set MOTO merchant account
-        if (!empty($stateData[self::MOTO_MERCHANT_ACCOUNT])) {
-            $paymentInfo->setAdditionalInformation(self::MOTO_MERCHANT_ACCOUNT, $stateData[self::MOTO_MERCHANT_ACCOUNT]);
+        if (!empty($orderStateData[self::MOTO_MERCHANT_ACCOUNT])) {
+            $paymentInfo->setAdditionalInformation(self::MOTO_MERCHANT_ACCOUNT, $orderStateData[self::MOTO_MERCHANT_ACCOUNT]);
         }
     }
 }

--- a/Test/Unit/Helper/DataTest.php
+++ b/Test/Unit/Helper/DataTest.php
@@ -73,6 +73,7 @@ class DataTest extends TestCase
         $localeHelper = $this->getSimpleMock(Locale::class);
         $orderManagement = $this->getSimpleMock(OrderManagementInterface::class);
         $orderStatusHistoryFactory = $this->getSimpleMock(HistoryFactory::class);
+        $adyenConfigHelper = $this->getSimpleMock(\Adyen\Payment\Helper\Config::class);
 
         $this->dataHelper = new Data(
             $context,
@@ -96,7 +97,8 @@ class DataTest extends TestCase
             $componentRegistrar,
             $localeHelper,
             $orderManagement,
-            $orderStatusHistoryFactory
+            $orderStatusHistoryFactory,
+            $adyenConfigHelper
         );
     }
 

--- a/etc/adminhtml/di.xml
+++ b/etc/adminhtml/di.xml
@@ -1,24 +1,5 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
-    <!-- Authorization Request -->
-    <virtualType name="AdyenPaymentCcAuthorizeRequest" type="Magento\Payment\Gateway\Request\BuilderComposite">
-        <arguments>
-            <argument name="builders" xsi:type="array">
-                <item name="merchantaccount" xsi:type="string">Adyen\Payment\Gateway\Request\MerchantAccountDataBuilder</item>
-                <item name="customer" xsi:type="string">Adyen\Payment\Gateway\Request\CustomerDataBuilder</item>
-                <item name="customerip" xsi:type="string">Adyen\Payment\Gateway\Request\CustomerIpDataBuilder</item>
-                <item name="address" xsi:type="string">Adyen\Payment\Gateway\Request\AddressDataBuilder</item>
-                <item name="payment" xsi:type="string">Adyen\Payment\Gateway\Request\PaymentDataBuilder</item>
-                <item name="browserinfo" xsi:type="string">Adyen\Payment\Gateway\Request\BrowserInfoDataBuilder</item>
-                <item name="transaction" xsi:type="string">Adyen\Payment\Gateway\Request\CcBackendAuthorizationDataBuilder</item>
-                <item name="shopperinteraction" xsi:type="string">Adyen\Payment\Gateway\Request\ShopperInteractionDataBuilder</item>
-                <item name="channel" xsi:type="string">Adyen\Payment\Gateway\Request\ChannelDataBuilder</item>
-                <item name="origin" xsi:type="string">Adyen\Payment\Gateway\Request\OriginDataBuilder</item>
-            </argument>
-        </arguments>
-    </virtualType>
-
-
     <type name="Magento\Framework\Notification\MessageList">
         <arguments>
             <argument name="messages" xsi:type="array">

--- a/etc/adminhtml/system/adyen_moto_settings.xml
+++ b/etc/adminhtml/system/adyen_moto_settings.xml
@@ -12,25 +12,25 @@
 -->
 <include xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_include.xsd">
     <group id="adyen_moto_advanced_settings" translate="label" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="600">
-        <label>MOTO settings</label>
+        <label>MOTO</label>
         <frontend_model>Magento\Config\Block\System\Config\Form\Fieldset</frontend_model>
-        <field id="enable_moto" translate="label" type="select" sortOrder="10" showInDefault="1"
+        <field id="active" translate="label" type="select" sortOrder="10" showInDefault="1"
                showInWebsite="1" showInStore="1">
-            <label>Enable MOTO</label>
+            <label>Enabled</label>
             <tooltip>
                 Using Adyen's Mail Order/Telephone Order (MOTO) your shopper can make a call to a call center or send a mail so that your employee can place an order from the admin panel using their card information.
             </tooltip>
             <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-            <config_path>payment/adyen_cc/enable_moto</config_path>
+            <config_path>payment/adyen_moto/active</config_path>
         </field>
-        <field id="moto_settings" translate="label" sortOrder="20" showInDefault="1" showInWebsite="1"
-               showInStore="1">
+        <field id="moto_settings" translate="label" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
+            <label>Accounts</label>
             <depends>
-                <field id="enable_moto">1</field>
+                <field id="active">1</field>
             </depends>
-             <frontend_model>Adyen\Payment\Block\Adminhtml\System\Config\Field\Moto</frontend_model>
+            <frontend_model>Adyen\Payment\Block\Adminhtml\System\Config\Field\Moto</frontend_model>
             <backend_model>Adyen\Payment\Model\Config\Backend\Moto</backend_model>
-            <config_path>payment/adyen_cc/moto</config_path>
+            <config_path>payment/adyen_moto/moto_merchant_accounts</config_path>
         </field>
     </group>
 </include>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -170,6 +170,31 @@
                 <can_cancel>1</can_cancel>
                 <group>adyen</group>
             </adyen_boleto>
+            <adyen_moto>
+                <active>0</active>
+                <model>AdyenPaymentMotoFacade</model>
+                <title>MOTO</title>
+                <allowspecific>0</allowspecific>
+                <sort_order>9</sort_order>
+                <useccv>0</useccv>
+                <has_holder_name>1</has_holder_name>
+                <holder_name_required>0</holder_name_required>
+                <payment_action>authorize</payment_action>
+                <is_gateway>1</is_gateway>
+                <can_use_checkout>0</can_use_checkout>
+                <can_authorize>1</can_authorize>
+                <can_authorize_3d>1</can_authorize_3d>
+                <can_capture>1</can_capture>
+                <can_capture_partial>1</can_capture_partial>
+                <can_use_internal>1</can_use_internal>
+                <can_refund_partial_per_invoice>1</can_refund_partial_per_invoice>
+                <can_refund>1</can_refund>
+                <can_void>1</can_void>
+                <can_cancel>1</can_cancel>
+                <can_authorize_vault>1</can_authorize_vault>
+                <can_capture_vault>1</can_capture_vault>
+                <group>adyen</group>
+            </adyen_moto>
         </payment>
     </default>
 </config>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -45,7 +45,7 @@
                 <can_authorize_3d>1</can_authorize_3d>
                 <can_capture>1</can_capture>
                 <can_capture_partial>1</can_capture_partial>
-                <can_use_internal>1</can_use_internal>
+                <can_use_internal>0</can_use_internal>
                 <can_refund_partial_per_invoice>1</can_refund_partial_per_invoice>
                 <can_refund>1</can_refund>
                 <can_void>1</can_void>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -32,6 +32,16 @@
             <argument name="commandPool" xsi:type="object">AdyenPaymentCcCommandPool</argument>
         </arguments>
     </virtualType>
+    <virtualType name="AdyenPaymentMotoFacade" type="Adyen\Payment\Model\Method\Adapter">
+        <arguments>
+            <argument name="code" xsi:type="const">Adyen\Payment\Model\Ui\AdyenMotoConfigProvider::CODE</argument>
+            <argument name="formBlockType" xsi:type="string">Adyen\Payment\Block\Form\Moto</argument>
+            <argument name="infoBlockType" xsi:type="string">Adyen\Payment\Block\Info\Moto</argument>
+            <argument name="valueHandlerPool" xsi:type="object">AdyenPaymentMotoValueHandlerPool</argument>
+            <argument name="validatorPool" xsi:type="object">AdyenPaymentMotoValidatorPool</argument>
+            <argument name="commandPool" xsi:type="object">AdyenPaymentMotoCommandPool</argument>
+        </arguments>
+    </virtualType>
     <virtualType name="AdyenPaymentCcVaultFacade" type="Magento\Vault\Model\Method\Vault">
         <arguments>
             <argument name="code" xsi:type="const">Adyen\Payment\Model\Ui\AdyenCcConfigProvider::CC_VAULT_CODE
@@ -132,7 +142,18 @@
             <argument name="configInterface" xsi:type="object">AdyenPaymentCcConfig</argument>
         </arguments>
     </virtualType>
-
+    <virtualType name="AdyenPaymentMotoValueHandlerPool" type="Magento\Payment\Gateway\Config\ValueHandlerPool">
+        <arguments>
+            <argument name="handlers" xsi:type="array">
+                <item name="default" xsi:type="string">AdyenPaymentMotoConfigValueHandler</item>
+            </argument>
+        </arguments>
+    </virtualType>
+    <virtualType name="AdyenPaymentMotoConfigValueHandler" type="Magento\Payment\Gateway\Config\ConfigValueHandler">
+        <arguments>
+            <argument name="configInterface" xsi:type="object">AdyenPaymentMotoConfig</argument>
+        </arguments>
+    </virtualType>
     <virtualType name="AdyenPaymentOneclickValueHandlerPool" type="Magento\Payment\Gateway\Config\ValueHandlerPool">
         <arguments>
             <argument name="handlers" xsi:type="array">
@@ -210,6 +231,11 @@
             <argument name="methodCode" xsi:type="const">Adyen\Payment\Model\Ui\AdyenCcConfigProvider::CODE</argument>
         </arguments>
     </virtualType>
+    <virtualType name="AdyenPaymentMotoConfig" type="Magento\Payment\Gateway\Config\Config">
+        <arguments>
+            <argument name="methodCode" xsi:type="const">Adyen\Payment\Model\Ui\AdyenMotoConfigProvider::CODE</argument>
+        </arguments>
+    </virtualType>
     <virtualType name="AdyenPaymentCcVaultConfig" type="Magento\Payment\Gateway\Config\Config">
         <arguments>
             <argument name="methodCode" xsi:type="const">Adyen\Payment\Model\Ui\AdyenCcConfigProvider::CC_VAULT_CODE
@@ -247,6 +273,19 @@
         <arguments>
             <argument name="commands" xsi:type="array">
                 <item name="authorize" xsi:type="string">AdyenPaymentCcAuthorizeCommand</item>
+                <item name="capture" xsi:type="string">AdyenPaymentCaptureCommand</item>
+                <item name="void" xsi:type="string">AdyenPaymentCancelCommand</item>
+                <item name="refund" xsi:type="string">AdyenPaymentRefundCommand</item>
+                <item name="cancel" xsi:type="string">AdyenPaymentCancelCommand</item>
+                <item name="vault_authorize" xsi:type="string">AdyenPaymentCcVaultAuthorizeCommand</item>
+            </argument>
+        </arguments>
+    </virtualType>
+
+    <virtualType name="AdyenPaymentMotoCommandPool" type="Magento\Payment\Gateway\Command\CommandPool">
+        <arguments>
+            <argument name="commands" xsi:type="array">
+                <item name="authorize" xsi:type="string">AdyenPaymentMotoAuthorizeCommand</item>
                 <item name="capture" xsi:type="string">AdyenPaymentCaptureCommand</item>
                 <item name="void" xsi:type="string">AdyenPaymentCancelCommand</item>
                 <item name="refund" xsi:type="string">AdyenPaymentRefundCommand</item>
@@ -370,6 +409,16 @@
         </arguments>
     </virtualType>
 
+    <virtualType name="AdyenPaymentMotoAuthorizeCommand" type="Magento\Payment\Gateway\Command\GatewayCommand">
+        <arguments>
+            <argument name="requestBuilder" xsi:type="object">AdyenPaymentMotoAuthorizeRequest</argument>
+            <argument name="transferFactory" xsi:type="object">Adyen\Payment\Gateway\Http\TransferFactory</argument>
+            <argument name="client" xsi:type="object">Adyen\Payment\Gateway\Http\Client\TransactionPayment</argument>
+            <argument name="validator" xsi:type="object">CheckoutResponseValidator</argument>
+            <argument name="handler" xsi:type="object">AdyenPaymentCcResponseHandlerComposite</argument>
+        </arguments>
+    </virtualType>
+
     <virtualType name="AdyenPaymentOneclickAuthorizeCommand" type="Magento\Payment\Gateway\Command\GatewayCommand">
         <arguments>
             <argument name="requestBuilder" xsi:type="object">AdyenPaymentOneclickAuthorizeRequest</argument>
@@ -466,6 +515,23 @@
                 <item name="shopperinteraction" xsi:type="string">Adyen\Payment\Gateway\Request\ShopperInteractionDataBuilder</item>
                 <item name="transaction" xsi:type="string">Adyen\Payment\Gateway\Request\CheckoutDataBuilder</item>
                 <item name="returnurl" xsi:type="string">Adyen\Payment\Gateway\Request\ReturnUrlDataBuilder</item>
+                <item name="channel" xsi:type="string">Adyen\Payment\Gateway\Request\ChannelDataBuilder</item>
+                <item name="origin" xsi:type="string">Adyen\Payment\Gateway\Request\OriginDataBuilder</item>
+            </argument>
+        </arguments>
+    </virtualType>
+
+    <virtualType name="AdyenPaymentMotoAuthorizeRequest" type="Magento\Payment\Gateway\Request\BuilderComposite">
+        <arguments>
+            <argument name="builders" xsi:type="array">
+                <item name="merchantaccount" xsi:type="string">Adyen\Payment\Gateway\Request\MerchantAccountDataBuilder</item>
+                <item name="customer" xsi:type="string">Adyen\Payment\Gateway\Request\CustomerDataBuilder</item>
+                <item name="customerip" xsi:type="string">Adyen\Payment\Gateway\Request\CustomerIpDataBuilder</item>
+                <item name="address" xsi:type="string">Adyen\Payment\Gateway\Request\AddressDataBuilder</item>
+                <item name="payment" xsi:type="string">Adyen\Payment\Gateway\Request\PaymentDataBuilder</item>
+                <item name="browserinfo" xsi:type="string">Adyen\Payment\Gateway\Request\BrowserInfoDataBuilder</item>
+                <item name="transaction" xsi:type="string">Adyen\Payment\Gateway\Request\CcBackendAuthorizationDataBuilder</item>
+                <item name="shopperinteraction" xsi:type="string">Adyen\Payment\Gateway\Request\ShopperInteractionDataBuilder</item>
                 <item name="channel" xsi:type="string">Adyen\Payment\Gateway\Request\ChannelDataBuilder</item>
                 <item name="origin" xsi:type="string">Adyen\Payment\Gateway\Request\OriginDataBuilder</item>
             </argument>
@@ -694,6 +760,14 @@
 
     <!-- Value validators infrastructure -->
     <virtualType name="AdyenPaymentCcValidatorPool" type="Magento\Payment\Gateway\Validator\ValidatorPool">
+        <arguments>
+            <argument name="validators" xsi:type="array">
+                <item name="country" xsi:type="string">AdyenCcCountryValidator</item>
+                <item name="global" xsi:type="string">Adyen\Payment\Gateway\Validator\InstallmentValidator</item>
+            </argument>
+        </arguments>
+    </virtualType>
+    <virtualType name="AdyenPaymentMotoValidatorPool" type="Magento\Payment\Gateway\Validator\ValidatorPool">
         <arguments>
             <argument name="validators" xsi:type="array">
                 <item name="country" xsi:type="string">AdyenCcCountryValidator</item>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -286,10 +286,10 @@
         <arguments>
             <argument name="commands" xsi:type="array">
                 <item name="authorize" xsi:type="string">AdyenPaymentMotoAuthorizeCommand</item>
-                <item name="capture" xsi:type="string">AdyenPaymentCaptureCommand</item>
-                <item name="void" xsi:type="string">AdyenPaymentCancelCommand</item>
-                <item name="refund" xsi:type="string">AdyenPaymentRefundCommand</item>
-                <item name="cancel" xsi:type="string">AdyenPaymentCancelCommand</item>
+                <item name="capture" xsi:type="string">AdyenPaymentMotoCaptureCommand</item>
+                <item name="void" xsi:type="string">AdyenPaymentMotoCancelCommand</item>
+                <item name="refund" xsi:type="string">AdyenPaymentMotoRefundCommand</item>
+                <item name="cancel" xsi:type="string">AdyenPaymentMotoCancelCommand</item>
                 <item name="vault_authorize" xsi:type="string">AdyenPaymentCcVaultAuthorizeCommand</item>
             </argument>
         </arguments>
@@ -469,6 +469,15 @@
             <argument name="handler" xsi:type="object">AdyenPaymentCaptureResponseHandlerComposite</argument>
         </arguments>
     </virtualType>
+    <virtualType name="AdyenPaymentMotoCaptureCommand" type="Magento\Payment\Gateway\Command\GatewayCommand">
+        <arguments>
+            <argument name="requestBuilder" xsi:type="object">AdyenPaymentMotoCaptureRequest</argument>
+            <argument name="transferFactory" xsi:type="object">Adyen\Payment\Gateway\Http\TransferFactory</argument>
+            <argument name="client" xsi:type="object">Adyen\Payment\Gateway\Http\Client\TransactionMotoCapture</argument>
+            <argument name="validator" xsi:type="object">Adyen\Payment\Gateway\Validator\CaptureResponseValidator</argument>
+            <argument name="handler" xsi:type="object">AdyenPaymentCaptureResponseHandlerComposite</argument>
+        </arguments>
+    </virtualType>
     <!--Refund command-->
     <virtualType name="AdyenPaymentRefundCommand" type="Magento\Payment\Gateway\Command\GatewayCommand">
         <arguments>
@@ -480,11 +489,31 @@
         </arguments>
     </virtualType>
 
+    <virtualType name="AdyenPaymentMotoRefundCommand" type="Magento\Payment\Gateway\Command\GatewayCommand">
+        <arguments>
+            <argument name="requestBuilder" xsi:type="object">AdyenPaymentMotoRefundRequest</argument>
+            <argument name="transferFactory" xsi:type="object">Adyen\Payment\Gateway\Http\TransferFactory</argument>
+            <argument name="client" xsi:type="object">Adyen\Payment\Gateway\Http\Client\TransactionMotoRefund</argument>
+            <argument name="validator" xsi:type="object">Adyen\Payment\Gateway\Validator\RefundResponseValidator</argument>
+            <argument name="handler" xsi:type="object">AdyenPaymentRefundResponseHandlerComposite</argument>
+        </arguments>
+    </virtualType>
+
     <virtualType name="AdyenPaymentCancelCommand" type="Magento\Payment\Gateway\Command\GatewayCommand">
         <arguments>
             <argument name="requestBuilder" xsi:type="object">AdyenPaymentCancelRequest</argument>
             <argument name="transferFactory" xsi:type="object">Adyen\Payment\Gateway\Http\TransferFactory</argument>
             <argument name="client" xsi:type="object">Adyen\Payment\Gateway\Http\Client\TransactionCancel</argument>
+            <argument name="validator" xsi:type="object">Adyen\Payment\Gateway\Validator\CancelResponseValidator</argument>
+            <argument name="handler" xsi:type="object">AdyenPaymentCancelResponseHandlerComposite</argument>
+        </arguments>
+    </virtualType>
+
+    <virtualType name="AdyenPaymentMotoCancelCommand" type="Magento\Payment\Gateway\Command\GatewayCommand">
+        <arguments>
+            <argument name="requestBuilder" xsi:type="object">AdyenPaymentMotoCancelRequest</argument>
+            <argument name="transferFactory" xsi:type="object">Adyen\Payment\Gateway\Http\TransferFactory</argument>
+            <argument name="client" xsi:type="object">Adyen\Payment\Gateway\Http\Client\TransactionMotoCancel</argument>
             <argument name="validator" xsi:type="object">Adyen\Payment\Gateway\Validator\CancelResponseValidator</argument>
             <argument name="handler" xsi:type="object">AdyenPaymentCancelResponseHandlerComposite</argument>
         </arguments>
@@ -678,12 +707,26 @@
             </argument>
         </arguments>
     </virtualType>
+    <virtualType name="AdyenPaymentMotoCaptureRequest" type="Magento\Payment\Gateway\Request\BuilderComposite">
+        <arguments>
+            <argument name="builders" xsi:type="array">
+                <item name="merchantaccount" xsi:type="string">Adyen\Payment\Gateway\Request\MotoMerchantAccountDataBuilder</item>
+                <item name="capture" xsi:type="string">Adyen\Payment\Gateway\Request\CaptureDataBuilder</item>
+            </argument>
+        </arguments>
+    </virtualType>
     <!-- Refund Request -->
     <virtualType name="AdyenPaymentRefundRequest" type="Magento\Payment\Gateway\Request\BuilderComposite">
         <arguments>
             <argument name="builders" xsi:type="array">
-                <!--<item name="merchantaccount" xsi:type="string">Adyen\Payment\Gateway\Request\MerchantAccountDataBuilder</item>-->
                 <item name="refund" xsi:type="string">Adyen\Payment\Gateway\Request\RefundDataBuilder</item>
+            </argument>
+        </arguments>
+    </virtualType>
+    <virtualType name="AdyenPaymentMotoRefundRequest" type="Magento\Payment\Gateway\Request\BuilderComposite">
+        <arguments>
+            <argument name="builders" xsi:type="array">
+                <item name="refund" xsi:type="string">Adyen\Payment\Gateway\Request\MotoRefundDataBuilder</item>
             </argument>
         </arguments>
     </virtualType>
@@ -692,6 +735,15 @@
         <arguments>
             <argument name="builders" xsi:type="array">
                 <item name="merchantaccount" xsi:type="string">Adyen\Payment\Gateway\Request\MerchantAccountDataBuilder</item>
+                <item name="cancel" xsi:type="string">Adyen\Payment\Gateway\Request\CancelDataBuilder</item>
+            </argument>
+        </arguments>
+    </virtualType>
+
+    <virtualType name="AdyenPaymentMotoCancelRequest" type="Magento\Payment\Gateway\Request\BuilderComposite">
+        <arguments>
+            <argument name="builders" xsi:type="array">
+                <item name="merchantaccount" xsi:type="string">Adyen\Payment\Gateway\Request\MotoMerchantAccountDataBuilder</item>
                 <item name="cancel" xsi:type="string">Adyen\Payment\Gateway\Request\CancelDataBuilder</item>
             </argument>
         </arguments>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -413,7 +413,7 @@
         <arguments>
             <argument name="requestBuilder" xsi:type="object">AdyenPaymentMotoAuthorizeRequest</argument>
             <argument name="transferFactory" xsi:type="object">Adyen\Payment\Gateway\Http\TransferFactory</argument>
-            <argument name="client" xsi:type="object">Adyen\Payment\Gateway\Http\Client\TransactionPayment</argument>
+            <argument name="client" xsi:type="object">Adyen\Payment\Gateway\Http\Client\TransactionMotoPayment</argument>
             <argument name="validator" xsi:type="object">CheckoutResponseValidator</argument>
             <argument name="handler" xsi:type="object">AdyenPaymentCcResponseHandlerComposite</argument>
         </arguments>
@@ -524,13 +524,13 @@
     <virtualType name="AdyenPaymentMotoAuthorizeRequest" type="Magento\Payment\Gateway\Request\BuilderComposite">
         <arguments>
             <argument name="builders" xsi:type="array">
-                <item name="merchantaccount" xsi:type="string">Adyen\Payment\Gateway\Request\MerchantAccountDataBuilder</item>
+                <item name="merchantaccount" xsi:type="string">Adyen\Payment\Gateway\Request\MotoMerchantAccountDataBuilder</item>
                 <item name="customer" xsi:type="string">Adyen\Payment\Gateway\Request\CustomerDataBuilder</item>
                 <item name="customerip" xsi:type="string">Adyen\Payment\Gateway\Request\CustomerIpDataBuilder</item>
                 <item name="address" xsi:type="string">Adyen\Payment\Gateway\Request\AddressDataBuilder</item>
                 <item name="payment" xsi:type="string">Adyen\Payment\Gateway\Request\PaymentDataBuilder</item>
                 <item name="browserinfo" xsi:type="string">Adyen\Payment\Gateway\Request\BrowserInfoDataBuilder</item>
-                <item name="transaction" xsi:type="string">Adyen\Payment\Gateway\Request\CcBackendAuthorizationDataBuilder</item>
+                <item name="transaction" xsi:type="string">Adyen\Payment\Gateway\Request\MotoAuthorizationDataBuilder</item>
                 <item name="shopperinteraction" xsi:type="string">Adyen\Payment\Gateway\Request\ShopperInteractionDataBuilder</item>
                 <item name="channel" xsi:type="string">Adyen\Payment\Gateway\Request\ChannelDataBuilder</item>
                 <item name="origin" xsi:type="string">Adyen\Payment\Gateway\Request\OriginDataBuilder</item>

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -15,7 +15,7 @@
         <observer name="adyen_cc_gateway_data_assign" instance="Adyen\Payment\Observer\AdyenCcDataAssignObserver" />
     </event>
     <event name="payment_method_assign_data_adyen_moto">
-        <observer name="adyen_cc_gateway_data_assign" instance="Adyen\Payment\Observer\AdyenCcDataAssignObserver" />
+        <observer name="adyen_moto_gateway_data_assign" instance="Adyen\Payment\Observer\AdyenMotoDataAssignObserver" />
     </event>
     <event name="payment_method_assign_data_adyen_oneclick">
         <observer name="adyen_oneclick_gateway_data_assign" instance="Adyen\Payment\Observer\AdyenOneclickDataAssignObserver" />

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -14,6 +14,9 @@
     <event name="payment_method_assign_data_adyen_cc">
         <observer name="adyen_cc_gateway_data_assign" instance="Adyen\Payment\Observer\AdyenCcDataAssignObserver" />
     </event>
+    <event name="payment_method_assign_data_adyen_moto">
+        <observer name="adyen_cc_gateway_data_assign" instance="Adyen\Payment\Observer\AdyenCcDataAssignObserver" />
+    </event>
     <event name="payment_method_assign_data_adyen_oneclick">
         <observer name="adyen_oneclick_gateway_data_assign" instance="Adyen\Payment\Observer\AdyenOneclickDataAssignObserver" />
     </event>

--- a/view/adminhtml/templates/form/moto.phtml
+++ b/view/adminhtml/templates/form/moto.phtml
@@ -25,21 +25,20 @@ $motoMerchantAccounts = $block->getMotoMerchantAccounts();
           id="payment_form_<?= /* @noEscape */ $code; ?>"
           style="display:none">
 
-    <input name="payment[stateData]" id="adyen-moto-statedata" type="hidden">
-    <input name="payment[motoMerchantAccount]" id="adyen-moto-merchant-account" type="hidden">
-    <input name="payment[motoConfigId]" id="adyen-moto-moto-config-id" type="hidden">
+    <input name="payment[stateData]" id="<?= /* @noEscape */ $code; ?>-statedata" type="hidden">
+    <input name="payment[motoMerchantAccount]" id="<?= /* @noEscape */ $code; ?>-merchant-account" type="hidden">
 
-    <label for="adyen_moto_merchant_accounts" class="admin__field-label">
+    <label for="<?= /* @noEscape */ $code; ?>_merchant_accounts" class="admin__field-label">
        <span>
-           <?= $escaper->escapeHtml(__('Select Merchant Account')) ?>
+           <?= $escaper->escapeHtml(__('MOTO Merchant Account')) ?>
        </span>
     </label>
     <div class="admin__field-control">
-        <select id="adyen_moto_merchant_accounts" class="required-entry admin__control-select">
+        <select id="<?= /* @noEscape */ $code; ?>_merchant_accounts" class="required-entry admin__control-select">
             <option value=""><?= $escaper->escapeHtml(__('Please select...')) ?></option>
             <?php
                 foreach ($motoMerchantAccounts as $key => $value) {
-                    printf("<option value='%s' data-adyen-client-key='%s' data-adyen-config-id='%d'>%s</option>", $key, $value['clientkey'], 100, $key);
+                    printf("<option value='%s' data-adyen-client-key='%s'>%s</option>", $key, $value['clientkey'], $key);
                 }
             ?>
         </select>
@@ -99,7 +98,7 @@ $motoMerchantAccounts = $block->getMotoMerchantAccounts();
                                     amount :<?= /* @noEscape */ $block->getAmount();?>,
                                     onChange: function (state) {
                                         if (state.isValid) {
-                                            $('#adyen-moto-statedata').val(JSON.stringify(state.data));
+                                            $('#<?= /* @noEscape */ $code; ?>-statedata').val(JSON.stringify(state.data));
                                         }
                                     }
                                 });
@@ -123,7 +122,7 @@ $motoMerchantAccounts = $block->getMotoMerchantAccounts();
                 'renderCheckoutComponent',
             ],
             function ($, renderCheckoutComponent) {
-                $("#adyen_moto_merchant_accounts").on("change", function () {
+                $("#<?= /* @noEscape */ $code; ?>_merchant_accounts").on("change", function () {
                     if (renderCheckoutComponent.status() !== null) {
                         renderCheckoutComponent.unmount();
                     }
@@ -131,7 +130,7 @@ $motoMerchantAccounts = $block->getMotoMerchantAccounts();
                     var clientKey = $(this).find("option:selected").attr('data-adyen-client-key');
                     var merchantAccount = $(this).find("option:selected").val();
 
-                    $("#adyen-moto-merchant-account").val(merchantAccount);
+                    $("#<?= /* @noEscape */ $code; ?>-merchant-account").val(merchantAccount);
                     renderCheckoutComponent.init(clientKey);
                 });
             }

--- a/view/adminhtml/templates/form/moto.phtml
+++ b/view/adminhtml/templates/form/moto.phtml
@@ -26,7 +26,7 @@ $motoMerchantAccounts = $block->getMotoMerchantAccounts();
           style="display:none">
 
     <input name="payment[stateData]" id="adyen-moto-statedata" type="hidden">
-    <input name="payment[merchantAccount]" id="adyen-moto-merchant-account" type="hidden">
+    <input name="payment[motoMerchantAccount]" id="adyen-moto-merchant-account" type="hidden">
     <input name="payment[motoConfigId]" id="adyen-moto-moto-config-id" type="hidden">
 
     <label for="adyen_moto_merchant_accounts" class="admin__field-label">

--- a/view/adminhtml/templates/form/moto.phtml
+++ b/view/adminhtml/templates/form/moto.phtml
@@ -17,6 +17,8 @@ $code = $block->escapeHtml($block->getMethodCode());
 $ccType = $block->getInfoData('cc_type');
 $ccExpMonth = $block->getInfoData('cc_exp_month');
 $ccExpYear = $block->getInfoData('cc_exp_year');
+$motoMerchantAccounts = $block->getMotoMerchantAccounts();
+
 ?>
 
 <fieldset class="admin__fieldset payment-method"
@@ -32,7 +34,24 @@ $ccExpYear = $block->getInfoData('cc_exp_year');
         ); ?>
     </span>
     <input name="payment[stateData]" id="adyen-moto-statedata" type="hidden">
-    <div id="cardContainer-<?= /* @noEscape */ $code; ?>"></div>
+
+    <label for="adyen_pbl_expires_at" class="admin__field-label">
+               <span>
+               <?= $escaper->escapeHtml(__('Select Merchant Account')) ?>
+               </span>
+    </label>
+    <div class="admin__field-control">
+        <select id="adyen_moto_merchant_accounts" class="required-entry admin__control-select" onchange="">
+            <option><?= $escaper->escapeHtml(__('Please select...')) ?></option>
+            <?php
+                foreach ($motoMerchantAccounts as $key => $value) {
+                    printf("<option data-adyen-client-key='%s' data-adyen-config-id='%d'>%s</option>", $value['clientkey'], 100, $key);
+                }
+            ?>
+        </select>
+    </div>
+
+    <div id="cardContainer-<?= /* @noEscape */ $code; ?>" style="display: none"></div>
 
     <script>
         require(
@@ -43,56 +62,63 @@ $ccExpYear = $block->getInfoData('cc_exp_year');
                 'Adyen_Payment/js/adyen'
             ],
             function ($, scripts, form, AdyenCheckout) {
-            (async function () { // RequireJS does not support async callback
-                var ccTypes = <?= /* @noEscape */ json_encode($block->getCcAvailableTypesByAlt()); ?>;
+                (async function () { // RequireJS does not support async callback
 
-                // Get cc type by adyen cc type
-                var getCcCodeByAltCode = function (altCode) {
+                    $("#cardContainer-<?= /* @noEscape */ $code; ?>").on("change", function () {
+                        alert('can');
+                        $("#cardContainer-<?= /* @noEscape */ $code; ?>").show();
+                    });
 
-                    if (ccTypes.hasOwnProperty(altCode)) {
-                        return ccTypes[altCode];
+                    var ccTypes = <?= /* @noEscape */ json_encode($block->getCcAvailableTypesByAlt()); ?>;
+
+                    // Get cc type by adyen cc type
+                    var getCcCodeByAltCode = function (altCode) {
+
+                        if (ccTypes.hasOwnProperty(altCode)) {
+                            return ccTypes[altCode];
+                        }
+
+                        return "";
                     }
 
-                    return "";
-                }
+                    if (!"<?= $block->getClientKey(); ?>") {
+                        document.getElementById('noClientKey').style = "visibility: visible; display:inline-block";
+                        return;
+                    }
+                    var cardNode = document.getElementById("cardContainer-<?= /* @noEscape */ $code; ?>");
 
-                if (!"<?= $block->getClientKey(); ?>") {
-                    document.getElementById('noClientKey').style = "visibility: visible; display:inline-block";
-                    return;
-                }
-                var cardNode = document.getElementById("cardContainer-<?= /* @noEscape */ $code; ?>");
+                    var checkout = await AdyenCheckout({
+                        clientKey: "<?= /* @noEscape */ $block->getClientKey(); ?>",
+                        environment: "<?= /* @noEscape */ $block->getCheckoutEnvironment(); ?>",
+                        locale: "<?= /* @noEscape */ $block->getLocale(); ?>",
+                        risk: {
+                            enabled: false
+                        },
 
-                var checkout = await AdyenCheckout({
-                    clientKey: "<?= /* @noEscape */ $block->getClientKey(); ?>",
-                    environment: "<?= /* @noEscape */ $block->getCheckoutEnvironment(); ?>",
-                    locale: "<?= /* @noEscape */ $block->getLocale(); ?>",
-                    risk: {
-                        enabled: false
-                    },
-
-                });
-                var hideCVC = "<?= !$block->hasVerification(); ?>";
-
-                try {
-                    var card = checkout.create('card', {
-                        brands: Object.keys(ccTypes),
-                        hideCVC: hideCVC,
-                        enableStoreDetails: false, // MOTO can't use CVC which is required for OneClick tokens
-                        hasHolderName: true,
-                        installmentOptions: <?= /* @noEscape */ $block->getFormattedInstallments();?>,
-                        showInstallmentAmounts: true,
-                        amount :<?= /* @noEscape */ $block->getAmount();?>,
-                        onChange: function (state) {
-                            if (state.isValid) {
-                                $('#adyen-moto-statedata').val(JSON.stringify(state.data));
-                            }
-                        }
                     });
-                    card.mount(cardNode);
-                } catch (e) {
-                    console.log(e);
-                }
-            })();
+                    var hideCVC = "<?= !$block->hasVerification(); ?>";
+
+                    try {
+                        var card = checkout.create('card', {
+                            brands: Object.keys(ccTypes),
+                            hideCVC: hideCVC,
+                            enableStoreDetails: false, // MOTO can't use CVC which is required for OneClick tokens
+                            hasHolderName: true,
+                            installmentOptions: <?= /* @noEscape */ $block->getFormattedInstallments();?>,
+                            showInstallmentAmounts: true,
+                            amount :<?= /* @noEscape */ $block->getAmount();?>,
+                            onChange: function (state) {
+                                if (state.isValid) {
+                                    alert('can');
+                                    $('#adyen-moto-statedata').val(JSON.stringify(state.data));
+                                }
+                            }
+                        });
+                        card.mount(cardNode);
+                    } catch (e) {
+                        console.log(e);
+                    }
+                })();
             });
     </script>
 </fieldset>

--- a/view/adminhtml/templates/form/moto.phtml
+++ b/view/adminhtml/templates/form/moto.phtml
@@ -1,0 +1,98 @@
+<?php
+/**
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2022 Adyen N.V. (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+// @codingStandardsIgnoreFile
+/**
+ * @var \Adyen\Payment\Block\Form\Moto $block
+ */
+$code = $block->escapeHtml($block->getMethodCode());
+$ccType = $block->getInfoData('cc_type');
+$ccExpMonth = $block->getInfoData('cc_exp_month');
+$ccExpYear = $block->getInfoData('cc_exp_year');
+?>
+
+<fieldset class="admin__fieldset payment-method"
+          id="payment_form_<?= /* @noEscape */ $code; ?>"
+          style="display:none">
+    <span id="noClientKey"
+          class="message message-error error"
+          style="display: none"><?= $block->escapeHtml(
+            __(
+                'Please configure a Client key and a live endpoint prefix (if in Production Mode) in your Adyen ' .
+                'Required Settings'
+            )
+        ); ?>
+    </span>
+    <input name="payment[stateData]" id="adyen-moto-statedata" type="hidden">
+    <div id="cardContainer-<?= /* @noEscape */ $code; ?>"></div>
+
+    <script>
+        require(
+            [
+                'jquery',
+                'Magento_Sales/order/create/scripts',
+                'Magento_Sales/order/create/form',
+                'Adyen_Payment/js/adyen'
+            ],
+            function ($, scripts, form, AdyenCheckout) {
+            (async function () { // RequireJS does not support async callback
+                var ccTypes = <?= /* @noEscape */ json_encode($block->getCcAvailableTypesByAlt()); ?>;
+
+                // Get cc type by adyen cc type
+                var getCcCodeByAltCode = function (altCode) {
+
+                    if (ccTypes.hasOwnProperty(altCode)) {
+                        return ccTypes[altCode];
+                    }
+
+                    return "";
+                }
+
+                if (!"<?= $block->getClientKey(); ?>") {
+                    document.getElementById('noClientKey').style = "visibility: visible; display:inline-block";
+                    return;
+                }
+                var cardNode = document.getElementById("cardContainer-<?= /* @noEscape */ $code; ?>");
+
+                var checkout = await AdyenCheckout({
+                    clientKey: "<?= /* @noEscape */ $block->getClientKey(); ?>",
+                    environment: "<?= /* @noEscape */ $block->getCheckoutEnvironment(); ?>",
+                    locale: "<?= /* @noEscape */ $block->getLocale(); ?>",
+                    risk: {
+                        enabled: false
+                    },
+
+                });
+                var hideCVC = "<?= !$block->hasVerification(); ?>";
+
+                try {
+                    var card = checkout.create('card', {
+                        brands: Object.keys(ccTypes),
+                        hideCVC: hideCVC,
+                        enableStoreDetails: false, // MOTO can't use CVC which is required for OneClick tokens
+                        hasHolderName: true,
+                        installmentOptions: <?= /* @noEscape */ $block->getFormattedInstallments();?>,
+                        showInstallmentAmounts: true,
+                        amount :<?= /* @noEscape */ $block->getAmount();?>,
+                        onChange: function (state) {
+                            if (state.isValid) {
+                                $('#adyen-moto-statedata').val(JSON.stringify(state.data));
+                            }
+                        }
+                    });
+                    card.mount(cardNode);
+                } catch (e) {
+                    console.log(e);
+                }
+            })();
+            });
+    </script>
+</fieldset>

--- a/view/adminhtml/templates/form/moto.phtml
+++ b/view/adminhtml/templates/form/moto.phtml
@@ -24,101 +24,117 @@ $motoMerchantAccounts = $block->getMotoMerchantAccounts();
 <fieldset class="admin__fieldset payment-method"
           id="payment_form_<?= /* @noEscape */ $code; ?>"
           style="display:none">
-    <span id="noClientKey"
-          class="message message-error error"
-          style="display: none"><?= $block->escapeHtml(
-            __(
-                'Please configure a Client key and a live endpoint prefix (if in Production Mode) in your Adyen ' .
-                'Required Settings'
-            )
-        ); ?>
-    </span>
-    <input name="payment[stateData]" id="adyen-moto-statedata" type="hidden">
 
-    <label for="adyen_pbl_expires_at" class="admin__field-label">
-               <span>
-               <?= $escaper->escapeHtml(__('Select Merchant Account')) ?>
-               </span>
+    <input name="payment[stateData]" id="adyen-moto-statedata" type="hidden">
+    <input name="payment[merchantAccount]" id="adyen-moto-merchant-account" type="hidden">
+    <input name="payment[motoConfigId]" id="adyen-moto-moto-config-id" type="hidden">
+
+    <label for="adyen_moto_merchant_accounts" class="admin__field-label">
+       <span>
+           <?= $escaper->escapeHtml(__('Select Merchant Account')) ?>
+       </span>
     </label>
     <div class="admin__field-control">
-        <select id="adyen_moto_merchant_accounts" class="required-entry admin__control-select" onchange="">
-            <option><?= $escaper->escapeHtml(__('Please select...')) ?></option>
+        <select id="adyen_moto_merchant_accounts" class="required-entry admin__control-select">
+            <option value=""><?= $escaper->escapeHtml(__('Please select...')) ?></option>
             <?php
                 foreach ($motoMerchantAccounts as $key => $value) {
-                    printf("<option data-adyen-client-key='%s' data-adyen-config-id='%d'>%s</option>", $value['clientkey'], 100, $key);
+                    printf("<option value='%s' data-adyen-client-key='%s' data-adyen-config-id='%d'>%s</option>", $key, $value['clientkey'], 100, $key);
                 }
             ?>
         </select>
     </div>
 
-    <div id="cardContainer-<?= /* @noEscape */ $code; ?>" style="display: none"></div>
+    <div id="cardContainer-<?= /* @noEscape */ $code; ?>" style=""></div>
 
     <script>
-        require(
+        define(
+            'renderCheckoutComponent',
             [
                 'jquery',
                 'Magento_Sales/order/create/scripts',
                 'Magento_Sales/order/create/form',
                 'Adyen_Payment/js/adyen'
             ],
-            function ($, scripts, form, AdyenCheckout) {
-                (async function () { // RequireJS does not support async callback
+            function($, scripts, form, AdyenCheckout) {
+                var card = null;
+                return {
+                    status: function () {
+                        return card;
+                    },
+                    init: function (clientKey) {
+                        (async function () { // RequireJS does not support async callback
+                            var ccTypes = <?= /* @noEscape */ json_encode($block->getCcAvailableTypesByAlt()); ?>;
 
-                    $("#cardContainer-<?= /* @noEscape */ $code; ?>").on("change", function () {
-                        alert('can');
-                        $("#cardContainer-<?= /* @noEscape */ $code; ?>").show();
-                    });
-
-                    var ccTypes = <?= /* @noEscape */ json_encode($block->getCcAvailableTypesByAlt()); ?>;
-
-                    // Get cc type by adyen cc type
-                    var getCcCodeByAltCode = function (altCode) {
-
-                        if (ccTypes.hasOwnProperty(altCode)) {
-                            return ccTypes[altCode];
-                        }
-
-                        return "";
-                    }
-
-                    if (!"<?= $block->getClientKey(); ?>") {
-                        document.getElementById('noClientKey').style = "visibility: visible; display:inline-block";
-                        return;
-                    }
-                    var cardNode = document.getElementById("cardContainer-<?= /* @noEscape */ $code; ?>");
-
-                    var checkout = await AdyenCheckout({
-                        clientKey: "<?= /* @noEscape */ $block->getClientKey(); ?>",
-                        environment: "<?= /* @noEscape */ $block->getCheckoutEnvironment(); ?>",
-                        locale: "<?= /* @noEscape */ $block->getLocale(); ?>",
-                        risk: {
-                            enabled: false
-                        },
-
-                    });
-                    var hideCVC = "<?= !$block->hasVerification(); ?>";
-
-                    try {
-                        var card = checkout.create('card', {
-                            brands: Object.keys(ccTypes),
-                            hideCVC: hideCVC,
-                            enableStoreDetails: false, // MOTO can't use CVC which is required for OneClick tokens
-                            hasHolderName: true,
-                            installmentOptions: <?= /* @noEscape */ $block->getFormattedInstallments();?>,
-                            showInstallmentAmounts: true,
-                            amount :<?= /* @noEscape */ $block->getAmount();?>,
-                            onChange: function (state) {
-                                if (state.isValid) {
-                                    alert('can');
-                                    $('#adyen-moto-statedata').val(JSON.stringify(state.data));
+                            // Get cc type by adyen cc type
+                            var getCcCodeByAltCode = function (altCode) {
+                                if (ccTypes.hasOwnProperty(altCode)) {
+                                    return ccTypes[altCode];
                                 }
+
+                                return "";
                             }
-                        });
-                        card.mount(cardNode);
-                    } catch (e) {
-                        console.log(e);
+
+                            var cardNode = document.getElementById("cardContainer-<?= /* @noEscape */ $code; ?>");
+
+                            var checkout = await AdyenCheckout({
+                                clientKey: clientKey,
+                                environment: "<?= /* @noEscape */ $block->getCheckoutEnvironment(); ?>",
+                                locale: "<?= /* @noEscape */ $block->getLocale(); ?>",
+                                risk: {
+                                    enabled: false
+                                },
+                            });
+
+                            var hideCVC = "<?= !$block->hasVerification(); ?>";
+
+                            try {
+                                card = checkout.create('card', {
+                                    brands: Object.keys(ccTypes),
+                                    hideCVC: hideCVC,
+                                    enableStoreDetails: false, // MOTO can't use CVC which is required for OneClick tokens
+                                    hasHolderName: true,
+                                    installmentOptions: <?= /* @noEscape */ $block->getFormattedInstallments();?>,
+                                    showInstallmentAmounts: true,
+                                    amount :<?= /* @noEscape */ $block->getAmount();?>,
+                                    onChange: function (state) {
+                                        if (state.isValid) {
+                                            $('#adyen-moto-statedata').val(JSON.stringify(state.data));
+                                        }
+                                    }
+                                });
+                                card.mount(cardNode);
+                            } catch (e) {
+                                console.log(e);
+                            }
+                        })();
+                    },
+
+                    unmount: function () {
+                        card.unmount();
                     }
-                })();
-            });
+                }
+            }
+        );
+
+        require(
+            [
+                'jquery',
+                'renderCheckoutComponent',
+            ],
+            function ($, renderCheckoutComponent) {
+                $("#adyen_moto_merchant_accounts").on("change", function () {
+                    if (renderCheckoutComponent.status() !== null) {
+                        renderCheckoutComponent.unmount();
+                    }
+
+                    var clientKey = $(this).find("option:selected").attr('data-adyen-client-key');
+                    var merchantAccount = $(this).find("option:selected").val();
+
+                    $("#adyen-moto-merchant-account").val(merchantAccount);
+                    renderCheckoutComponent.init(clientKey);
+                });
+            }
+        );
     </script>
 </fieldset>

--- a/view/adminhtml/templates/info/adyen_moto.phtml
+++ b/view/adminhtml/templates/info/adyen_moto.phtml
@@ -1,0 +1,100 @@
+<?php
+/**
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2022 Adyen N.V. (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+// @codingStandardsIgnoreFile
+
+?>
+<?php
+/**
+ * @see \Magento\Payment\Block\Info
+ */
+
+?>
+<div>
+    <?= $block->escapeHtml($block->getMethod()->getTitle()); ?>
+</div>
+<?php
+$_info = $block->getInfo();
+$_isDemoMode = $block->isDemoMode();
+?>
+<?php if ($_pspReference = $_info->getAdditionalInformation('pspReference')): ?>
+    <div>
+        <?php if ($_isDemoMode): ?>
+            <?= $block->escapeHtml(__('Adyen PSP Reference: ')); ?>
+            <a href="https://ca-test.adyen.com/ca/ca/accounts/showTx.shtml?pspReference=<?= $block->escapeHtml(
+                $_pspReference
+            ); ?>&txType=Payment" target="_blank"><?= $block->escapeHtml($_pspReference); ?></a>
+        <?php else: ?>
+            <?= $block->escapeHtml(__('Adyen PSP Reference: ')); ?>
+            <a href="https://ca-live.adyen.com/ca/ca/accounts/showTx.shtml?pspReference=<?= $block->escapeHtml(
+                $_pspReference
+            ); ?>&txType=Payment" target="_blank"><?= $block->escapeHtml($_pspReference); ?></a>
+        <?php endif; ?>
+    </div>
+<?php endif; ?>
+
+<?php if ($block->getCcTypeName() != ""): ?>
+    <div>
+        <?= $block->escapeHtml(__('Payment Method: %1', $block->getCcTypeName())); ?><br/>
+    </div>
+<?php endif; ?>
+<?php if ($_info->getCcLast4() != ""): ?>
+    <?= $block->escapeHtml(__('Credit Card Number: xxxx-%1', $block->getInfo()->getCcLast4())); ?><br/>
+<?php endif; ?>
+
+<?php if ($_info->getAdditionalInformation('number_of_installments') != ""): ?>
+    <?= $block->escapeHtml(
+        __('Number of installments: %1', $_info->getAdditionalInformation('number_of_installments'))
+    ); ?><br/>
+<?php endif; ?>
+
+<?php if ($_info->getAdditionalInformation('adyen_avs_result') != ""): ?>
+    <?= $block->escapeHtml(__('Avs result: %1', $_info->getAdditionalInformation('adyen_avs_result'))); ?><br/>
+<?php endif; ?>
+
+<?php if ($_info->getAdditionalInformation('adyen_cvc_result') != ""): ?>
+    <?= $block->escapeHtml(__('Cvc result: %1', $_info->getAdditionalInformation('adyen_cvc_result'))); ?><br/>
+<?php endif; ?>
+
+<?php if ($_info->getAdditionalInformation('adyen_total_fraud_score') != ""): ?>
+    <?= $block->escapeHtml(__('Total fraud score: %1', $_info->getAdditionalInformation('adyen_total_fraud_score'))); ?>
+    <br/>
+<?php endif; ?>
+
+<?php if ($_info->getAdditionalInformation('adyen_refusal_reason_raw') != ""): ?>
+    <?= $block->escapeHtml(
+        __('Raw acquirer response: %1', $_info->getAdditionalInformation('adyen_refusal_reason_raw'))
+    ); ?><br/>
+<?php endif; ?>
+
+<?php if ($_info->getAdditionalInformation('adyen_auth_code') != ""): ?>
+    <?= $block->escapeHtml(__('Authorisation code: %1', $_info->getAdditionalInformation('adyen_auth_code'))); ?><br/>
+<?php endif; ?>
+
+<?php if ($_info->getAdditionalInformation('adyen_acquirer_reference') != ""): ?>
+    <?= $block->escapeHtml(
+        __('Acquirer reference: %1', $_info->getAdditionalInformation('adyen_acquirer_reference'))
+    ); ?><br/>
+<?php endif; ?>
+
+<?php if ($_specificInfo = $block->getSpecificInformation()): ?>
+    <table class="data-table admin__table-secondary">
+        <?php foreach ($_specificInfo as $_label => $_value): ?>
+            <tr>
+                <th scope="row"><?= $block->escapeHtml($_label) ?>:
+                </th>
+                <td><?= $block->escapeHtml(nl2br(implode("\n", $block->getValueAsArray($_value, true)))); ?></td>
+            </tr>
+        <?php endforeach; ?>
+    </table>
+<?php endif; ?>
+
+<?= $block->escapeHtml($block->getChildHtml()); ?>

--- a/view/adminhtml/templates/info/adyen_moto.phtml
+++ b/view/adminhtml/templates/info/adyen_moto.phtml
@@ -25,6 +25,13 @@
 $_info = $block->getInfo();
 $_isDemoMode = $block->isDemoMode();
 ?>
+
+<?php if ($block->getMotoMerchantAccount() != ""): ?>
+    <div>
+        <?= $block->escapeHtml(__('Merchant Account: %1', $block->getMotoMerchantAccount())); ?><br/>
+    </div>
+<?php endif; ?>
+
 <?php if ($_pspReference = $_info->getAdditionalInformation('pspReference')): ?>
     <div>
         <?php if ($_isDemoMode): ?>

--- a/view/adminhtml/web/css/order_create_styles.css
+++ b/view/adminhtml/web/css/order_create_styles.css
@@ -8,26 +8,26 @@
  * Author: Adyen <magento@adyen.com>
  */
 
-#payment_form_adyen_cc {
+#payment_form_adyen_moto {
     padding-left: 30px;
+    margin-top: 15px;
 }
 
 .adyen-checkout-card__form .adyen-checkout__input iframe{
     max-height: 40px;
 }
 
-#payment_form_adyen_cc .admin__field{
+#payment_form_adyen_moto .admin__field{
     margin-bottom: 10px;
 }
 
-#payment_form_adyen_cc .helper-text{
+#payment_form_adyen_moto .helper-text{
     font-size: 11px;
     color: rgb(144, 162, 189);
     font-weight: 100;
 }
 
-
-#payment_form_adyen_cc #adyen_cc_cc_owner {
+#payment_form_adyen_moto #adyen_moto_cc_owner {
     width: 225px;
     border: none;
     padding: 0;
@@ -37,20 +37,24 @@
     margin-top: 10px;
 }
 
-#payment_form_adyen_cc #adyen_cc_cc_owner .input-text:focus {
+#payment_form_adyen_moto #adyen_moto_cc_owner .input-text:focus {
     border: none;
     box-shadow: none;
 }
 
-#payment_form_adyen_cc #adyen_cc_cc_owner::placeholder,
-#payment_form_adyen_cc #adyen_cc_cc_owner:placeholder-shown
+#payment_form_adyen_moto #adyen_moto_cc_owner::placeholder,
+#payment_form_adyen_moto #adyen_moto_cc_owner:placeholder-shown
 {
     color: rgb(144, 162, 189);
     font-weight: 200;
 }
 
-#payment_form_adyen_cc .cc-type-VI {
+#payment_form_adyen_moto .cc-type-VI {
     margin: 10px;
     display: inline-block;
     font-weight: bold;
+}
+
+#adyen_moto_merchant_accounts {
+    margin-bottom: 15px;
 }


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Since MOTO is using different merchant account, it is required to create separate commands for capture, cancel, refund and void.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

**Fixed issue**:  <!-- #-prefixed issue number -->