### PR TITLE
[PW-6987] [v7] - Set order state to pending_payment in InvoiceObserver

### DIFF
--- a/Helper/PaymentMethods.php
+++ b/Helper/PaymentMethods.php
@@ -24,6 +24,7 @@
 namespace Adyen\Payment\Helper;
 
 use Magento\Framework\App\Helper\AbstractHelper;
+use Magento\Payment\Helper\Data as MagentoDataHelper;
 
 /**
  * @SuppressWarnings(PHPMD.LongVariable)
@@ -33,6 +34,8 @@ class PaymentMethods extends AbstractHelper
     const ADYEN_HPP = 'adyen_hpp';
     const ADYEN_CC = 'adyen_cc';
     const ADYEN_ONE_CLICK = 'adyen_oneclick';
+
+    const ADYEN_PREFIX = 'adyen_';
 
     const METHODS_WITH_BRAND_LOGO = [
         "giftcard"
@@ -52,6 +55,11 @@ class PaymentMethods extends AbstractHelper
      * @var \Adyen\Payment\Helper\Data
      */
     protected $adyenHelper;
+
+    /**
+     * @var MagentoDataHelper
+     */
+    protected $magentoDataHelper;
 
     /**
      * @var \Magento\Framework\Locale\ResolverInterface
@@ -123,7 +131,8 @@ class PaymentMethods extends AbstractHelper
         \Magento\Framework\View\Asset\Source $assetSource,
         \Magento\Framework\View\DesignInterface $design,
         \Magento\Framework\View\Design\Theme\ThemeProviderInterface $themeProvider,
-        ChargedCurrency $chargedCurrency
+        ChargedCurrency $chargedCurrency,
+        MagentoDataHelper $magentoDataHelper
     ) {
         $this->quoteRepository = $quoteRepository;
         $this->config = $config;
@@ -136,6 +145,7 @@ class PaymentMethods extends AbstractHelper
         $this->design = $design;
         $this->themeProvider = $themeProvider;
         $this->chargedCurrency = $chargedCurrency;
+        $this->magentoDataHelper = $magentoDataHelper;
     }
 
     /**
@@ -512,5 +522,29 @@ class PaymentMethods extends AbstractHelper
         ];
 
         return in_array($paymentMethod, $paymentMethodRecurring);
+    }
+
+    public function isAdyenPayment(string $methodCode): bool
+    {
+        return in_array($methodCode, $this->getAdyenPaymentMethods(), true);
+    }
+
+    /**
+     * Returns an array of Adyen payment method codes
+     *
+     */
+    public function getAdyenPaymentMethods(): array
+    {
+        $paymentMethods = $this->magentoDataHelper->getPaymentMethodList();
+
+        $filtered = array_filter(
+            $paymentMethods,
+            function ($key) {
+                return strpos($key, self::ADYEN_PREFIX) === 0;
+            },
+            ARRAY_FILTER_USE_KEY
+        );
+
+        return array_keys($filtered);
     }
 }

