### PR TITLE
[PW-7150]Add null for the moto merchant account

### DIFF
--- a/Helper/ManagementHelper.php
+++ b/Helper/ManagementHelper.php
@@ -124,7 +124,7 @@ class ManagementHelper
         bool $demoMode
     ): void {
         $storeId = $this->storeManager->getStore()->getId();
-        $client = $this->dataHelper->initializeAdyenClient($storeId, $apiKey, $demoMode);
+        $client = $this->dataHelper->initializeAdyenClient($storeId, $apiKey, null, $demoMode);
 
         $management = new Management($client);
         $params = [
@@ -206,7 +206,7 @@ class ManagementHelper
             // API key contains '******', set to the previously saved config value
             $apiKey = $this->configHelper->getApiKey($environment);
         }
-        $client = $this->dataHelper->initializeAdyenClient($storeId, $apiKey, $environment === 'test');
+        $client = $this->dataHelper->initializeAdyenClient($storeId, $apiKey,null, $environment === 'test');
 
         return new Management($client);
     }

--- a/Helper/ManagementHelper.php
+++ b/Helper/ManagementHelper.php
@@ -206,7 +206,7 @@ class ManagementHelper
             // API key contains '******', set to the previously saved config value
             $apiKey = $this->configHelper->getApiKey($environment);
         }
-        $client = $this->dataHelper->initializeAdyenClient($storeId, $apiKey,null, $environment === 'test');
+        $client = $this->dataHelper->initializeAdyenClient($storeId, $apiKey, null, $environment === 'test');
 
         return new Management($client);
     }


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
In the ManagementHelper.php class the `$this->dataHelper->initializeAdyenClient` has wrong parameters which cause the management api config to throw an exception. The `initializeAdyenClient` has `$motoMerchantAccount` and it should be `null` when we do not use moto


**Tested scenarios**
Required Settings in admin panel with automated flow
