### PR TITLE
[PW-6971] - Upgrade Adyen PHP API Library 13.0.1

### DIFF
--- a/Controller/Process/Result.php
+++ b/Controller/Process/Result.php
@@ -317,7 +317,16 @@ class Result extends \Magento\Framework\App\Action\Action
 
         $this->_adyenLogger->addAdyenResult('Updating the order');
 
-        $paymentMethod = isset($response['paymentMethod']) ? trim($response['paymentMethod']) : '';
+        if (isset($response['paymentMethod']['brand'])) {
+            $paymentMethod = $response['paymentMethod']['brand'];
+        }
+        elseif (isset($response['paymentMethod']['type'])) {
+            $paymentMethod = $response['paymentMethod']['type'];
+        }
+        else {
+            $paymentMethod = '';
+        }
+
         $pspReference = isset($response['pspReference']) ? trim($response['pspReference']) : '';
 
         $type = 'Adyen Result URL response:';

--- a/Gateway/Request/CheckoutDataBuilder.php
+++ b/Gateway/Request/CheckoutDataBuilder.php
@@ -281,7 +281,6 @@ class CheckoutDataBuilder implements BuilderInterface
                 'taxAmount' => $formattedTaxAmount,
                 'description' => $item->getName(),
                 'quantity' => $numberOfItems,
-                'taxCategory' => $item->getProduct()->getAttributeText('tax_class_id'),
                 'taxPercentage' => $formattedTaxPercentage,
                 'productUrl' => $item->getProduct()->getUrlModel()->getUrl($item->getProduct()),
                 'imageUrl' => $this->getImageUrl($item)
@@ -306,7 +305,6 @@ class CheckoutDataBuilder implements BuilderInterface
                 'taxAmount' => $itemVatAmount,
                 'description' => $description,
                 'quantity' => $numberOfItems,
-                'taxCategory' => 'None',
                 'taxPercentage' => $itemVatPercentage
             ];
         }

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     }
   ],
   "require": {
-    "adyen/php-api-library": "^12.0.0",
+    "adyen/php-api-library": "^13.0.1",
     "adyen/php-webhook-module": "^0.6.0",
     "magento/framework": ">=101.0.8 <102 || >=102.0.1",
     "magento/module-vault": "101.*",

--- a/view/frontend/web/css/styles.css
+++ b/view/frontend/web/css/styles.css
@@ -12,6 +12,6 @@
     width: auto;
 }
 
-.payment-method:nth-of-type(3) {
+.payment-method+#hpp_actionModalWrapper {
     border-bottom: 1px solid #ccc;
 }


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
[Adyen PHP API Library](https://github.com/Adyen/adyen-php-api-library) started to use [Checkout API v69](https://docs.adyen.com/api-explorer/#/CheckoutService/v69/overview) with the v13.0.0.

Redirect controller updated due the change in the `/payments` endpoint response and `taxCategory` parameter removed from the line items since API doesn't contain that field anymore.

Following tests completed for the version upgrade.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- [x] Cards payments w/ and wo/ 3DS1-2
- [x] iDeal
- [x] Klarna
- [x] Afterpay
- [x] PayPal
- [x] Google Pay
- [x] SEPA Direct Debit
- [x] Dotpay
- [x] Giftcards w/ & wo/ partial payments
- [x] Adyen Giving
- [x] Recurring payments
- [x] Adyen Pay by Link
- [x] Manual capture, refund, cancel