### PR TITLE
[PW-6910] Add functionality to tokenize AmazonPay payments

### DIFF
--- a/Gateway/Request/RecurringDataBuilder.php
+++ b/Gateway/Request/RecurringDataBuilder.php
@@ -89,11 +89,11 @@ class RecurringDataBuilder implements BuilderInterface
         $order = $payment->getOrder();
         $storeId = $order->getStoreId();
         $method = $payment->getMethod();
-
+        $brand = $this->adyenRequestsHelper->getPaymentMethodVariant($order->getQuoteId());
         if ($method === PaymentMethods::ADYEN_CC) {
             $body = $this->adyenRequestsHelper->buildCardRecurringData($storeId, $payment);
         } elseif ($method === PaymentMethods::ADYEN_HPP) {
-            $body = $this->vaultHelper->buildPaymentMethodRecurringData($storeId, $payment);
+            $body = $this->vaultHelper->buildPaymentMethodRecurringData($storeId, $brand);
         } elseif ($method === PaymentMethods::ADYEN_ONE_CLICK) {
             $body = $this->adyenRequestsHelper->buildAdyenTokenizedPaymentRecurringData($storeId, $payment);
         } else {

--- a/Gateway/Request/RecurringDataBuilder.php
+++ b/Gateway/Request/RecurringDataBuilder.php
@@ -15,6 +15,7 @@ use Adyen\Payment\Helper\AdyenOrderPayment;
 use Adyen\Payment\Helper\PaymentMethods;
 use Adyen\Payment\Helper\Requests;
 use Adyen\Payment\Helper\Vault;
+use Adyen\Payment\Helper\StateData;
 use Adyen\Payment\Logger\AdyenLogger;
 use Magento\Framework\Model\Context;
 use Magento\Payment\Gateway\Helper\SubjectReader;
@@ -53,12 +54,18 @@ class RecurringDataBuilder implements BuilderInterface
     private $vaultHelper;
 
     /**
+     * @var StateData
+     */
+    private $stateData;
+
+    /**
      * RecurringDataBuilder constructor.
      *
      * @param Context $context
      * @param Requests $adyenRequestsHelper
      * @param PaymentMethods $paymentMethodsHelper
      * @param AdyenLogger $adyenLogger
+     * @param StateData $stateData
      */
     public function __construct(
         Context $context,
@@ -66,7 +73,8 @@ class RecurringDataBuilder implements BuilderInterface
         PaymentMethods $paymentMethodsHelper,
         AdyenLogger $adyenLogger,
         AdyenOrderPayment $adyenOrderPayment,
-        Vault $vaultHelper
+        Vault $vaultHelper,
+        StateData $stateData
     ) {
         $this->appState = $context->getAppState();
         $this->adyenRequestsHelper = $adyenRequestsHelper;
@@ -74,6 +82,7 @@ class RecurringDataBuilder implements BuilderInterface
         $this->adyenLogger = $adyenLogger;
         $this->adyenOrderPayment = $adyenOrderPayment;
         $this->vaultHelper = $vaultHelper;
+        $this->stateData = $stateData;
     }
 
     /**
@@ -89,7 +98,7 @@ class RecurringDataBuilder implements BuilderInterface
         $order = $payment->getOrder();
         $storeId = $order->getStoreId();
         $method = $payment->getMethod();
-        $brand = $this->adyenRequestsHelper->getPaymentMethodVariant($order->getQuoteId());
+        $brand = $this->stateData->getPaymentMethodVariant($order->getQuoteId());
         if ($method === PaymentMethods::ADYEN_CC) {
             $body = $this->adyenRequestsHelper->buildCardRecurringData($storeId, $payment);
         } elseif ($method === PaymentMethods::ADYEN_HPP) {

--- a/Helper/PaymentMethods/AmazonPayPaymentMethod.php
+++ b/Helper/PaymentMethods/AmazonPayPaymentMethod.php
@@ -1,5 +1,14 @@
 <?php
-
+/**
+ *
+ * Adyen Payment Module
+ *
+ * Copyright (c) 2022 Adyen N.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
 
 namespace Adyen\Payment\Helper\PaymentMethods;
 

--- a/Helper/PaymentMethods/AmazonPayPaymentMethod.php
+++ b/Helper/PaymentMethods/AmazonPayPaymentMethod.php
@@ -1,0 +1,51 @@
+<?php
+
+
+namespace Adyen\Payment\Helper\PaymentMethods;
+
+
+class AmazonPayPaymentMethod implements PaymentMethodInterface
+{
+    const TX_VARIANT = 'amazonpay';
+    const NAME = 'Amazon Pay';
+
+    public function getTxVariant(): string
+    {
+        return self::TX_VARIANT;
+    }
+
+    public function getPaymentMethodName(): string
+    {
+        return self::NAME;
+    }
+
+    public function supportsManualCapture(): bool
+    {
+        return true;
+    }
+
+    public function supportsAutoCapture(): bool
+    {
+        return true;
+    }
+
+    public function supportsCardOnFile(): bool
+    {
+        return true;
+    }
+
+    public function supportsSubscription(): bool
+    {
+        return true;
+    }
+
+    public function isWalletPaymentMethod(): bool
+    {
+        return true;
+    }
+
+    public function supportsUnscheduledCardOnFile(): bool
+    {
+        return true;
+    }
+}

--- a/Helper/PaymentMethods/PaymentMethodFactory.php
+++ b/Helper/PaymentMethods/PaymentMethodFactory.php
@@ -32,6 +32,8 @@ class PaymentMethodFactory
         switch ($txVariant) {
             case ApplePayPaymentMethod::TX_VARIANT:
                 return new ApplePayPaymentMethod();
+            case AmazonPayPaymentMethod::TX_VARIANT:
+                return new AmazonPayPaymentMethod();
             case GooglePayPaymentMethod::TX_VARIANT:
                 return new GooglePayPaymentMethod();
             case PayPalPaymentMethod::TX_VARIANT:

--- a/Helper/Requests.php
+++ b/Helper/Requests.php
@@ -432,7 +432,7 @@ class Requests extends AbstractHelper
      */
     public function getPaymentMethodVariant(int $quoteId): string
     {
-        $stateData = $this->stateData->getStateData($quoteId);
-        return $stateData['paymentMethod']['type'];
+        $stateDataByQuoteId = $this->stateData->getStateData($quoteId);
+        return $stateDataByQuoteId['paymentMethod']['type'];
     }
 }

