### PR TITLE
[PW-7036] - Change the method to check open invoice payment method

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -1001,6 +1001,7 @@ class Data extends AbstractHelper
             return false;
         }
 
+        // Those open invoice methods support auto capture.
         if (strpos($paymentMethod, self::AFTERPAY) !== false ||
             strpos($paymentMethod, self::KLARNA) !== false ||
             strpos($paymentMethod, self::RATEPAY) !== false ||

--- a/Helper/PaymentMethods.php
+++ b/Helper/PaymentMethods.php
@@ -645,7 +645,7 @@ class PaymentMethods extends AbstractHelper
 
             // if auto capture mode for openinvoice is turned on then use auto capture
             if ($captureModeOpenInvoice &&
-                $this->adyenHelper->isPaymentMethodOpenInvoiceMethodValidForAutoCapture($notificationPaymentMethod)
+                $this->adyenHelper->isPaymentMethodOpenInvoiceMethod($notificationPaymentMethod)
             ) {
                 $this->adyenLogger->addAdyenNotificationCronjob(
                     'This payment method is configured to be working as auto capture '


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
`isPaymentMethodOpenInvoiceMethodValidForAutoCapture()` method was deprecated but is still in use. Instead of this method use `isPaymentMethodOpenInvoiceMethod()` this method.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- Klarna
- Afterpay