### PR TITLE
PW-5394: Log only into Adyen files

### DIFF
--- a/etc/di.xml
+++ b/etc/di.xml
@@ -957,8 +957,6 @@
                 <item name="adyenInfo" xsi:type="object">Adyen\Payment\Logger\Handler\AdyenInfo</item>
                 <item name="adyenError" xsi:type="object">Adyen\Payment\Logger\Handler\AdyenError</item>
                 <item name="adyenWarning" xsi:type="object">Adyen\Payment\Logger\Handler\AdyenWarning</item>
-                <item name="system" xsi:type="object">Magento\Framework\Logger\Handler\System</item>
-                <item name="debug" xsi:type="object">Magento\Framework\Logger\Handler\Debug</item>
             </argument>
         </arguments>
     </type>


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Our logger `Adyen\Payment\Logger\AdyenLogger` contains a stack of handlers that includes Magento handlers. That causes a single log call with info/debug level to be stored 3 times by:

1. `Adyen\Payment\Logger\Handler\AdyenInfo` (or `AdyenDebug`)
2. `Magento\Framework\Logger\Handler\System`
3. `Magento\Framework\Logger\Handler\Debug`

This PR removes the redundant handlers such that only 1 record is saved per call. 

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
* CC
* iDeal

Fixes #1137 