### PR TITLE
[PW-4730] - Use php library client's method to set the region

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -1479,6 +1479,8 @@ class Data extends AbstractHelper
         $client = $this->createAdyenClient();
         $client->setApplicationName(self::APPLICATION_NAME);
         $client->setXApiKey($apiKey);
+        $checkoutFrontendRegion = $this->getCheckoutFrontendRegion($storeId);
+        $client->setRegion($checkoutFrontendRegion);
         $moduleVersion = $this->getModuleVersion();
 
         $client->setMerchantApplication($this->getModuleName(), $moduleVersion);

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -1479,10 +1479,13 @@ class Data extends AbstractHelper
         $client = $this->createAdyenClient();
         $client->setApplicationName(self::APPLICATION_NAME);
         $client->setXApiKey($apiKey);
-        $checkoutFrontendRegion = $this->getCheckoutFrontendRegion($storeId);
-        $client->setRegion($checkoutFrontendRegion);
-        $moduleVersion = $this->getModuleVersion();
 
+        $checkoutFrontendRegion = $this->getCheckoutFrontendRegion($storeId);
+        if (isset($checkoutFrontendRegion)) {
+            $client->setRegion($checkoutFrontendRegion);
+        }
+
+        $moduleVersion = $this->getModuleVersion();
         $client->setMerchantApplication($this->getModuleName(), $moduleVersion);
         $client->setExternalPlatform($this->productMetadata->getName(), $this->productMetadata->getVersion());
         if ($isDemo) {

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     }
   ],
   "require": {
-    "adyen/php-api-library": "^13.0.1",
+    "adyen/php-api-library": "^13.0.3",
     "adyen/php-webhook-module": "^0.6.0",
     "magento/framework": ">=101.0.8 <102 || >=102.0.1",
     "magento/module-vault": "101.*",

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "adyen/module-payment",
   "description": "Official Magento2 Plugin to connect to Payment Service Provider Adyen.",
   "type": "magento2-module",
-  "version": "8.4.0",
+  "version": "8.5.0",
   "license": "MIT",
   "repositories": [
     {

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -12,7 +12,7 @@
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
 
-    <module name="Adyen_Payment" setup_version="8.4.0">
+    <module name="Adyen_Payment" setup_version="8.5.0">
         <sequence>
             <module name="Magento_Sales"/>
             <module name="Magento_Quote"/>


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Terminal API has region based endpoints. Use Adyen PHP API Library client's `setRegion()` method to set and use these region based endpoints. 
