### PR TITLE
[PW-6949] Include event codes when creating webhooks

### DIFF
--- a/Helper/ManagementHelper.php
+++ b/Helper/ManagementHelper.php
@@ -137,8 +137,6 @@ class ManagementHelper
                     'includeEventCodes' => [
                         'AUTHORISATION',
                         'PENDING',
-                        'AUTHORISED',
-                        'CANCELLED',
                         'REFUND',
                         'REFUND_FAILED',
                         'CANCEL_OR_REFUND',

--- a/Helper/ManagementHelper.php
+++ b/Helper/ManagementHelper.php
@@ -132,6 +132,28 @@ class ManagementHelper
             'password' => $password,
             'communicationFormat' => 'json',
             'active' => true,
+            'additionalSettings' =>
+                [
+                    'includeEventCodes' => [
+                        'AUTHORISATION',
+                        'PENDING',
+                        'AUTHORISED',
+                        'CANCELLED',
+                        'REFUND',
+                        'REFUND_FAILED',
+                        'CANCEL_OR_REFUND',
+                        'CAPTURE',
+                        'CAPTURE_FAILED',
+                        'CANCELLATION',
+                        'HANDLED_EXTERNALLY',
+                        'MANUAL_REVIEW_ACCEPT',
+                        'MANUAL_REVIEW_REJECT',
+                        "RECURRING_CONTRACT",
+                        "REPORT_AVAILABLE",
+                        "ORDER_CLOSED",
+                        "OFFER_CLOSED"
+                    ]
+                ]
         ];
         $webhookId = $this->configHelper->getWebhookId($storeId);
         if (!empty($webhookId)) {


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
The API endpoint for creating webhooks provides the includeEventCodes parameter for specifying which notifications should be applied.
In the webhook creation logic we add this parameter with a list of all event codes that we process in magento.


**Tested scenarios**
Create a webhook
