### PR TITLE
[PW-7146] Update the `$cachedIpsArray` variable upon cache expiry

### DIFF
--- a/Controller/Process/Json.php
+++ b/Controller/Process/Json.php
@@ -32,6 +32,7 @@ use Magento\Framework\App\Request\Http as Http;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Serialize\SerializerInterface;
 use Symfony\Component\Config\Definition\Exception\Exception;
+use Magento\Framework\HTTP\PhpEnvironment\RemoteAddress;
 
 /**
  * Class Json extends Action
@@ -84,6 +85,11 @@ class Json extends Action
     private $notificationReceiver;
 
     /**
+     * @var RemoteAddress
+     */
+    private $remoteAddress;
+
+    /**
      * Json constructor.
      *
      * @param Context $context
@@ -95,6 +101,7 @@ class Json extends Action
      * @param RateLimiter $rateLimiterHelper
      * @param HmacSignature $hmacSignature
      * @param NotificationReceiver $notificationReceiver
+     * @param RemoteAddress $remoteAddress
      */
     public function __construct(
         Context $context,
@@ -106,7 +113,8 @@ class Json extends Action
         IpAddress $ipAddressHelper,
         RateLimiter $rateLimiterHelper,
         HmacSignature $hmacSignature,
-        NotificationReceiver $notificationReceiver
+        NotificationReceiver $notificationReceiver,
+        RemoteAddress $remoteAddress
     ) {
         parent::__construct($context);
         $this->notificationFactory = $notificationFactory;
@@ -118,6 +126,7 @@ class Json extends Action
         $this->rateLimiterHelper = $rateLimiterHelper;
         $this->hmacSignature = $hmacSignature;
         $this->notificationReceiver = $notificationReceiver;
+        $this->remoteAddress = $remoteAddress;
 
         // Fix for Magento2.3 adding isAjax to the request params
         if (interface_exists(CsrfAwareActionInterface::class)) {
@@ -339,9 +348,10 @@ class Json extends Action
     private function isIpValid()
     {
         $ipAddress = [];
+        $fetchedIpAddress = $this->remoteAddress->getRemoteAddress();
         //Getting remote and possibly forwarded IP addresses
-        if (!empty($_SERVER['REMOTE_ADDR'])) {
-            $ipAddress = explode(',', $_SERVER['REMOTE_ADDR']);
+        if (!empty($fetchedIpAddress)) {
+            $ipAddress = explode(',', $fetchedIpAddress);
         }
         return $this->ipAddressHelper->isIpAddressValid($ipAddress);
     }

--- a/Helper/IpAddress.php
+++ b/Helper/IpAddress.php
@@ -84,7 +84,8 @@ class IpAddress
             $this->adyenLogger->addAdyenDebug(
                 'There are no verified Adyen IP addresses in cache. Updating IP records.'
             );
-            $this->updateCachedIpAddresses();
+           $this->updateCachedIpAddresses();
+           $cachedIpsArray = $this->getIpAddressesFromCache();
         }
 
         foreach ($ipAddresses as $ipAddress) {


### PR DESCRIPTION
**Description**
As of now, when receiving notifications, we check the sender's IP. The list of allowed IPs is kept on cache. We refresh the list when the cache expires but currently we don't update the local variable `$cachedIpsArray`. In such cases the check will still use an empty list.
The solution this PR introduces does just that, it updates the variable so the sender IP check uses an updated list.
The other change this PR introduces is how we are obtaining the senders IP address. As of now, we are getting this information from the global variable, however when using proxies, the remote address would be the proxy's IP, which is something Magento's `RemoteAddress` class already deals with.

**Tested scenarios**
- send the notification to Magento and make sure the list of allowed IPs is updated
- make sure the remote address is correctly fetched

**Fixed issue**:  #1694 