### PR TITLE
PW-7129: Remove full request/response logging

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -1496,8 +1496,6 @@ class Data extends AbstractHelper
             $client->setEnvironment(\Adyen\Environment::LIVE, $this->getLiveEndpointPrefix($storeId));
         }
 
-        $client->setLogger($this->adyenLogger);
-
         return $client;
     }
 

--- a/Helper/Webhook.php
+++ b/Helper/Webhook.php
@@ -162,7 +162,7 @@ class Webhook
             $currentState = $this->getCurrentState($this->order->getState());
             if (!$currentState) {
                 $this->logger->addAdyenNotification(
-                    sprintf("ERROR: Unhandled order state '%s'.", $this->order->getState()),
+                    "ERROR: Unhandled order state '{orderState}'",
                     $this->logger->getOrderContext($this->order)
                 );
                 return false;

--- a/Helper/Webhook/CaptureWebhookHandler.php
+++ b/Helper/Webhook/CaptureWebhookHandler.php
@@ -105,7 +105,7 @@ class CaptureWebhookHandler implements WebhookHandlerInterface
 
             $magentoInvoice = $this->magentoInvoiceFactory->create()->load($adyenInvoice->getInvoiceId(), MagentoInvoice::ENTITY_ID);
             $this->adyenLogger->addAdyenNotification(
-                sprintf('Notification %s updated invoice %s.', $notification->getEntityId(), $magentoInvoice->getEntityid()),
+                sprintf('Notification %s updated invoice {invoiceId}', $notification->getEntityId()),
                 $this->adyenLogger->getInvoiceContext($magentoInvoice)
             );
 

--- a/Observer/InvoiceObserver.php
+++ b/Observer/InvoiceObserver.php
@@ -104,7 +104,7 @@ class InvoiceObserver implements ObserverInterface
 
 
         $this->logger->addAdyenDebug(
-            sprintf('Event sales_order_invoice_save_after for invoice %s will be handled', $invoice->getEntityId()),
+            'Event sales_order_invoice_save_after for invoice {invoiceId} will be handled',
             array_merge($this->logger->getInvoiceContext($invoice), $this->logger->getOrderContext($order))
         );
 
@@ -134,7 +134,7 @@ class InvoiceObserver implements ObserverInterface
         $order->setStatus($status);
 
         $this->logger->addAdyenDebug(
-            sprintf('Event sales_order_invoice_save_after for invoice %s was handled', $invoice->getEntityId()),
+            'Event sales_order_invoice_save_after for invoice {invoiceId} was handled',
             array_merge($this->logger->getInvoiceContext($invoice), $this->logger->getOrderContext($order))
         );
     }

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -958,6 +958,10 @@
                 <item name="adyenError" xsi:type="object">Adyen\Payment\Logger\Handler\AdyenError</item>
                 <item name="adyenWarning" xsi:type="object">Adyen\Payment\Logger\Handler\AdyenWarning</item>
             </argument>
+            <argument name="processors" xsi:type="array">
+                <item name="uid" xsi:type="object">Monolog\Processor\UidProcessor</item>
+                <item name="psr3" xsi:type="object">Monolog\Processor\PsrLogMessageProcessor</item>
+            </argument>
         </arguments>
     </type>
     <type name="Adyen\Payment\Model\Config\Reader">


### PR DESCRIPTION
**Description**

This change stops passing the application logger to the PHP library to avoid logging full request/responses all the time. We can add partial logging (e.g. messages with order ID and PSP reference) in specific events when really necessary and helpful.  

It also adds two log processors. The first one adds a UID (e.g. `{"uid":"9ed0b12"}`) into each plugin log line per request/cron run. The second "psr3" adds the ability to use placeholders for context variables inside the message.

**Tested scenarios**
* iDeal
* Credit card