### PR TITLE
Fix #1688 : explode: string expected, got null

### DIFF
--- a/Model/Billing/Agreement.php
+++ b/Model/Billing/Agreement.php
@@ -230,11 +230,9 @@ class Agreement extends \Magento\Paypal\Model\Billing\Agreement
 
         $expiryDate = explode('/', $contractDetail['expiryDate']);
 
-        if (!empty($contractDetail['pos_payment'])) {
-            $recurringType = $this->adyenHelper->getAdyenPosCloudConfigData('recurring_type', $storeId);
-        } else {
-            $recurringType = $this->recurringHelper->getRecurringTypeFromSetting($storeId);
-        }
+        $recurringType = !empty($contractDetail['pos_payment'])
+            ? $this->adyenHelper->getAdyenPosCloudConfigData('recurring_type', $storeId)
+            : $this->recurringHelper->getRecurringTypeFromSetting($storeId);
 
         $agreementData = [
             'card' => [
@@ -246,7 +244,7 @@ class Agreement extends \Magento\Paypal\Model\Billing\Agreement
             'variant' => $variant,
             // contractTypes should be changed from an array to a single value in the future. It has not been done yet
             // to ensure past tokens are still operational.
-            'contractTypes' => explode(',', $recurringType)
+            'contractTypes' => $recurringType ? explode(',', $recurringType) : []
         ];
 
         if (!empty($contractDetail['pos_payment'])) {


### PR DESCRIPTION
**Description**
After a successful payment, we have the following history comment:

Deprecated Functionality: explode(): Passing null to parameter https://github.com/Adyen/adyen-magento2/issues/2 ($string) of type string is deprecated in /var/www/html/vendor/adyen/module-payment/Model/Billing/Agreement.php on line 249

See \Adyen\Payment\Model\Billing\Agreement::setCcBillingAgreement

This is because those methods can return null:

\Adyen\Payment\Helper\Data::getAdyenPosCloudConfigData
\Adyen\Payment\Helper\Recurring::getRecurringTypeFromSetting
\Adyen\Payment\Helper\Config::getCardRecurringType

**Fixed issue**:  #1688 