### PR TITLE
[PW-6922] Add PayByLink support for headless integration

### DIFF
--- a/Gateway/Request/ExpiryDateDataBuilder.php
+++ b/Gateway/Request/ExpiryDateDataBuilder.php
@@ -40,13 +40,25 @@ class ExpiryDateDataBuilder implements BuilderInterface
     public function build(array $buildSubject)
     {
         $paymentFormFields = $this->request->getParam('payment');
-        $expiryDate = date_create_from_format(
-            AdyenPayByLinkConfigProvider::DATE_TIME_FORMAT,
-            $paymentFormFields["adyen_pbl_expires_at"] . ' 23:59:59'
-        );
+        $expiryDate = null;
+        $payment = $buildSubject['payment']->getPayment()->getAdditionalInformation()['adyen_pbl_expires_at'];
 
-        $request['body']['expiresAt'] = $expiryDate->format(DATE_ATOM);
+        if (!is_null($paymentFormFields) && isset($paymentFormFields["adyen_pbl_expires_at"])) {
+            $expiryDate = $paymentFormFields["adyen_pbl_expires_at"];
+        }
+        elseif (isset($payment)) {
+            $expiryDate = $payment;
+        }
 
-        return $request;
+        if ($expiryDate) {
+            $expiryDateTime = date_create_from_format(
+                AdyenPayByLinkConfigProvider::DATE_TIME_FORMAT,
+                $expiryDate . ' 23:59:59'
+            );
+
+            $request['body']['expiresAt'] = $expiryDateTime->format(DATE_ATOM);
+
+            return $request;
+        }
     }
 }

--- a/Gateway/Request/ExpiryDateDataBuilder.php
+++ b/Gateway/Request/ExpiryDateDataBuilder.php
@@ -12,6 +12,7 @@
 namespace Adyen\Payment\Gateway\Request;
 
 use Adyen\Payment\Model\Ui\AdyenPayByLinkConfigProvider;
+use Adyen\Payment\Observer\AdyenPayByLinkDataAssignObserver;
 use Magento\Framework\App\RequestInterface;
 use Magento\Payment\Gateway\Request\BuilderInterface;
 
@@ -41,10 +42,10 @@ class ExpiryDateDataBuilder implements BuilderInterface
     {
         $paymentFormFields = $this->request->getParam('payment');
         $expiryDate = null;
-        $payment = $buildSubject['payment']->getPayment()->getAdditionalInformation()['adyen_pbl_expires_at'];
+        $payment = $buildSubject['payment']->getPayment()->getAdditionalInformation()[AdyenPayByLinkDataAssignObserver::PBL_EXPIRY_DATE];
 
-        if (!is_null($paymentFormFields) && isset($paymentFormFields["adyen_pbl_expires_at"])) {
-            $expiryDate = $paymentFormFields["adyen_pbl_expires_at"];
+        if (!is_null($paymentFormFields) && isset($paymentFormFields[AdyenPayByLinkDataAssignObserver::PBL_EXPIRY_DATE])) {
+            $expiryDate = $paymentFormFields[AdyenPayByLinkDataAssignObserver::PBL_EXPIRY_DATE];
         }
         elseif (isset($payment)) {
             $expiryDate = $payment;

--- a/Model/Api/AdyenOrderPaymentStatus.php
+++ b/Model/Api/AdyenOrderPaymentStatus.php
@@ -79,6 +79,11 @@ class AdyenOrderPaymentStatus implements AdyenOrderPaymentStatusInterface
         $payment = $order->getPayment();
         $additionalInformation = $payment->getAdditionalInformation();
 
+        if(!empty($additionalInformation['payByLinkUrl'])) {
+            $result['paymentLink'] = $additionalInformation['payByLinkUrl'];
+            return json_encode($result);
+        }
+
         if (empty($additionalInformation['resultCode'])) {
             $this->adyenLogger->info('resultCode is empty in the payment\'s additional information');
             return json_encode(

--- a/Observer/AdyenPayByLinkDataAssignObserver.php
+++ b/Observer/AdyenPayByLinkDataAssignObserver.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2022 Adyen NV (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\Payment\Observer;
+
+use Adyen\Service\Validator\DataArrayValidator;
+use Magento\Framework\Event\Observer;
+use Magento\Payment\Observer\AbstractDataAssignObserver;
+use Magento\Quote\Api\Data\PaymentInterface;
+
+class AdyenPayByLinkDataAssignObserver extends AbstractDataAssignObserver
+{
+    const PBL_EXPIRY_DATE = 'adyen_pbl_expires_at';
+
+    /**
+     * Approved root level keys from additional data array
+     *
+     * @var array
+     */
+    private static $approvedAdditionalDataKeys = [
+        self::PBL_EXPIRY_DATE
+    ];
+
+    /**
+     * @param Observer $observer
+     * @return void
+     */
+    public function execute(Observer $observer)
+    {
+        // Get request fields
+        $data = $this->readDataArgument($observer);
+        $paymentInfo = $this->readPaymentModelArgument($observer);
+
+        // Get additional data array
+        $additionalData = $data->getData(PaymentInterface::KEY_ADDITIONAL_DATA);
+        if (!is_array($additionalData)) {
+            return;
+        }
+
+        // Get a validated additional data array
+        $additionalData = DataArrayValidator::getArrayOnlyWithApprovedKeys(
+            $additionalData,
+            self::$approvedAdditionalDataKeys
+        );
+
+        // Set additional data in the payment
+        foreach ($additionalData as $key => $data) {
+            $paymentInfo->setAdditionalInformation($key, $data);
+        }
+    }
+}

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -139,7 +139,7 @@
                 <days_to_expire>1</days_to_expire>
                 <payment_action>order</payment_action>
                 <is_gateway>1</is_gateway>
-                <can_use_checkout>0</can_use_checkout>
+                <can_use_checkout>1</can_use_checkout>
                 <can_initialize>1</can_initialize>
                 <can_capture>1</can_capture>
                 <can_capture_partial>1</can_capture_partial>

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -20,6 +20,9 @@
     <event name="payment_method_assign_data_adyen_hpp">
         <observer name="adyen_hpp_gateway_data_assign" instance="Adyen\Payment\Observer\AdyenHppDataAssignObserver" />
     </event>
+    <event name="payment_method_assign_data_adyen_pay_by_link">
+        <observer name="adyen_pay_by_link_gateway_data_assign" instance="Adyen\Payment\Observer\AdyenPayByLinkDataAssignObserver" />
+    </event>
     <event name="payment_method_assign_data_adyen_pos_cloud">
         <observer name="adyen_pos_cloud_gateway_data_assign" instance="Adyen\Payment\Observer\AdyenPosCloudDataAssignObserver" />
     </event>


### PR DESCRIPTION
**Description**
This PR is adding PBL as a supported payment method for the headless integration. In this solution, a new custom event is added that has a new observer assigned to it. The observer is setting the expiry date in the payment. `AdyenOrderPaymentStatus` model is modified so it can handle adding the payment link to payment's additional information. `ExpiryDateDataBuilder` is modified so it can fetch the expiry date from the request when there is no `stateData`.

**Tested scenarios**
* Place an order by sending the request to `/V1/carts/mine/payment-information` endpoint with `adyen_pay_by_link` as a payment method
* Make a POST request to the `/V1/adyen/orders/payment-status` endpoint. In the body, use `orderId that was received in the response from the `/payment-information endpoint` in the previous step. Make sure that `paymentLink` is received the the response.