### PR TITLE
[PW-6744] Add a check to Multishipping success page to verify whether it is Adyen payment method

### DIFF
--- a/view/frontend/templates/checkout/multishipping/success.phtml
+++ b/view/frontend/templates/checkout/multishipping/success.phtml
@@ -44,29 +44,31 @@ $paymentResponseEntities = $block->getPaymentResponseEntities();
                             </span>
                                 <?php endif; ?>
 
-                                <!-- Adyen custom 'Complete Payment' button -->
-                                <span class="adyen-continue-payment">
-                                        <button
-                                            <?php if ($block->getIsPaymentCompleted($orderId)): ?>
-                                                disabled="disabled"
-                                                class="adyen-finish-payment adyen-payment-finished"
-                                            <?php else: ?>
-                                                class="adyen-finish-payment adyen-payment-unfinished"
-                                                data-order-id="<?= $block->escapeHtml($orderId); ?>"
-                                                data-adyen-response="<?= $block->escapeHtml(
-                                                    $paymentResponseEntities[array_search(
-                                                        $incrementId,
-                                                        array_column(
-                                                            $paymentResponseEntities,
-                                                            'merchant_reference'
-                                                        )
-                                                    )]['response']
-                                                ); ?>"
-                                            <?php endif; ?>
-                                        ><?= $block->escapeHtml($block->getPaymentButtonLabel($orderId)); ?></button>
-                                <div class="adyen-component"></div>
-                                </span>
-                                <!-- End of Adyen custom 'Complete Payment' button -->
+                                <?php if($block->isAdyenPayment()): ?>
+                                    <!-- Adyen custom 'Complete Payment' button -->
+                                    <span class="adyen-continue-payment">
+                                            <button
+                                                <?php if ($block->getIsPaymentCompleted($orderId)): ?>
+                                                    disabled="disabled"
+                                                    class="adyen-finish-payment adyen-payment-finished"
+                                                <?php else: ?>
+                                                    class="adyen-finish-payment adyen-payment-unfinished"
+                                                    data-order-id="<?= $block->escapeHtml($orderId); ?>"
+                                                    data-adyen-response="<?= $block->escapeHtml(
+                                                        $paymentResponseEntities[array_search(
+                                                            $incrementId,
+                                                            array_column(
+                                                                $paymentResponseEntities,
+                                                                'merchant_reference'
+                                                            )
+                                                        )]['response']
+                                                    ); ?>"
+                                                <?php endif; ?>
+                                            ><?= $block->escapeHtml($block->getPaymentButtonLabel($orderId)); ?></button>
+                                    <div class="adyen-component"></div>
+                                    </span>
+                                    <!-- End of Adyen custom 'Complete Payment' button -->
+                                <?php endif; ?>
 
                             </div>
                         </li>


### PR DESCRIPTION
**Description**
As of now, when using multishipping checkout and choosing to pay with a non-Adyen payment method, an error is thrown when you click place order because the `resultCode` is missing from the additional payment information, which is required.

This PR introduces a solution that only requires the `resultCode` is it is Adyen's payment method.

**Tested scenarios**
- with multishipping configured in the admin panel, selected 2 shipping addresses and placed an order with non-Adyen payment method. Made sure I was redirected to the success page and the order details were displayed.

**Fixed issue**:  #1521 