### PR TITLE
[PW-7105] - Set captureDelayHours to 0 if auto capture is enabled, on Klarna

### DIFF
--- a/Gateway/Request/CheckoutDataBuilder.php
+++ b/Gateway/Request/CheckoutDataBuilder.php
@@ -118,7 +118,7 @@ class CheckoutDataBuilder implements BuilderInterface
         }
 
         $brandCode = $payment->getAdditionalInformation(AdyenHppDataAssignObserver::BRAND_CODE);
-        if ($this->adyenHelper->isPaymentMethodOpenInvoiceMethod($brandCode)
+        if (isset($brandCode) && $this->adyenHelper->isPaymentMethodOpenInvoiceMethod($brandCode)
             || $this->adyenHelper->isPaymentMethodOfType($brandCode, Data::FACILYPAY)
             || $payment->getMethod() === AdyenPayByLinkConfigProvider::CODE
         ) {

--- a/Gateway/Request/CheckoutDataBuilder.php
+++ b/Gateway/Request/CheckoutDataBuilder.php
@@ -12,6 +12,7 @@
 namespace Adyen\Payment\Gateway\Request;
 
 use Adyen\Payment\Helper\ChargedCurrency;
+use Adyen\Payment\Helper\Config;
 use Adyen\Payment\Helper\Data;
 use Adyen\Payment\Helper\StateData;
 use Adyen\Payment\Model\Ui\AdyenBoletoConfigProvider;
@@ -53,6 +54,9 @@ class CheckoutDataBuilder implements BuilderInterface
      */
     private $stateData;
 
+    /** @var Config */
+    private $configHelper;
+
     /**
      * CheckoutDataBuilder constructor.
      * @param Data $adyenHelper
@@ -66,13 +70,15 @@ class CheckoutDataBuilder implements BuilderInterface
         StateData $stateData,
         CartRepositoryInterface $cartRepository,
         ChargedCurrency $chargedCurrency,
-        Image $imageHelper
+        Image $imageHelper,
+        Config $configHelper
     ) {
         $this->adyenHelper = $adyenHelper;
         $this->stateData = $stateData;
         $this->cartRepository = $cartRepository;
         $this->chargedCurrency = $chargedCurrency;
         $this->imageHelper = $imageHelper;
+        $this->configHelper = $configHelper;
     }
 
     /**
@@ -114,10 +120,14 @@ class CheckoutDataBuilder implements BuilderInterface
         $brandCode = $payment->getAdditionalInformation(AdyenHppDataAssignObserver::BRAND_CODE);
         if ($this->adyenHelper->isPaymentMethodOpenInvoiceMethod($brandCode)
             || $this->adyenHelper->isPaymentMethodOfType($brandCode, Data::FACILYPAY)
-            || $payment->getMethod() == AdyenPayByLinkConfigProvider::CODE
+            || $payment->getMethod() === AdyenPayByLinkConfigProvider::CODE
         ) {
             $openInvoiceFields = $this->getOpenInvoiceData($order);
             $requestBody = array_merge($requestBody, $openInvoiceFields);
+            if ($this->adyenHelper->isPaymentMethodOfType($brandCode, Data::KLARNA) &&
+                $this->configHelper->getAutoCaptureOpenInvoice($storeId)) {
+                $requestBody['captureDelayHours'] = 0;
+            }
         }
 
         // Ratepay specific Fingerprint

--- a/Gateway/Request/CheckoutDataBuilder.php
+++ b/Gateway/Request/CheckoutDataBuilder.php
@@ -113,7 +113,7 @@ class CheckoutDataBuilder implements BuilderInterface
 
         $brandCode = $payment->getAdditionalInformation(AdyenHppDataAssignObserver::BRAND_CODE);
         if ($this->adyenHelper->isPaymentMethodOpenInvoiceMethod($brandCode)
-            || $this->adyenHelper->isPaymentMethodOneyMethod($brandCode)
+            || $this->adyenHelper->isPaymentMethodOfType($brandCode, Data::FACILYPAY)
             || $payment->getMethod() == AdyenPayByLinkConfigProvider::CODE
         ) {
             $openInvoiceFields = $this->getOpenInvoiceData($order);
@@ -122,7 +122,7 @@ class CheckoutDataBuilder implements BuilderInterface
 
         // Ratepay specific Fingerprint
         $deviceFingerprint = $payment->getAdditionalInformation(AdyenHppDataAssignObserver::DF_VALUE);
-        if ($deviceFingerprint && $this->adyenHelper->isPaymentMethodRatepayMethod($brandCode)) {
+        if ($deviceFingerprint && $this->adyenHelper->isPaymentMethodOfType($brandCode, Data::RATEPAY)) {
             $requestBody['deviceFingerprint'] = $deviceFingerprint;
         }
 

--- a/Gateway/Request/CheckoutDataBuilder.php
+++ b/Gateway/Request/CheckoutDataBuilder.php
@@ -118,9 +118,9 @@ class CheckoutDataBuilder implements BuilderInterface
         }
 
         $brandCode = $payment->getAdditionalInformation(AdyenHppDataAssignObserver::BRAND_CODE);
-        if (isset($brandCode) && $this->adyenHelper->isPaymentMethodOpenInvoiceMethod($brandCode)
+        if (isset($brandCode) && ($this->adyenHelper->isPaymentMethodOpenInvoiceMethod($brandCode)
             || $this->adyenHelper->isPaymentMethodOfType($brandCode, Data::FACILYPAY)
-            || $payment->getMethod() === AdyenPayByLinkConfigProvider::CODE
+            || $payment->getMethod() === AdyenPayByLinkConfigProvider::CODE)
         ) {
             $openInvoiceFields = $this->getOpenInvoiceData($order);
             $requestBody = array_merge($requestBody, $openInvoiceFields);

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -457,6 +457,11 @@ class Config
         return $this->getConfigData('debug', self::XML_ADYEN_ABSTRACT_PREFIX, $storeId, true);
     }
 
+    public function getAutoCaptureOpenInvoice(int $storeId): bool
+    {
+        return $this->getConfigData('auto_capture_openinvoice', self::XML_ADYEN_ABSTRACT_PREFIX, $storeId, true);
+    }
+
     /**
      * Retrieve information from payment configuration
      *

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -66,6 +66,7 @@ class Data extends AbstractHelper
     const ZIP = 'zip';
     const PAYBRIGHT = 'paybright';
     const SEPA = 'sepadirectdebit';
+    const MOLPAY = 'molpay_';
 
     /**
      * @var EncryptorInterface
@@ -1044,71 +1045,11 @@ class Data extends AbstractHelper
     }
 
     /**
-     * @param $paymentMethod
-     * @return bool
+     * This function should be removed once we add specific classes for payment methods
      */
-    public function isPaymentMethodRatepayMethod($paymentMethod)
+    public function isPaymentMethodOfType(string $paymentMethod, string $type): bool
     {
-        if (!is_null($paymentMethod) && strpos($paymentMethod, self::RATEPAY) !== false) {
-            return true;
-        }
-
-        return false;
-    }
-
-    /**
-     * @param $paymentMethod
-     * @return bool
-     */
-    public function isPaymentMethodAfterpayTouchMethod($paymentMethod)
-    {
-        if (!is_null($paymentMethod) && strpos($paymentMethod, self::AFTERPAY_TOUCH) !== false) {
-            return true;
-        }
-
-        return false;
-    }
-
-    /**
-     * @param string $paymentMethod
-     * @return bool
-     */
-    public function isPaymentMethodMolpayMethod($paymentMethod)
-    {
-        if (!is_null($paymentMethod) && strpos($paymentMethod, 'molpay_') !== false) {
-            return true;
-        }
-
-        return false;
-    }
-
-    /**
-     * @param $paymentMethod
-     * @return bool
-     */
-    public function isPaymentMethodOneyMethod($paymentMethod)
-    {
-        if (!is_null($paymentMethod) && strpos($paymentMethod, self::FACILYPAY) !== false) {
-            return true;
-        }
-
-        return false;
-    }
-
-    /**
-     * @param string $paymentMethod
-     * @return bool
-     */
-    public function doesPaymentMethodSkipDetails($paymentMethod)
-    {
-        if ($this->isPaymentMethodOpenInvoiceMethod($paymentMethod) ||
-            $this->isPaymentMethodMolpayMethod($paymentMethod) ||
-            $this->isPaymentMethodOneyMethod($paymentMethod)
-        ) {
-            return true;
-        }
-
-        return false;
+        return strpos($paymentMethod, $type) !== false;
     }
 
     public function getRatePayId()

--- a/Helper/PaymentMethods.php
+++ b/Helper/PaymentMethods.php
@@ -602,11 +602,7 @@ class PaymentMethods extends AbstractHelper
                 )
             );
             $paymentCode = $order->getPayment()->getMethod();