--- a/Model/Config/Backend/OrderStatus.php
+++ b/Model/Config/Backend/OrderStatus.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2022 Adyen NV (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\Payment\Model\Config\Backend;
+
+use Adyen\Payment\Helper\PaymentMethods;
+use Magento\Framework\App\Cache\TypeListInterface;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\App\Config\Storage\WriterInterface;
+use Magento\Framework\App\Config\Value;
+use Magento\Framework\Data\Collection\AbstractDb;
+use Magento\Framework\Model\Context;
+use Magento\Framework\Model\ResourceModel\AbstractResource;
+use Magento\Framework\Registry;
+
+class OrderStatus extends Value
+{
+    /**
+     * @var PaymentMethods
+     */
+    protected $paymentMethodsHelper;
+
+    /**
+     * @var WriterInterface
+     */
+    private $configWriter;
+
+    public function __construct(
+        Context $context,
+        Registry $registry,
+        ScopeConfigInterface $config,
+        TypeListInterface $cacheTypeList,
+        AbstractResource $resource = null,
+        AbstractDb $resourceCollection = null,
+        WriterInterface $configWriter,
+        PaymentMethods $paymentMethodsHelper,
+        array $data = []
+    ) {
+        $this->configWriter = $configWriter;
+        $this->paymentMethodsHelper = $paymentMethodsHelper;
+
+        parent::__construct($context, $registry, $config, $cacheTypeList, $resource, $resourceCollection, $data);
+    }
+
+    /**
+     * @return $this|OrderStatus
+     */
+    public function afterSave()
+    {
+        $value = $this->getValue();
+        $adyenPaymentMethods = $this->paymentMethodsHelper->getAdyenPaymentMethods();
+
+        foreach ($adyenPaymentMethods as $adyenPaymentMethod) {
+            $this->configWriter->save(
+                'payment/' . $adyenPaymentMethod . '/order_status',
+                $value,
+            );
+        }
+
+        return $this;
+    }
+}

--- a/Model/Config/Source/PreAuthorized.php
+++ b/Model/Config/Source/PreAuthorized.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2022 Adyen BV (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\Payment\Model\Config\Source;
+
+use Magento\Sales\Model\Config\Source\Order\Status;
+use Magento\Sales\Model\Order;
+
+/**
+ * Order Statuses source model
+ */
+class PreAuthorized extends Status
+{
+    /**
+     * @var string[]
+     */
+    protected $_stateStatuses = [
+        Order::STATE_PENDING_PAYMENT,
+        Order::STATE_NEW
+    ];
+}

--- a/Observer/BeforeShipmentObserver.php
+++ b/Observer/BeforeShipmentObserver.php
@@ -125,7 +125,7 @@ class BeforeShipmentObserver extends AbstractDataAssignObserver
             $pspReference = $order->getPayment()->getAdyenPspReference();
             $invoice->setTransactionId($pspReference);
             $invoice->setRequestedCaptureCase(Invoice::CAPTURE_ONLINE);
-            $invoice->register()->pay();
+            $invoice->register();
             $this->invoiceRepository->save($invoice);
         } catch (Throwable $e) {
             $this->logger->error($e);

--- a/etc/adminhtml/system/adyen_required_settings.xml
+++ b/etc/adminhtml/system/adyen_required_settings.xml
@@ -99,6 +99,7 @@
             <label>Order status: order creation</label>
             <tooltip>Status given to newly created orders before payment result confirmation via server notifications from Adyen.</tooltip>
             <source_model>Magento\Sales\Model\Config\Source\Order\Status\NewStatus</source_model>
+            <backend_model>Adyen\Payment\Model\Config\Backend\OrderStatus</backend_model>
             <config_path>payment/adyen_abstract/order_status</config_path>
         </field>
         <field id="payment_pre_authorized" translate="label" type="select" sortOrder="130" showInDefault="1" showInWebsite="1" showInStore="0">

--- a/etc/adminhtml/system/adyen_required_settings.xml
+++ b/etc/adminhtml/system/adyen_required_settings.xml
@@ -105,7 +105,7 @@
         <field id="payment_pre_authorized" translate="label" type="select" sortOrder="130" showInDefault="1" showInWebsite="1" showInStore="0">
             <label>Order status: payment authorisation</label>
             <tooltip>Status given to orders after authorisation confirmed by an AUTHORISATION notification from Adyen. Note: an authorisation status via the result URL does not yet trigger this status.</tooltip>
-            <source_model>Magento\Sales\Model\Config\Source\Order\Status\Newprocessing</source_model>
+            <source_model>Adyen\Payment\Model\Config\Source\PreAuthorized</source_model>
             <config_path>payment/adyen_abstract/payment_pre_authorized</config_path>
         </field>
         <field id="payment_authorized" translate="label" type="select" sortOrder="140" showInDefault="1" showInWebsite="1" showInStore="0">


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
When manual capture is enabled and an invoice is created, set the order of the status to `pending_payment` instead of `processing`. Also, correctly utilize the `order_status` field, to set the correct status on order creation.

**Tested scenarios**
* Manual capture w/capture on shipment option