### PR TITLE
[PW-7168] Add support for Magento v2.4.5 to integration and functional tests

### DIFF
--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -5,12 +5,12 @@ on:
     branches: [ main, develop ]
 
 jobs:
-  build:
+  build::
     strategy:
       matrix:
         include:
           - php-version: '8.1'
-            magento-version: '2.4.5'
+            magento-version: '2.4.4'
     runs-on: ubuntu-latest
     env:
       PHP_VERSION: ${{ matrix.php-version }}

--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -2,7 +2,7 @@ name: Functional Tests
 on:
   workflow_dispatch:
   pull_request:
-    branches: [ main, develop ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -2,7 +2,7 @@ name: Functional Tests
 on:
   workflow_dispatch:
   pull_request:
-    branches: [ main ]
+    branches: [ main, PW-7168 ]
 
 jobs:
   build:
@@ -10,7 +10,7 @@ jobs:
       matrix:
         include:
           - php-version: '8.1'
-            magento-version: '2.4.4'
+            magento-version: '2.4.5'
     runs-on: ubuntu-latest
     env:
       PHP_VERSION: ${{ matrix.php-version }}

--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -2,7 +2,7 @@ name: Functional Tests
 on:
   workflow_dispatch:
   pull_request:
-    branches: [ main, PW-7168 ]
+    branches: [ main, develop ]
 
 jobs:
   build:

--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -5,7 +5,7 @@ on:
     branches: [ main, develop ]
 
 jobs:
-  build::
+  build:
     strategy:
       matrix:
         include:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         php-version: ['7.4']
-        magento-version: ['2.3.7', '2.4.2']
+        magento-version: ['2.3.7', '2.4.2', '2.4.5']
         include:
           - php-version: '8.1'
             magento-version: '2.4.5'

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         php-version: ['7.4']
-        magento-version: ['2.3.7', '2.4.2', '2.4.5']
+        magento-version: ['2.3.7', '2.4.2']
         include:
           - php-version: '8.1'
             magento-version: '2.4.5'

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -9,7 +9,7 @@ jobs:
         magento-version: ['2.3.7', '2.4.2']
         include:
           - php-version: '8.1'
-            magento-version: '2.4.4'
+            magento-version: '2.4.5'
     runs-on: ubuntu-latest
     env:
       PHP_VERSION: ${{ matrix.php-version }}


### PR DESCRIPTION
**Description**
During the submission of our plugin v8.4.0 to Adobe Commerce Marketplace, some tests failed within the technical review. This PR introduces a solution to include the support of Magento v2.4.5 to our plugin.

**Tested scenarios**
- run the integration and MFTF tests in our GitHub CI/CD pipeline to resemble Adobe Marketplace Installation and MFTF tests
