### PR TITLE
fix for #1632

### DIFF
--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -257,6 +257,9 @@ class Order extends AbstractHelper
             // Else add comment
             if (!empty($status) && $maintainingState) {
                 $order->addStatusHistoryComment(__($comment), $status);
+                if (strcmp($order->getState(), MagentoOrder::STATE_NEW) == 0 || strcmp($order->getState(), MagentoOrder::STATE_PENDING_PAYMENT) == 0) {
+                    $order->setState(MagentoOrder::STATE_PROCESSING);
+                }
                 $this->adyenLogger->addAdyenNotificationCronjob(
                     'Maintaining current status: ' . $status,
                     $this->adyenLogger->getOrderContext($order)


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->

This is a fix for [PW-7006] Orders Stuck in a processing status after being completely invoiced and shipped #1632. Overall the logic in the Helper/Order.php file should really be revisited.  The main issue arises from updating order state in various scenarios that overall should be avoided if possible, mainly due the inability of admin users to edit order state via the admin if any issues arise.  But essentially the source of this issue is that in a happy path of an order workflow, the order state is either kept in new or pending_payment (both scenarios the order on the adyen and magento side has been successfully authorized and payment captured), changing the order state to processing actually fixes this issue in both of those scenarios and magento then properly completes the order when all items are invoiced and shipped.

**Tested scenarios**

Tested order authorized invoiced and shipped all the way through

**Fixed issue**:  #1632 

Fixes issues where orders are stuck in a processing or new status when they should be complete.