### PR TITLE
[PW-6981] Validate AfterPay gender field as required

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/adyen-hpp-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-hpp-method.js
@@ -637,7 +637,7 @@ define(
                     } else if (gender == 2) {
                         return 'FEMALE';
                     }
-                    return 'UNKNOWN';
+                    return null;
 
                 }
 


### PR DESCRIPTION
**Description**
Gender field of AfterPay component is not required, although it should be as this is a requirement on AfterPay side. This solution is changing the return value of the `getAdyenGender()` function. It now returns `null` if the field is not selected rather than a string `"UNKNOWN"`. This way, if the gender is not selected, the value of the `component.state.isValid` is `false`. When we were returning the value `"UNKNOWN"`, the `component.state.isValid` was returning `true` even when the gender was not selected, as the value (string) was returned in the `getAdyenGender()` function.

With this solution, it is not possible to place an order with AfterPay before selecting a gender.

**Tested scenarios**
- tried to place an order selecting AfterPay payment method without selecting gender, made sure the `Place order` button was not active
- observed whether the button would become active upon passing the gender along with the date of birth - confirmed

**Fixed issue**:  #1624 