### PR TITLE
[PW-7157]Add India live prefix for frontend

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -55,6 +55,7 @@ class Data extends AbstractHelper
     const LIVE = 'live';
     const LIVE_AU = 'live-au';
     const LIVE_US = 'live-us';
+    const LIVE_IN = 'live-in';
     const PSP_REFERENCE_REGEX = '/(?P<pspReference>[0-9.A-Z]{16})(?P<suffix>[a-z\-]*)/';
     const AFTERPAY = 'afterpay';
     const AFTERPAY_TOUCH = 'afterpaytouch';
@@ -286,7 +287,8 @@ class Data extends AbstractHelper
         return [
             'eu' => 'Default (EU - Europe)',
             'au' => 'AU - Australasia',
-            'us' => 'US - United States'
+            'us' => 'US - United States',
+            'in' => 'IN - India'
         ];
     }
 
@@ -1608,6 +1610,8 @@ class Data extends AbstractHelper
                 return self::LIVE_AU;
             case "us":
                 return self::LIVE_US;
+            case "in":
+                return self::LIVE_IN;
             default:
                 return self::LIVE;
         }

--- a/view/frontend/web/js/view/payment/adyen-methods.js
+++ b/view/frontend/web/js/view/payment/adyen-methods.js
@@ -75,6 +75,14 @@ define(
                         console.log('Fetching the payment methods failed!');
                     });
                 };
+                quote.shippingAddress.subscribe(function (address) {
+                    // In case the country hasn't changed don't retrieve new payment methods
+                    if (shippingAddressCountry === quote.shippingAddress().countryId) {
+                        return;
+                    }
+                    shippingAddressCountry = quote.shippingAddress().countryId;
+                    retrievePaymentMethods();
+                });
                 //Retrieve payment methods to ensure the amount is updated, when applying the discount code
                 setCouponCodeAction.registerSuccessCallback(function () {
                     retrievePaymentMethods();

--- a/view/frontend/web/js/view/payment/adyen-methods.js
+++ b/view/frontend/web/js/view/payment/adyen-methods.js
@@ -75,14 +75,6 @@ define(
                         console.log('Fetching the payment methods failed!');
                     });
                 };
-                quote.shippingAddress.subscribe(function (address) {
-                    // In case the country hasn't changed don't retrieve new payment methods
-                    if (shippingAddressCountry === quote.shippingAddress().countryId) {
-                        return;
-                    }
-                    shippingAddressCountry = quote.shippingAddress().countryId;
-                    retrievePaymentMethods();
-                });
                 //Retrieve payment methods to ensure the amount is updated, when applying the discount code
                 setCouponCodeAction.registerSuccessCallback(function () {
                     retrievePaymentMethods();


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
There is a new regulation in India that all data should be kept within India's servers. Therefore, we need to make all backend endpoints (/payments, /details, /refunds etc.,) India specific (Will be available in BO/CA of the India merchant account)

We should also make front end drop-in/component libraries will be hosted in India and hence will have India specific checkout shopper URL based in Adyen [docs](https://docs.adyen.com/development-resources/live-endpoints#checkout-js-endpoints)

Related to this [pull request](https://github.com/Adyen/adyen-magento2/pull/1367)
**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

Returns in the `adyen-configuration.js` the `live-in` enviroment
