### PR TITLE
[PW-6860] Order cancelled in Magento and status:Settled in Adyen CA

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/adyen-cc-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-cc-method.js
@@ -312,6 +312,7 @@ define(
 
                 var self = this;
 
+                $(this.modalLabel + ' .action-close').hide();
                 var request = result.data;
                 request.orderId = self.orderId;
 

--- a/view/frontend/web/js/view/payment/method-renderer/adyen-cc-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-cc-method.js
@@ -309,10 +309,10 @@ define(
                 }
             },
             handleOnAdditionalDetails: function(result) {
+                $('.action-close').hide();
 
                 var self = this;
 
-                $(this.modalLabel + ' .action-close').hide();
                 var request = result.data;
                 request.orderId = self.orderId;
 


### PR DESCRIPTION
**Description**
This PR is addressing the issue of the way we handle the orders that make use of the popup modals in cases of slow internet connectivity on the shopper's end. As of now, we are setting the order to cancelled state in Magento, however the `/payment-details` call is going through to Adyen. This results the orders in Magento being cancelled and at the same time settled in Adyen CA. 
This fix hides the `X` button in the `handleOnAdditionalDetails` function once the `/payment-details` call goes through, so that the shopper can't cancel the order that has already been sent to Adyen. 
**Tested scenarios**
- Place an order with a payment method that initiates the popup modal, enter the password and click `OK`. Make sure that the `X` button is not showing in the top right of the modal.
- Place an order with a payment method that initiates the popup modal, enter the password and click `OK`. Try to cancel the order with pressing `Esc` and make sure that the order is not cancelled in Magento.
-  Place an order with a payment method that initiates the popup modal, enter the password and click `OK`. Try to cancel the order with clicking outside of the popup modal. Make sure that the order is not cancelled in Magento.

**Fixed issue**:  #1588 