### PR TITLE
[PW-5788] Return cctype if the pm type if missing from adyen_payment.xml

### DIFF
--- a/Block/Info/Cc.php
+++ b/Block/Info/Cc.php
@@ -31,15 +31,8 @@ class Cc extends AbstractInfo
 
         if (isset($types[$ccType])) {
             return $types[$ccType]['name'];
-        }
-        // TODO::Refactor this block after tokenization of the alternative payment methods.
-        // This elseif block should be removed after the tokenization of the alternative payment methods (In progress: PW-6764). More general approach is required.
-        // Also remove `sepadirectdebit` from translation files.
-        elseif ($ccType == 'sepadirectdebit') {
-            return __('sepadirectdebit');
-        }
-        else {
-            return __('Unknown');
+        } else {
+            return $ccType;
         }
     }
 }

--- a/Controller/Process/Json.php
+++ b/Controller/Process/Json.php
@@ -32,7 +32,6 @@ use Magento\Framework\App\Request\Http as Http;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Serialize\SerializerInterface;
 use Symfony\Component\Config\Definition\Exception\Exception;
-use Magento\Framework\HTTP\PhpEnvironment\RemoteAddress;
 
 /**
  * Class Json extends Action
@@ -85,11 +84,6 @@ class Json extends Action
     private $notificationReceiver;
 
     /**
-     * @var RemoteAddress
-     */
-    private $remoteAddress;
-
-    /**
      * Json constructor.
      *
      * @param Context $context
@@ -101,7 +95,6 @@ class Json extends Action
      * @param RateLimiter $rateLimiterHelper
      * @param HmacSignature $hmacSignature
      * @param NotificationReceiver $notificationReceiver
-     * @param RemoteAddress $remoteAddress
      */
     public function __construct(
         Context $context,
@@ -113,8 +106,7 @@ class Json extends Action
         IpAddress $ipAddressHelper,
         RateLimiter $rateLimiterHelper,
         HmacSignature $hmacSignature,
-        NotificationReceiver $notificationReceiver,
-        RemoteAddress $remoteAddress
+        NotificationReceiver $notificationReceiver
     ) {
         parent::__construct($context);
         $this->notificationFactory = $notificationFactory;
@@ -126,7 +118,6 @@ class Json extends Action
         $this->rateLimiterHelper = $rateLimiterHelper;
         $this->hmacSignature = $hmacSignature;
         $this->notificationReceiver = $notificationReceiver;
-        $this->remoteAddress = $remoteAddress;
 
         // Fix for Magento2.3 adding isAjax to the request params
         if (interface_exists(CsrfAwareActionInterface::class)) {
@@ -348,10 +339,9 @@ class Json extends Action
     private function isIpValid()
     {
         $ipAddress = [];
-        $fetchedIpAddress = $this->remoteAddress->getRemoteAddress();
         //Getting remote and possibly forwarded IP addresses
-        if (!empty($fetchedIpAddress)) {
-            $ipAddress = explode(',', $fetchedIpAddress);
+        if (!empty($_SERVER['REMOTE_ADDR'])) {
+            $ipAddress = explode(',', $_SERVER['REMOTE_ADDR']);
         }
         return $this->ipAddressHelper->isIpAddressValid($ipAddress);
     }

--- a/Controller/Process/Json.php
+++ b/Controller/Process/Json.php
@@ -252,12 +252,12 @@ class Json extends Action
         }
 
         // Validate if Ip check is enabled and if the notification comes from a verified IP
-        if (!$this->isIpValid()) {
-            $this->adyenLogger->addAdyenNotification(
-                "Notification has been rejected because the IP address could not be verified"
-            );
-            return false;
-        }
+//        if (!$this->isIpValid()) {
+//            $this->adyenLogger->addAdyenNotification(
+//                "Notification has been rejected because the IP address could not be verified"
+//            );
+//            return false;
+//        }
 
         // Validate the Hmac calculation
         $hasHmacCheck = $this->configHelper->getNotificationsHmacKey() && 

--- a/Controller/Process/Json.php
+++ b/Controller/Process/Json.php
@@ -32,6 +32,7 @@ use Magento\Framework\App\Request\Http as Http;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Serialize\SerializerInterface;
 use Symfony\Component\Config\Definition\Exception\Exception;
+use Magento\Framework\HTTP\PhpEnvironment\RemoteAddress;
 
 /**
  * Class Json extends Action
@@ -84,6 +85,11 @@ class Json extends Action
     private $notificationReceiver;
 
     /**
+     * @var RemoteAddress
+     */
+    private $remoteAddress;
+
+    /**
      * Json constructor.
      *
      * @param Context $context
@@ -95,6 +101,7 @@ class Json extends Action
      * @param RateLimiter $rateLimiterHelper
      * @param HmacSignature $hmacSignature
      * @param NotificationReceiver $notificationReceiver
+     * @param RemoteAddress $remoteAddress
      */
     public function __construct(
         Context $context,
@@ -106,7 +113,8 @@ class Json extends Action
         IpAddress $ipAddressHelper,
         RateLimiter $rateLimiterHelper,
         HmacSignature $hmacSignature,
-        NotificationReceiver $notificationReceiver
+        NotificationReceiver $notificationReceiver,
+        RemoteAddress $remoteAddress
     ) {
         parent::__construct($context);
         $this->notificationFactory = $notificationFactory;
@@ -118,6 +126,7 @@ class Json extends Action
         $this->rateLimiterHelper = $rateLimiterHelper;
         $this->hmacSignature = $hmacSignature;
         $this->notificationReceiver = $notificationReceiver;
+        $this->remoteAddress = $remoteAddress;
 
         // Fix for Magento2.3 adding isAjax to the request params
         if (interface_exists(CsrfAwareActionInterface::class)) {
@@ -252,12 +261,12 @@ class Json extends Action
         }
 
         // Validate if Ip check is enabled and if the notification comes from a verified IP
-//        if (!$this->isIpValid()) {
-//            $this->adyenLogger->addAdyenNotification(
-//                "Notification has been rejected because the IP address could not be verified"
-//            );
-//            return false;
-//        }
+        if (!$this->isIpValid()) {
+            $this->adyenLogger->addAdyenNotification(
+                "Notification has been rejected because the IP address could not be verified"
+            );
+            return false;
+        }
 
         // Validate the Hmac calculation
         $hasHmacCheck = $this->configHelper->getNotificationsHmacKey() && 
@@ -339,9 +348,10 @@ class Json extends Action
     private function isIpValid()
     {
         $ipAddress = [];
+        $fetchedIpAddress = $this->remoteAddress->getRemoteAddress();
         //Getting remote and possibly forwarded IP addresses
-        if (!empty($_SERVER['REMOTE_ADDR'])) {
-            $ipAddress = explode(',', $_SERVER['REMOTE_ADDR']);
+        if (!empty($fetchedIpAddress)) {
+            $ipAddress = explode(',', $fetchedIpAddress);
         }
         return $this->ipAddressHelper->isIpAddressValid($ipAddress);
     }

--- a/etc/adyen_payment.xml
+++ b/etc/adyen_payment.xml
@@ -77,5 +77,53 @@
             <label>Korean Local Card</label>
             <code_alt>korean_local_card</code_alt>
         </type>
+        <type id="AMEXAPPLEPAY" order="160">
+            <label>Applepay American express</label>
+            <code_alt>amex_applepay</code_alt>
+        </type>
+        <type id="DISCOVERAPPLEPAY" order="170">
+            <label>Applepay Discover</label>
+            <code_alt>discover_applepay</code_alt>
+        </type>
+        <type id="ELECTRONAPPLEPAY" order="180">
+            <label>Applepay Electron</label>
+            <code_alt>electron_applepay</code_alt>
+        </type>
+        <type id="ELOAPPLEPAY" order="190">
+            <label>Applepay Elo</label>
+            <code_alt>elo_applepay</code_alt>
+        </type>
+        <type id="ELODEBITAPPLEPAY" order="200">
+            <label>Applepay Elodebit</label>
+            <code_alt>elodebit_applepay</code_alt>
+        </type>
+        <type id="InteracAPPLEPAY" order="210">
+            <label>Applepay Interac</label>
+            <code_alt>interac_applepay</code_alt>
+        </type>
+        <type id="JCBAPPLEPAY" order="220">
+            <label>Applepay Jcb</label>
+            <code_alt>jcb_applepay</code_alt>
+        </type>
+        <type id="JCBAPPLEPAY" order="230">
+            <label>Applepay Jcb</label>
+            <code_alt>jcb_applepay</code_alt>
+        </type>
+        <type id="MAESTROAPPLEPAY" order="240">
+            <label>Applepay Maestro</label>
+            <code_alt>maestro_applepay</code_alt>
+        </type>
+        <type id="MCAPPLEPAY" order="250">
+            <label>Applepay Mastercard</label>
+            <code_alt>mc_applepay</code_alt>
+        </type>
+        <type id="VIAPPLEPAY" order="260">
+            <label>Applepay Visa</label>
+            <code_alt>visa_applepay</code_alt>
+        </type>
+        <type id="GIROCARDAPPLEPAY" order="270">
+            <label>Applepay Girocard</label>
+            <code_alt>girocard_applepay</code_alt>
+        </type>
     </adyen_credit_cards>
 </payment>

--- a/etc/adyen_payment.xml
+++ b/etc/adyen_payment.xml
@@ -102,7 +102,7 @@
             <code_alt>interac_applepay</code_alt>
         </type>
         <type id="JCBAPPLEPAY" order="220">
-            <label>Apple Pay Jcb</label>
+            <label>Apple Pay JCB</label>
             <code_alt>jcb_applepay</code_alt>
         </type>
         <type id="MAESTROAPPLEPAY" order="230">

--- a/etc/adyen_payment.xml
+++ b/etc/adyen_payment.xml
@@ -78,7 +78,7 @@
             <code_alt>korean_local_card</code_alt>
         </type>
         <type id="AMEXAPPLEPAY" order="160">
-            <label>Apple Pay American express</label>
+            <label>Apple Pay American Express</label>
             <code_alt>amex_applepay</code_alt>
         </type>
         <type id="DISCOVERAPPLEPAY" order="170">

--- a/etc/adyen_payment.xml
+++ b/etc/adyen_payment.xml
@@ -78,51 +78,47 @@
             <code_alt>korean_local_card</code_alt>
         </type>
         <type id="AMEXAPPLEPAY" order="160">
-            <label>Applepay American express</label>
+            <label>Apple pay American express</label>
             <code_alt>amex_applepay</code_alt>
         </type>
         <type id="DISCOVERAPPLEPAY" order="170">
-            <label>Applepay Discover</label>
+            <label>Apple pay Discover</label>
             <code_alt>discover_applepay</code_alt>
         </type>
         <type id="ELECTRONAPPLEPAY" order="180">
-            <label>Applepay Electron</label>
+            <label>Apple pay Electron</label>
             <code_alt>electron_applepay</code_alt>
         </type>
         <type id="ELOAPPLEPAY" order="190">
-            <label>Applepay Elo</label>
+            <label>Apple pay Elo</label>
             <code_alt>elo_applepay</code_alt>
         </type>
         <type id="ELODEBITAPPLEPAY" order="200">
-            <label>Applepay Elodebit</label>
+            <label>Apple pay Elodebit</label>
             <code_alt>elodebit_applepay</code_alt>
         </type>
         <type id="InteracAPPLEPAY" order="210">
-            <label>Applepay Interac</label>
+            <label>Apple pay Interac</label>
             <code_alt>interac_applepay</code_alt>
         </type>
         <type id="JCBAPPLEPAY" order="220">
-            <label>Applepay Jcb</label>
+            <label>Apple pay Jcb</label>
             <code_alt>jcb_applepay</code_alt>
         </type>
-        <type id="JCBAPPLEPAY" order="230">
-            <label>Applepay Jcb</label>
-            <code_alt>jcb_applepay</code_alt>
-        </type>
-        <type id="MAESTROAPPLEPAY" order="240">
-            <label>Applepay Maestro</label>
+        <type id="MAESTROAPPLEPAY" order="230">
+            <label>Apple pay Maestro</label>
             <code_alt>maestro_applepay</code_alt>
         </type>
-        <type id="MCAPPLEPAY" order="250">
-            <label>Applepay Mastercard</label>
+        <type id="MCAPPLEPAY" order="240">
+            <label>Apple pay Mastercard</label>
             <code_alt>mc_applepay</code_alt>
         </type>
-        <type id="VIAPPLEPAY" order="260">
-            <label>Applepay Visa</label>
+        <type id="VIAPPLEPAY" order="250">
+            <label>Apple pay Visa</label>
             <code_alt>visa_applepay</code_alt>
         </type>
-        <type id="GIROCARDAPPLEPAY" order="270">
-            <label>Applepay Girocard</label>
+        <type id="GIROCARDAPPLEPAY" order="260">
+            <label>Apple pay Girocard</label>
             <code_alt>girocard_applepay</code_alt>
         </type>
     </adyen_credit_cards>

--- a/etc/adyen_payment.xml
+++ b/etc/adyen_payment.xml
@@ -94,7 +94,7 @@
             <code_alt>elo_applepay</code_alt>
         </type>
         <type id="ELODEBITAPPLEPAY" order="200">
-            <label>Apple Pay Elodebit</label>
+            <label>Apple Pay Elo Debit</label>
             <code_alt>elodebit_applepay</code_alt>
         </type>
         <type id="INTERACAPPLEPAY" order="210">

--- a/etc/adyen_payment.xml
+++ b/etc/adyen_payment.xml
@@ -78,47 +78,47 @@
             <code_alt>korean_local_card</code_alt>
         </type>
         <type id="AMEXAPPLEPAY" order="160">
-            <label>Apple pay American express</label>
+            <label>Apple Pay American express</label>
             <code_alt>amex_applepay</code_alt>
         </type>
         <type id="DISCOVERAPPLEPAY" order="170">
-            <label>Apple pay Discover</label>
+            <label>Apple Pay Discover</label>
             <code_alt>discover_applepay</code_alt>
         </type>
         <type id="ELECTRONAPPLEPAY" order="180">
-            <label>Apple pay Electron</label>
+            <label>Apple Pay Electron</label>
             <code_alt>electron_applepay</code_alt>
         </type>
         <type id="ELOAPPLEPAY" order="190">
-            <label>Apple pay Elo</label>
+            <label>Apple Pay Elo</label>
             <code_alt>elo_applepay</code_alt>
         </type>
         <type id="ELODEBITAPPLEPAY" order="200">
-            <label>Apple pay Elodebit</label>
+            <label>Apple Pay Elodebit</label>
             <code_alt>elodebit_applepay</code_alt>
         </type>
         <type id="InteracAPPLEPAY" order="210">
-            <label>Apple pay Interac</label>
+            <label>Apple Pay Interac</label>
             <code_alt>interac_applepay</code_alt>
         </type>
         <type id="JCBAPPLEPAY" order="220">
-            <label>Apple pay Jcb</label>
+            <label>Apple Pay Jcb</label>
             <code_alt>jcb_applepay</code_alt>
         </type>
         <type id="MAESTROAPPLEPAY" order="230">
-            <label>Apple pay Maestro</label>
+            <label>Apple Pay Maestro</label>
             <code_alt>maestro_applepay</code_alt>
         </type>
         <type id="MCAPPLEPAY" order="240">
-            <label>Apple pay Mastercard</label>
+            <label>Apple Pay Mastercard</label>
             <code_alt>mc_applepay</code_alt>
         </type>
         <type id="VIAPPLEPAY" order="250">
-            <label>Apple pay Visa</label>
+            <label>Apple Pay Visa</label>
             <code_alt>visa_applepay</code_alt>
         </type>
         <type id="GIROCARDAPPLEPAY" order="260">
-            <label>Apple pay Girocard</label>
+            <label>Apple Pay Girocard</label>
             <code_alt>girocard_applepay</code_alt>
         </type>
     </adyen_credit_cards>

--- a/etc/adyen_payment.xml
+++ b/etc/adyen_payment.xml
@@ -97,7 +97,7 @@
             <label>Apple Pay Elodebit</label>
             <code_alt>elodebit_applepay</code_alt>
         </type>
-        <type id="InteracAPPLEPAY" order="210">
+        <type id="INTERACAPPLEPAY" order="210">
             <label>Apple Pay Interac</label>
             <code_alt>interac_applepay</code_alt>
         </type>


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
The apple tx variants are self described for example: `elodebit_applepay `, `visa_applepay `, `mc_applepay`  and with this pull request the type is returned in case the name is not in the payment method [list]( https://github.com/Adyen/adyen-magento2/blob/develop/etc/adyen_payment.xml.). This list is used to map the tx variants with a payment method name for orders in magento admin 

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- Google pay
- CC
- Ideal
- Sepadirect tokenized pm
