### PR TITLE
[PW-7021] - Add failure counter for pay by link attempts

### DIFF
--- a/Helper/Webhook/AuthorisationWebhookHandler.php
+++ b/Helper/Webhook/AuthorisationWebhookHandler.php
@@ -244,7 +244,7 @@ class AuthorisationWebhookHandler implements WebhookHandlerInterface
      * @return bool
      * @throws \Exception
      */
-    private function checkPaybylinkCancellation(Order $order, Notification $notification)
+    private function canCancelPayByLinkOrder(Order $order, Notification $notification): bool
     {
         $payByLinkFailureCount = $order->getPayment()->getAdditionalInformation('payByLinkFailureCount');
         $payByLinkFailureCount = isset($payByLinkFailureCount) ? ++$payByLinkFailureCount : 1;

--- a/Helper/Webhook/AuthorisationWebhookHandler.php
+++ b/Helper/Webhook/AuthorisationWebhookHandler.php
@@ -251,31 +251,30 @@ class AuthorisationWebhookHandler implements WebhookHandlerInterface
 
         $order->getPayment()->setAdditionalInformation('payByLinkFailureCount', $payByLinkFailureCount);
 
-        if ($payByLinkFailureCount < AdyenPayByLinkConfigProvider::MAX_FAILURE_COUNT) {
-            $notification->setDone(true);
-            $notification->setProcessing(false);
-            $notification->save();
-
-            $order->addStatusHistoryComment(__(sprintf(
-                "Order wasn't cancelled by this webhook notification. Pay by Link failure count: %s/%s",
-                $payByLinkFailureCount,
-                AdyenPayByLinkConfigProvider::MAX_FAILURE_COUNT
-            )), false);
-
-            $this->adyenLogger->addAdyenNotification(
-                __(sprintf(
-                    "Order wasn't cancelled by this webhook notification. Pay by Link failure count: %s/%s",
-                    $payByLinkFailureCount,
-                    AdyenPayByLinkConfigProvider::MAX_FAILURE_COUNT
-                )),
-                $this->adyenLogger->getOrderContext($order)
-            );
-
-            return false;
-        }
-        else {
+        if ($payByLinkFailureCount >= AdyenPayByLinkConfigProvider::MAX_FAILURE_COUNT) {
             // Order can be cancelled.
             return true;
         }
+
+        $notification->setDone(true);
+        $notification->setProcessing(false);
+        $notification->save();
+
+        $order->addStatusHistoryComment(__(sprintf(
+            "Order wasn't cancelled by this webhook notification. Pay by Link failure count: %s/%s",
+            $payByLinkFailureCount,
+            AdyenPayByLinkConfigProvider::MAX_FAILURE_COUNT
+        )), false);
+
+        $this->adyenLogger->addAdyenNotification(
+            __(sprintf(
+                "Order wasn't cancelled by this webhook notification. Pay by Link failure count: %s/%s",
+                $payByLinkFailureCount,
+                AdyenPayByLinkConfigProvider::MAX_FAILURE_COUNT
+            )),
+            $this->adyenLogger->getOrderContext($order)
+        );
+
+        return false;
     }
 }

--- a/Helper/Webhook/AuthorisationWebhookHandler.php
+++ b/Helper/Webhook/AuthorisationWebhookHandler.php
@@ -187,7 +187,7 @@ class AuthorisationWebhookHandler implements WebhookHandlerInterface
 
         // If the payment method is PBL, use failure counter before cancelling the order
         if ($order->getPayment()->getMethod() == AdyenPayByLinkConfigProvider::CODE) {
-            if ($this->checkPaybylinkCancellation($order, $notification) === false) {
+            if (!$this->canCancelPayByLinkOrder($order, $notification)) {
                 return $order;
             }
         }

--- a/Model/Ui/AdyenPayByLinkConfigProvider.php
+++ b/Model/Ui/AdyenPayByLinkConfigProvider.php
@@ -17,6 +17,7 @@ use Magento\Framework\App\RequestInterface;
 class AdyenPayByLinkConfigProvider implements ConfigProviderInterface
 {
     const CODE = 'adyen_pay_by_link';
+    const MAX_FAILURE_COUNT = 5;
     const MIN_EXPIRY_DAYS = 1;
     const MAX_EXPIRY_DAYS = 70;
     const DAYS_TO_EXPIRE_CONFIG_PATH = 'payment/adyen_pay_by_link/days_to_expire';


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Pay By Link link is valid until the fifth failed payment attempt. Keep the order open until the fifth failure then cancel it.

For this purpose, a counter was added for the `Authorisation success=false` webhook notifications.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- Pay by Link