--- a/Helper/Requests.php
+++ b/Helper/Requests.php
@@ -424,15 +424,4 @@ class Requests extends AbstractHelper
 
         return $shopperReference;
     }
-
-    /**
-     * Returns the payment method type from state data
-     * @param int $quoteId
-     * @return string
-     */
-    public function getPaymentMethodVariant(int $quoteId): string
-    {
-        $stateDataByQuoteId = $this->stateData->getStateData($quoteId);
-        return $stateDataByQuoteId['paymentMethod']['type'];
-    }
 }

--- a/Helper/Requests.php
+++ b/Helper/Requests.php
@@ -424,4 +424,15 @@ class Requests extends AbstractHelper
 
         return $shopperReference;
     }
+
+    /**
+     * Returns the payment method type from state data
+     * @param int $quoteId
+     * @return string
+     */
+    public function getPaymentMethodVariant(int $quoteId): string
+    {
+        $stateData = $this->stateData->getStateData($quoteId);
+        return $stateData['paymentMethod']['type'];
+    }
 }

--- a/Helper/StateData.php
+++ b/Helper/StateData.php
@@ -87,4 +87,15 @@ class StateData
     {
         return $this->stateData[$quoteId] ?? [];
     }
+
+    /**
+     * Returns the payment method type from state data
+     * @param int $quoteId
+     * @return string
+     */
+    public function getPaymentMethodVariant(int $quoteId): string
+    {
+        $stateDataByQuoteId = $this->stateData[$quoteId];
+        return $stateDataByQuoteId['paymentMethod']['type'];
+    }
 }

--- a/Helper/Vault.php
+++ b/Helper/Vault.php
@@ -197,15 +197,12 @@ class Vault
      * @param $payment
      * @return array
      */
-    public function buildPaymentMethodRecurringData(int $storeId, $payment): array
+    public function buildPaymentMethodRecurringData(int $storeId, $brand): array
     {
         $request = [];
-        $brand = $payment->getCcType();
-
         if (!$this->config->isStoreAlternativePaymentMethodEnabled()) {
             return $request;
         }
-
         try {
             $adyenPaymentMethod = $this->paymentMethodFactory::createAdyenPaymentMethod($brand);
             $allowRecurring = $this->allowRecurringOnPaymentMethod($adyenPaymentMethod, $storeId);
@@ -226,7 +223,6 @@ class Vault
             $request['storePaymentMethod'] = true;
             $request['recurringProcessingModel'] = $recurringModel;
         }
-
         return $request;
     }
 

--- a/Model/Config/Source/TokenizedPaymentMethods.php
+++ b/Model/Config/Source/TokenizedPaymentMethods.php
@@ -18,6 +18,10 @@ class TokenizedPaymentMethods implements OptionSourceInterface
                 'label' => PaymentMethods\ApplePayPaymentMethod::NAME
             ],
             [
+                'value' => PaymentMethods\AmazonPayPaymentMethod::TX_VARIANT,
+                'label' => PaymentMethods\AmazonPayPaymentMethod::NAME
+            ],
+            [
                 'value' => PaymentMethods\GooglePayPaymentMethod::TX_VARIANT,
                 'label' => PaymentMethods\GooglePayPaymentMethod::NAME
             ],


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Added the functionality to enable create token for the amazon pay. Furthermore it is added in the admin panel in the `Tokenized Payment Methods`  dropdown. The payment method type is now retrieved from the `statedata` instead of the `payment` object. 


**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- Amazon pay token created 
- Sepa token 
- Google pay token 
**Fixed issue**:  <!-- #-prefixed issue number -->