### PR TITLE
[PW-6911] - Resolve incompatibility with Magento 2.3.x

### DIFF
--- a/view/frontend/templates/checkout/success.phtml
+++ b/view/frontend/templates/checkout/success.phtml
@@ -18,9 +18,7 @@
     require(['Magento_Customer/js/customer-data'], function (customerData) {
         'use strict';
 
-        customerData.getInitCustomerData().done(function () {
-            customerData.reload(['cart'], true);
-        });
+        customerData.reload(['cart'], true);
     });
 </script>
 <?php if ($block->renderAction()): ?>
@@ -115,4 +113,3 @@
 </script>
 <div id='donation-container'></div>
 <?php endif; ?>
-

--- a/view/frontend/templates/checkout/success.phtml
+++ b/view/frontend/templates/checkout/success.phtml
@@ -113,3 +113,4 @@
 </script>
 <div id='donation-container'></div>
 <?php endif; ?>
+

--- a/view/frontend/templates/checkout/success.phtml
+++ b/view/frontend/templates/checkout/success.phtml
@@ -113,4 +113,3 @@
 </script>
 <div id='donation-container'></div>
 <?php endif; ?>
-


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
`getInitCustomerData()` function called on `success` page does not exist in Magento 2.3.x versions. Remove that additional check for existence of the customer information and reload cart directly.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

**Fixed issue**:  <!-- #-prefixed issue number --> Closes #1615