### PR TITLE
[PW-7077] - Remove shipping address subscriber

### DIFF
--- a/view/frontend/web/js/view/payment/adyen-methods.js
+++ b/view/frontend/web/js/view/payment/adyen-methods.js
@@ -74,15 +74,7 @@ define(
                     }).fail(function() {
                         console.log('Fetching the payment methods failed!');
                     });
-                                                       };
-                quote.shippingAddress.subscribe(function(address) {
-                    // In case the country hasn't changed don't retrieve new payment methods
-                    if (shippingAddressCountry === quote.shippingAddress().countryId) {
-                        return;
-                    }
-                    shippingAddressCountry = quote.shippingAddress().countryId;
-                    retrievePaymentMethods();
-                });
+                };
                 //Retrieve payment methods to ensure the amount is updated, when applying the discount code
                 setCouponCodeAction.registerSuccessCallback(function () {
                     retrievePaymentMethods();


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
This subscriber is responsible for making `paymentMethods` call. This call is also being made by `set-shipping-information-mixin`. So, the duplicate function is removed from `adyen-methods` file. 

Also, this duplication is the current blocker of the E2E tests due to not rendering payment methods list correctly on the checkout page.