### PR TITLE
[PW-6706] - Add capture, cancel, refund and void commands for MOTO

### DIFF
--- a/Gateway/Http/Client/TransactionMotoCancel.php
+++ b/Gateway/Http/Client/TransactionMotoCancel.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2022 Adyen N.V. (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\Payment\Gateway\Http\Client;
+
+use Adyen\Service\Modification;
+use Magento\Payment\Gateway\Http\ClientInterface;
+
+/**
+ * Class TransactionSale
+ */
+class TransactionMotoCancel implements ClientInterface
+{
+    /**
+     * @var \Adyen\Payment\Helper\Data
+     */
+    private $adyenHelper;
+
+    /**
+     * PaymentRequest constructor.
+     * @param \Adyen\Payment\Helper\Data $adyenHelper
+     */
+    public function __construct(
+        \Adyen\Payment\Helper\Data $adyenHelper
+    ) {
+        $this->adyenHelper = $adyenHelper;
+    }
+
+    /**
+     * @param \Magento\Payment\Gateway\Http\TransferInterface $transferObject
+     * @return null
+     */
+    public function placeRequest(\Magento\Payment\Gateway\Http\TransferInterface $transferObject)
+    {
+        $request = $transferObject->getBody();
+
+        $client = $this->adyenHelper->initializeAdyenMotoClient($request['merchantAccount']);
+        $service = new Modification($client);
+
+        try {
+            $response = $service->cancel($request);
+        } catch (\Adyen\AdyenException $e) {
+            $response['error'] = $e->getMessage();
+        }
+        return $response;
+    }
+}

--- a/Gateway/Http/Client/TransactionMotoCapture.php
+++ b/Gateway/Http/Client/TransactionMotoCapture.php
@@ -1,0 +1,133 @@
+<?php
+/**
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2022 Adyen N.V. (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\Payment\Gateway\Http\Client;
+
+use Adyen\AdyenException;
+use Adyen\Payment\Api\Data\OrderPaymentInterface;
+use Adyen\Payment\Helper\Data;
+use Adyen\Payment\Helper\Requests;
+use Adyen\Payment\Logger\AdyenLogger;
+use Adyen\Service\Modification;
+use Magento\Payment\Gateway\Http\ClientInterface;
+use Magento\Payment\Gateway\Http\TransferInterface;
+
+/**
+ * Class TransactionSale
+ */
+class TransactionMotoCapture implements ClientInterface
+{
+    const MULTIPLE_AUTHORIZATIONS = 'multiple_authorizations';
+    const FORMATTED_CAPTURE_AMOUNT = 'formatted_capture_amount';
+    const CAPTURE_AMOUNT = 'capture_amount';
+    const ORIGINAL_REFERENCE = 'original_reference';
+    const CAPTURE_RECEIVED = '[capture-received]';
+
+    /**
+     * @var Data
+     */
+    private $adyenHelper;
+
+    /**
+     * @var AdyenLogger
+     */
+    private $adyenLogger;
+
+    /**
+     * PaymentRequest constructor.
+     * @param Data $adyenHelper
+     * @param AdyenLogger $adyenLogger
+     */
+    public function __construct(
+        Data $adyenHelper,
+        AdyenLogger $adyenLogger
+    ) {
+        $this->adyenHelper = $adyenHelper;
+        $this->adyenLogger = $adyenLogger;
+    }
+
+    /**
+     * @param TransferInterface $transferObject
+     * @return null
+     * @throws AdyenException
+     */
+    public function placeRequest(TransferInterface $transferObject)
+    {
+        $request = $transferObject->getBody();
+
+        $client = $this->adyenHelper->initializeAdyenMotoClient($request['merchantAccount']);
+        $service = new Modification($client);
+
+        if (array_key_exists(self::MULTIPLE_AUTHORIZATIONS, $request)) {
+            return $this->placeMultipleCaptureRequests($service, $request);
+        }
+
+        try {
+            $response = $service->capture($request);
+            $response = $this->copyParamsToResponse($response, $request);
+        } catch (AdyenException $e) {
+            $response['error'] = $e->getMessage();
+        }
+
+        return $response;
+    }
+
+    /**
+     * @param Modification $service
+     * @param $requestContainer
+     * @return array
+     */
+    private function placeMultipleCaptureRequests(Modification $service, $requestContainer)
+    {
+        $response = [];
+        foreach ($requestContainer[self::MULTIPLE_AUTHORIZATIONS] as $request) {
+            try {
+                // Copy merchant account from parent array to every request array
+                $request[Requests::MERCHANT_ACCOUNT] = $requestContainer[Requests::MERCHANT_ACCOUNT];
+                $singleResponse = $service->capture($request);
+                $singleResponse[self::FORMATTED_CAPTURE_AMOUNT] = $request['modificationAmount']['currency'] . ' ' .
+                $this->adyenHelper->originalAmount(
+                    $request['modificationAmount']['value'],
+                    $request['modificationAmount']['currency']
+                );
+                $singleResponse = $this->copyParamsToResponse($singleResponse, $request);
+                $response[self::MULTIPLE_AUTHORIZATIONS][] = $singleResponse;
+            } catch (AdyenException $e) {
+                $message = sprintf(
+                    'Exception occurred when attempting to capture multiple authorizations.
+                    Authorization with pspReference %s: %s',
+                    $request[OrderPaymentInterface::PSPREFRENCE],
+                    $e->getMessage()
+                );
+
+                $this->adyenLogger->error($message);
+                $response[self::MULTIPLE_AUTHORIZATIONS]['error'] = $message;
+            }
+        }
+
+        return $response;
+    }
+
+    /**
+     * Copy data from the request to the response. This data will be used later when handling the response
+     *
+     * @param array $response
+     * @param array $request
+     * @return array
+     */
+    private function copyParamsToResponse(array $response, array $request): array
+    {
+        $response[self::CAPTURE_AMOUNT] = $request['modificationAmount']['value'];
+        $response[self::ORIGINAL_REFERENCE] = $request['originalReference'];
+
+        return $response;
+    }
+}

--- a/Gateway/Http/Client/TransactionMotoRefund.php
+++ b/Gateway/Http/Client/TransactionMotoRefund.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2022 Adyen N.V. (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\Payment\Gateway\Http\Client;
+
+use Magento\Payment\Gateway\Http\ClientInterface;
+
+/**
+ * Class TransactionSale
+ */
+class TransactionMotoRefund implements ClientInterface
+{
+    /**
+     * @var \Adyen\Payment\Helper\Data
+     */
+    private $adyenHelper;
+
+    /**
+     * PaymentRequest constructor.
+     * @param \Adyen\Payment\Helper\Data $adyenHelper
+     */
+    public function __construct(
+        \Adyen\Payment\Helper\Data $adyenHelper
+    ) {
+        $this->adyenHelper = $adyenHelper;
+    }
+
+    /**
+     * @param \Magento\Payment\Gateway\Http\TransferInterface $transferObject
+     * @return null
+     */
+    public function placeRequest(\Magento\Payment\Gateway\Http\TransferInterface $transferObject)
+    {
+        $requests = $transferObject->getBody();
+        $responses = [];
+
+        foreach ($requests as $request) {
+            // call lib
+
+            $client = $this->adyenHelper->initializeAdyenMotoClient($request['merchantAccount']);
+            $service = new \Adyen\Service\Modification($client);
+            try {
+                $responses[] = $service->refund($request);
+            } catch (\Adyen\AdyenException $e) {
+                $responses[] = ['error' => $e->getMessage()];
+            }
+        }
+        return $responses;
+    }
+}

--- a/Gateway/Request/MotoRefundDataBuilder.php
+++ b/Gateway/Request/MotoRefundDataBuilder.php
@@ -1,0 +1,269 @@
+<?php
+/**
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2022 Adyen N.V. (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\Payment\Gateway\Request;
+
+use Adyen\Payment\Helper\ChargedCurrency;
+use Magento\Payment\Gateway\Request\BuilderInterface;
+
+/**
+ * Class CustomerDataBuilder
+ */
+class MotoRefundDataBuilder implements BuilderInterface
+{
+    /**
+     * @var \Adyen\Payment\Helper\Data
+     */
+    private $adyenHelper;
+
+    /**
+     * @var \Adyen\Payment\Model\ResourceModel\Order\Payment\CollectionFactory
+     */
+    private $orderPaymentCollectionFactory;
+
+    /**
+     * @var \Adyen\Payment\Model\ResourceModel\Invoice\CollectionFactory
+     */
+    protected $adyenInvoiceCollectionFactory;
+
+    /**
+     * @var ChargedCurrency
+     */
+    private $chargedCurrency;
+
+    /**
+     * RefundDataBuilder constructor.
+     *
+     * @param \Adyen\Payment\Helper\Data $adyenHelper
+     * @param \Adyen\Payment\Model\ResourceModel\Order\Payment\CollectionFactory $orderPaymentCollectionFactory
+     * @param ChargedCurrency $chargedCurrency
+     */
+    public function __construct(
+        \Adyen\Payment\Helper\Data $adyenHelper,
+        \Adyen\Payment\Model\ResourceModel\Order\Payment\CollectionFactory $orderPaymentCollectionFactory,
+        \Adyen\Payment\Model\ResourceModel\Invoice\CollectionFactory $adyenInvoiceCollectionFactory,
+        ChargedCurrency $chargedCurrency
+    ) {
+        $this->adyenHelper = $adyenHelper;
+        $this->orderPaymentCollectionFactory = $orderPaymentCollectionFactory;
+        $this->adyenInvoiceCollectionFactory = $adyenInvoiceCollectionFactory;
+        $this->chargedCurrency = $chargedCurrency;
+    }
+
+    /**
+     * @param array $buildSubject
+     * @return array
+     */
+    public function build(array $buildSubject)
+    {
+        /** @var \Magento\Payment\Gateway\Data\PaymentDataObject $paymentDataObject */
+        $paymentDataObject = \Magento\Payment\Gateway\Helper\SubjectReader::readPayment($buildSubject);
+
+        $order = $paymentDataObject->getOrder();
+        $payment = $paymentDataObject->getPayment();
+        $orderAmountCurrency = $this->chargedCurrency->getOrderAmountCurrency($payment->getOrder(), false);
+
+        // Construct AdyenAmountCurrency from creditmemo
+        $creditMemo = $payment->getCreditMemo();
+        $creditMemoAmountCurrency = $this->chargedCurrency->getCreditMemoAmountCurrency($creditMemo, false);
+
+        $pspReference = $payment->getCcTransId();
+        $currency = $creditMemoAmountCurrency->getCurrencyCode();
+        $amount = $creditMemoAmountCurrency->getAmount();
+        $storeId = $order->getStoreId();
+        $method = $payment->getMethod();
+        $merchantAccount = $payment->getAdditionalInformation('motoMerchantAccount');
+
+        // check if it contains a partial payment
+        $orderPaymentCollection = $this->orderPaymentCollectionFactory
+            ->create()
+            ->addFieldToFilter('payment_id', $payment->getId());
+
+        // partial refund if multiple payments check refund strategy
+        if ($orderPaymentCollection->getSize() > 1) {
+            $refundStrategy = $this->adyenHelper->getAdyenAbstractConfigData(
+                'partial_payments_refund_strategy',
+                $order->getStoreId()
+            );
+            $ratio = null;
+
+            if ($refundStrategy == "1") {
+                // Refund in ascending order
+                $orderPaymentCollection->addPaymentFilterAscending($payment->getId());
+            } elseif ($refundStrategy == "2") {
+                // Refund in descending order
+                $orderPaymentCollection->addPaymentFilterDescending($payment->getId());
+            } elseif ($refundStrategy == "3") {
+                // refund based on ratio
+                $ratio = $amount / $orderAmountCurrency->getAmount();
+                $orderPaymentCollection->addPaymentFilterAscending($payment->getId());
+            }
+
+            // loop over payment methods and refund them all
+            $requestBody = [];
+            foreach ($orderPaymentCollection as $partialPayment) {
+                // could be that not all the partial payments need a refund
+                if ($amount > 0) {
+                    if ($ratio) {
+                        // refund based on ratio calculate refund amount
+                        $modificationAmount = $ratio * (
+                                $partialPayment->getAmount() - $partialPayment->getTotalRefunded()
+                            );
+                    } else {
+                        // total authorised amount of the partial payment
+                        $partialPaymentAmount = $partialPayment->getAmount() - $partialPayment->getTotalRefunded();
+
+                        // if rest amount is zero go to next payment
+                        if (!$partialPaymentAmount > 0) {
+                            continue;
+                        }
+
+                        // if refunded amount is greater than partial payment amount do a full refund
+                        if ($amount >= $partialPaymentAmount) {
+                            $modificationAmount = $partialPaymentAmount;
+                        } else {
+                            $modificationAmount = $amount;
+                        }
+                        // update amount with rest of the available amount
+                        $amount = $amount - $partialPaymentAmount;
+                    }
+
+                    $modificationAmountObject = [
+                        'currency' => $currency,
+                        'value' => $this->adyenHelper->formatAmount($modificationAmount, $currency)
+                    ];
+
+                    $requestBody[] = [
+                        "modificationAmount" => $modificationAmountObject,
+                        "reference" => $payment->getOrder()->getIncrementId(),
+                        "originalReference" => $partialPayment->getPspreference(),
+                        "merchantAccount" => $merchantAccount
+                    ];
+                }
+            }
+        } else {
+            //format the amount to minor units
+            $amount = $this->adyenHelper->formatAmount($amount, $currency);
+            $modificationAmount = ['currency' => $currency, 'value' => $amount];
+
+            $requestBody = [
+                [
+                    "modificationAmount" => $modificationAmount,
+                    "reference" => $payment->getOrder()->getIncrementId(),
+                    "originalReference" => $pspReference,
+                    "merchantAccount" => $merchantAccount
+                ]
+            ];
+
+            $brandCode = $payment->getAdditionalInformation(
+                \Adyen\Payment\Observer\AdyenHppDataAssignObserver::BRAND_CODE
+            );
+
+            if ($this->adyenHelper->isPaymentMethodOpenInvoiceMethod($brandCode)) {
+                $openInvoiceFields = $this->getOpenInvoiceData($payment);
+
+                //There is only one payment, so we add the fields to the first(and only) result
+                $requestBody[0]["additionalData"] = $openInvoiceFields;
+            }
+        }
+        $request['clientConfig'] = ["storeId" => $payment->getOrder()->getStoreId()];
+        $request['body'] = $requestBody;
+        return $request;
+    }
+
+    /**
+     * @param \Magento\Payment\Model\InfoInterface $payment
+     * @return array|mixed
+     */
+    protected function getOpenInvoiceData($payment)
+    {
+        $formFields = [];
+        $count = 0;
+
+        // Construct AdyenAmountCurrency from creditmemo
+        /**
+         * @var \Magento\Sales\Model\Order\Creditmemo $creditMemo
+         */
+        $creditMemo = $payment->getCreditMemo();
+
+        foreach ($creditMemo->getItems() as $refundItem) {
+            $numberOfItems = (int)$refundItem->getQty();
+            if ($numberOfItems == 0) {
+                continue;
+            }
+
+            ++$count;
+            $itemAmountCurrency = $this->chargedCurrency->getCreditMemoItemAmountCurrency($refundItem);
+
+            $formFields = $this->adyenHelper->createOpenInvoiceLineItem(
+                $formFields,
+                $count,
+                $refundItem->getName(),
+                $itemAmountCurrency->getAmount(),
+                $itemAmountCurrency->getCurrencyCode(),
+                $itemAmountCurrency->getTaxAmount(),
+                $itemAmountCurrency->getAmount() + $itemAmountCurrency->getTaxAmount(),
+                $refundItem->getOrderItem()->getTaxPercent(),
+                $numberOfItems,
+                $payment,
+                $refundItem->getId()
+            );
+        }
+
+        // Shipping cost
+        $shippingAmountCurrency = $this->chargedCurrency->getCreditMemoShippingAmountCurrency($creditMemo);
+        if ($shippingAmountCurrency->getAmount() > 0) {
+            ++$count;
+            $formFields = $this->adyenHelper->createOpenInvoiceLineShipping(
+                $formFields,
+                $count,
+                $payment->getOrder(),
+                $shippingAmountCurrency->getAmount(),
+                $shippingAmountCurrency->getTaxAmount(),
+                $shippingAmountCurrency->getCurrencyCode(),
+                $payment
+            );
+        }
+
+        // Adjustment
+        $adjustmentAmountCurrency = $this->chargedCurrency->getCreditMemoAdjustmentAmountCurrency($creditMemo);
+        if ($adjustmentAmountCurrency->getAmount() != 0) {
+            $positive = $adjustmentAmountCurrency->getAmount() > 0 ? 'Positive' : '';
+            $negative = $adjustmentAmountCurrency->getAmount() < 0 ? 'Negative' : '';
+            $description = "Adjustment - " . implode(' | ', array_filter([$positive, $negative]));
+
+            ++$count;
+            $formFields = $this->adyenHelper->createOpenInvoiceLineAdjustment(
+                $formFields,
+                $count,
+                $description,
+                $adjustmentAmountCurrency->getAmount(),
+                $adjustmentAmountCurrency->getCurrencyCode(),
+                $payment
+            );
+        }
+
+        $formFields['openinvoicedata.numberOfLines'] = $count;
+
+        //Retrieve acquirerReference from the adyen_invoice
+        $invoiceId = $creditMemo->getInvoice()->getId();
+        $invoices = $this->adyenInvoiceCollectionFactory->create()
+            ->addFieldToFilter('invoice_id', $invoiceId);
+
+        $invoice = $invoices->getFirstItem();
+
+        if ($invoice) {
+            $formFields['acquirerReference'] = $invoice->getAcquirerReference();
+        }
+
+        return $formFields;
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -286,10 +286,10 @@
         <arguments>
             <argument name="commands" xsi:type="array">
                 <item name="authorize" xsi:type="string">AdyenPaymentMotoAuthorizeCommand</item>
-                <item name="capture" xsi:type="string">AdyenPaymentCaptureCommand</item>
-                <item name="void" xsi:type="string">AdyenPaymentCancelCommand</item>
-                <item name="refund" xsi:type="string">AdyenPaymentRefundCommand</item>
-                <item name="cancel" xsi:type="string">AdyenPaymentCancelCommand</item>
+                <item name="capture" xsi:type="string">AdyenPaymentMotoCaptureCommand</item>
+                <item name="void" xsi:type="string">AdyenPaymentMotoCancelCommand</item>
+                <item name="refund" xsi:type="string">AdyenPaymentMotoRefundCommand</item>
+                <item name="cancel" xsi:type="string">AdyenPaymentMotoCancelCommand</item>
                 <item name="vault_authorize" xsi:type="string">AdyenPaymentCcVaultAuthorizeCommand</item>
             </argument>
         </arguments>
@@ -469,6 +469,15 @@
             <argument name="handler" xsi:type="object">AdyenPaymentCaptureResponseHandlerComposite</argument>
         </arguments>
     </virtualType>
+    <virtualType name="AdyenPaymentMotoCaptureCommand" type="Magento\Payment\Gateway\Command\GatewayCommand">
+        <arguments>
+            <argument name="requestBuilder" xsi:type="object">AdyenPaymentMotoCaptureRequest</argument>
+            <argument name="transferFactory" xsi:type="object">Adyen\Payment\Gateway\Http\TransferFactory</argument>
+            <argument name="client" xsi:type="object">Adyen\Payment\Gateway\Http\Client\TransactionMotoCapture</argument>
+            <argument name="validator" xsi:type="object">Adyen\Payment\Gateway\Validator\CaptureResponseValidator</argument>
+            <argument name="handler" xsi:type="object">AdyenPaymentCaptureResponseHandlerComposite</argument>
+        </arguments>
+    </virtualType>
     <!--Refund command-->
     <virtualType name="AdyenPaymentRefundCommand" type="Magento\Payment\Gateway\Command\GatewayCommand">
         <arguments>
@@ -480,11 +489,31 @@
         </arguments>
     </virtualType>
 
+    <virtualType name="AdyenPaymentMotoRefundCommand" type="Magento\Payment\Gateway\Command\GatewayCommand">
+        <arguments>
+            <argument name="requestBuilder" xsi:type="object">AdyenPaymentMotoRefundRequest</argument>
+            <argument name="transferFactory" xsi:type="object">Adyen\Payment\Gateway\Http\TransferFactory</argument>
+            <argument name="client" xsi:type="object">Adyen\Payment\Gateway\Http\Client\TransactionMotoRefund</argument>
+            <argument name="validator" xsi:type="object">Adyen\Payment\Gateway\Validator\RefundResponseValidator</argument>
+            <argument name="handler" xsi:type="object">AdyenPaymentRefundResponseHandlerComposite</argument>
+        </arguments>
+    </virtualType>
+
     <virtualType name="AdyenPaymentCancelCommand" type="Magento\Payment\Gateway\Command\GatewayCommand">
         <arguments>
             <argument name="requestBuilder" xsi:type="object">AdyenPaymentCancelRequest</argument>
             <argument name="transferFactory" xsi:type="object">Adyen\Payment\Gateway\Http\TransferFactory</argument>
             <argument name="client" xsi:type="object">Adyen\Payment\Gateway\Http\Client\TransactionCancel</argument>
+            <argument name="validator" xsi:type="object">Adyen\Payment\Gateway\Validator\CancelResponseValidator</argument>
+            <argument name="handler" xsi:type="object">AdyenPaymentCancelResponseHandlerComposite</argument>
+        </arguments>
+    </virtualType>
+
+    <virtualType name="AdyenPaymentMotoCancelCommand" type="Magento\Payment\Gateway\Command\GatewayCommand">
+        <arguments>
+            <argument name="requestBuilder" xsi:type="object">AdyenPaymentMotoCancelRequest</argument>
+            <argument name="transferFactory" xsi:type="object">Adyen\Payment\Gateway\Http\TransferFactory</argument>
+            <argument name="client" xsi:type="object">Adyen\Payment\Gateway\Http\Client\TransactionMotoCancel</argument>
             <argument name="validator" xsi:type="object">Adyen\Payment\Gateway\Validator\CancelResponseValidator</argument>
             <argument name="handler" xsi:type="object">AdyenPaymentCancelResponseHandlerComposite</argument>
         </arguments>
@@ -678,12 +707,26 @@
             </argument>
         </arguments>
     </virtualType>
+    <virtualType name="AdyenPaymentMotoCaptureRequest" type="Magento\Payment\Gateway\Request\BuilderComposite">
+        <arguments>
+            <argument name="builders" xsi:type="array">
+                <item name="merchantaccount" xsi:type="string">Adyen\Payment\Gateway\Request\MotoMerchantAccountDataBuilder</item>
+                <item name="capture" xsi:type="string">Adyen\Payment\Gateway\Request\CaptureDataBuilder</item>
+            </argument>
+        </arguments>
+    </virtualType>
     <!-- Refund Request -->
     <virtualType name="AdyenPaymentRefundRequest" type="Magento\Payment\Gateway\Request\BuilderComposite">
         <arguments>
             <argument name="builders" xsi:type="array">
-                <!--<item name="merchantaccount" xsi:type="string">Adyen\Payment\Gateway\Request\MerchantAccountDataBuilder</item>-->
                 <item name="refund" xsi:type="string">Adyen\Payment\Gateway\Request\RefundDataBuilder</item>
+            </argument>
+        </arguments>
+    </virtualType>
+    <virtualType name="AdyenPaymentMotoRefundRequest" type="Magento\Payment\Gateway\Request\BuilderComposite">
+        <arguments>
+            <argument name="builders" xsi:type="array">
+                <item name="refund" xsi:type="string">Adyen\Payment\Gateway\Request\MotoRefundDataBuilder</item>
             </argument>
         </arguments>
     </virtualType>
@@ -692,6 +735,15 @@
         <arguments>
             <argument name="builders" xsi:type="array">
                 <item name="merchantaccount" xsi:type="string">Adyen\Payment\Gateway\Request\MerchantAccountDataBuilder</item>
+                <item name="cancel" xsi:type="string">Adyen\Payment\Gateway\Request\CancelDataBuilder</item>
+            </argument>
+        </arguments>
+    </virtualType>
+
+    <virtualType name="AdyenPaymentMotoCancelRequest" type="Magento\Payment\Gateway\Request\BuilderComposite">
+        <arguments>
+            <argument name="builders" xsi:type="array">
+                <item name="merchantaccount" xsi:type="string">Adyen\Payment\Gateway\Request\MotoMerchantAccountDataBuilder</item>
                 <item name="cancel" xsi:type="string">Adyen\Payment\Gateway\Request\CancelDataBuilder</item>
             </argument>
         </arguments>


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Since MOTO is using different merchant account, it is required to create separate commands for capture, cancel, refund and void.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

**Fixed issue**:  <!-- #-prefixed issue number -->