-            $captureModeOpenInvoice = $this->configHelper->getConfigData(
-                'auto_capture_openinvoice',
-                'adyen_abstract',
-                $order->getStoreId()
-            );
+            $autoCaptureOpenInvoice = $this->configHelper->getAutoCaptureOpenInvoice($order->getStoreId());
             $manualCapturePayPal = trim(
                 $this->configHelper->getConfigData(
                     'paypal_capture_mode',
@@ -658,9 +654,7 @@ class PaymentMethods extends AbstractHelper
             }
 
             // if auto capture mode for openinvoice is turned on then use auto capture
-            if ($captureModeOpenInvoice &&
-                $this->adyenHelper->isPaymentMethodOpenInvoiceMethod($notificationPaymentMethod)
-            ) {
+            if ($autoCaptureOpenInvoice && $this->adyenHelper->isPaymentMethodOpenInvoiceMethod($notificationPaymentMethod)) {
                 $this->adyenLogger->addAdyenNotification(
                     'This payment method is configured to be working as auto capture ',
                     $this->adyenLogger->getOrderContext($order)


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
If a merchant has Capture Delay set to Manual, but he also has 'Use auto-capture for OpenInvoice payments' enabled, the adyen magento 2 module should include `captureDelayHours = 0` in the [/payments](https://docs.adyen.com/api-explorer/#/CheckoutService/v69/post/payments__reqParam_captureDelayHours) request to Adyen.

**Tested scenarios**
* Klarna payment w/ 'Use auto-capture for OpenInvoice payments' enabled
* Klarna payment w/o 'Use auto-capture for OpenInvoice payments' enabled