### PR TITLE
Fix typing issue as requiresManualReview expects an array

### DIFF
--- a/Helper/Webhook/AuthorisationWebhookHandler.php
+++ b/Helper/Webhook/AuthorisationWebhookHandler.php
@@ -119,7 +119,7 @@ class AuthorisationWebhookHandler implements WebhookHandlerInterface
             $order = $this->orderHelper->setPrePaymentAuthorized($order);
             $this->orderHelper->updatePaymentDetails($order, $notification);
 
-            $additionalData = !empty($notification->getAdditionalData()) ? $this->serializer->unserialize($notification->getAdditionalData()) : "";
+            $additionalData = !empty($notification->getAdditionalData()) ? $this->serializer->unserialize($notification->getAdditionalData()) : [];
             $requireFraudManualReview = $this->caseManagementHelper->requiresManualReview($additionalData);
 
             if ($isAutoCapture) {


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
In the following commit additional data on the notification model was introduced.
https://github.com/Adyen/adyen-magento2/commit/121969c342157855c4374ef1c18b1abe361d875f

However the ternary statement is not correct as it fall backs to an empty string, but the `requiresManualReview` is type hinted as `array`, which obviously will cause a fatal PHP error.
`Adyen\Payment\Helper\CaseManagement::requiresManualReview(): Argument #1 ($additionalData) must be of type array, string given`

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

**Fixed issue**:  <!-- #-prefixed issue number -->