### PR TITLE
[PW-7043] Missing separator line bellow CC in checkout page when user has stored payment methods

### DIFF
--- a/view/frontend/web/css/styles.css
+++ b/view/frontend/web/css/styles.css
@@ -12,6 +12,6 @@
     width: auto;
 }
 
-.payment-method:nth-of-type(3) {
+.payment-method+#hpp_actionModalWrapper {
     border-bottom: 1px solid #ccc;
 }


### PR DESCRIPTION
**Description**
Moving the separator line in the checkout page to `#hpp_actionModalWrapper`, so when the stored payment methods are showing, the line shows bellow the credit card.

**Tested scenarios**
- make sure the separator line is showing under the credit card component in the checkout page when there are no stored payment methods
- make sure the separator line is showing under the credit card component in the checkout page when there are stored payment methods