### PR TITLE
[PW-7147] Handle Capture Requests triggered from Customer Area

### DIFF
--- a/Helper/Invoice.php
+++ b/Helper/Invoice.php
@@ -287,7 +287,7 @@ class Invoice extends AbstractHelper
 
         if (is_null($adyenInvoice) && $order->canInvoice()) {
                 if ($isFullAmountCaptured) {
-                   $adyenInvoice = $this->createInvoiceFromWebhook($order, $notification);
+                   $adyenInvoiceObject = $this->createInvoiceFromWebhook($order, $notification);
                 } else {
                     $order->addStatusHistoryComment(__(sprintf(
                         'Partial %s webhook notification w/amount %s %s was processed, no invoice created.
@@ -317,7 +317,7 @@ class Invoice extends AbstractHelper
         }
 
         /** @var AdyenInvoice $adyenInvoiceObject */
-        $adyenInvoiceObject = $invoiceFactory->load($adyenInvoice[InvoiceInterface::ENTITY_ID], InvoiceInterface::ENTITY_ID);
+        $adyenInvoiceObject = $adyenInvoiceObject ?? $invoiceFactory->load($adyenInvoice[InvoiceInterface::ENTITY_ID], InvoiceInterface::ENTITY_ID);
 
         $additionalData = $notification->getAdditionalData();
         $acquirerReference = $additionalData[Notification::ADDITIONAL_DATA] ?? null;

--- a/Helper/Invoice.php
+++ b/Helper/Invoice.php
@@ -263,8 +263,7 @@ class Invoice extends AbstractHelper
         $adyenInvoice = $this->adyenInvoiceResourceModel->getAdyenInvoiceByCaptureWebhook($order, $notification);
         $fullAmountCaptured = $this->adyenDataHelper->originalAmount($notification->getAmountValue(), $notification->getAmountCurrency()) >= $order->getBaseGrandTotal();
 
-        if (is_null($adyenInvoice)) {
-            if ($order->canInvoice()) {
+        if (is_null($adyenInvoice) && $order->canInvoice()) {
                 if($fullAmountCaptured) {
                     $this->createInvoiceFromWebhook($order, $notification);
                 } else {
@@ -274,7 +273,6 @@ class Invoice extends AbstractHelper
                         $notification->getAmountCurrency(),
                         $this->adyenDataHelper->originalAmount($notification->getAmountValue(), $notification->getAmountCurrency())
                     )), false);
-                }
             }
         }
 
@@ -404,7 +402,7 @@ class Invoice extends AbstractHelper
                 __('Created invoice #%1.', $invoice->getId())
             )
                 ->setIsCustomerNotified(false)
-                ->save();;
+                ->save();
         }
 
         //Create entry in adyen_invoice table

--- a/Helper/Invoice.php
+++ b/Helper/Invoice.php
@@ -266,7 +266,7 @@ class Invoice extends AbstractHelper
 
         if (is_null($adyenInvoice) && $order->canInvoice()) {
                 if($isFullAmountCaptured) {
-                    $adyenInvoice = $this->createInvoiceFromWebhook($order, $notification);
+                   $adyenInvoice = $this->createInvoiceFromWebhook($order, $notification);
                 } else {
                     $order->addStatusHistoryComment(__(sprintf(
                         'Partial %s webhook notification w/amount %s %s was processed, no invoice created. Please create offline invoice.',
@@ -376,9 +376,10 @@ class Invoice extends AbstractHelper
      * @param Order $order
      * @param Notification $notification
      * @throws AlreadyExistsException
+     * @return AdyenInvoice
      * @throws Exception
      */
-    public function createInvoiceFromWebhook(Order $order, Notification $notification)
+    public function createInvoiceFromWebhook(Order $order, Notification $notification): AdyenInvoice
     {
         //Create entry in sales_invoice table
         $invoice = $order->prepareInvoice();
@@ -419,7 +420,7 @@ class Invoice extends AbstractHelper
         }
 
         //Create entry in adyen_invoice table
-        $this->createAdyenInvoice(
+        $adyenInvoice = $this->createAdyenInvoice(
             $order->getPayment(),
             $notification->getData()['pspreference'],
             $notification->getData()['original_reference'],
@@ -432,5 +433,7 @@ class Invoice extends AbstractHelper
             $notification->getPspreference(),
             $order->getIncrementId()
         ));
+
+        return $adyenInvoice;
     }
 }

--- a/Helper/Invoice.php
+++ b/Helper/Invoice.php
@@ -265,7 +265,7 @@ class Invoice extends AbstractHelper
         $isFullAmountCaptured = $this->adyenDataHelper->originalAmount($notification->getAmountValue(), $notification->getAmountCurrency()) >= $order->getBaseGrandTotal();
 
         if (is_null($adyenInvoice) && $order->canInvoice()) {
-                if($fullAmountCaptured) {
+                if($isFullAmountCaptured) {
                     $this->createInvoiceFromWebhook($order, $notification);
                 } else {
                     $order->addStatusHistoryComment(__(sprintf(

--- a/Helper/Invoice.php
+++ b/Helper/Invoice.php
@@ -274,6 +274,13 @@ class Invoice extends AbstractHelper
                         $this->adyenDataHelper->originalAmount($notification->getAmountValue(), $notification->getAmountCurrency())
                     )), false);
             }
+        } elseif (is_null($adyenInvoice) && !$order->canInvoice()) {
+            throw new \Exception(sprintf(
+                'Unable to find adyen_invoice linked to original reference %s, psp reference %s, and order %s. Cannot create invoice.',
+                $notification->getOriginalReference(),
+                $notification->getPspreference(),
+                $order->getIncrementId()
+            ));
         }
 
         /** @var AdyenInvoice $adyenInvoiceObject */
@@ -361,7 +368,6 @@ class Invoice extends AbstractHelper
      *
      * @param Order $order
      * @param Notification $notification
-     * @return AdyenInvoice
      * @throws AlreadyExistsException
      * @throws Exception
      */

--- a/Helper/Invoice.php
+++ b/Helper/Invoice.php
@@ -22,6 +22,7 @@ use Adyen\Payment\Model\Order\PaymentFactory;
 use Adyen\Payment\Model\ResourceModel\Invoice\Collection;
 use Adyen\Payment\Model\ResourceModel\Invoice\Invoice as AdyenInvoiceResourceModel;
 use Adyen\Payment\Model\ResourceModel\Order\Payment as OrderPaymentResourceModel;
+use Adyen\Payment\Exception\AdyenWebhookException;
 use Exception;
 use Magento\Framework\App\Helper\AbstractHelper;
 use Magento\Framework\App\Helper\Context;
@@ -273,20 +274,20 @@ class Invoice extends AbstractHelper
                         $notification->getAmountCurrency(),
                         $this->adyenDataHelper->originalAmount($notification->getAmountValue(), $notification->getAmountCurrency())
                     )), false);
-                    throw new \Exception(sprintf(
+                    throw new AdyenWebhookException(__(sprintf(
                         'Unable to create adyen_invoice from CA partial capture linked to original reference %s, psp reference %s, and order %s.',
                         $notification->getOriginalReference(),
                         $notification->getPspreference(),
                         $order->getIncrementId()
-                    ));
+                    )));
             }
         } elseif (is_null($adyenInvoice) && !$order->canInvoice()) {
-            throw new \Exception(sprintf(
+            throw new AdyenWebhookException(__(sprintf(
                 'Unable to find adyen_invoice linked to original reference %s, psp reference %s, and order %s. Cannot create invoice.',
                 $notification->getOriginalReference(),
                 $notification->getPspreference(),
                 $order->getIncrementId()
-            ));
+            )));
         }
 
         /** @var AdyenInvoice $adyenInvoiceObject */

--- a/Helper/Invoice.php
+++ b/Helper/Invoice.php
@@ -266,7 +266,7 @@ class Invoice extends AbstractHelper
 
         if (is_null($adyenInvoice) && $order->canInvoice()) {
                 if($isFullAmountCaptured) {
-                    $this->createInvoiceFromWebhook($order, $notification);
+                    $adyenInvoice = $this->createInvoiceFromWebhook($order, $notification);
                 } else {
                     $order->addStatusHistoryComment(__(sprintf(
                         'Partial %s webhook notification w/amount %s %s was processed, no invoice created. Please create offline invoice.',

--- a/Helper/Invoice.php
+++ b/Helper/Invoice.php
@@ -272,7 +272,7 @@ class Invoice extends AbstractHelper
                    $adyenInvoice = $this->createInvoiceFromWebhook($order, $notification);
                 } else {
                     $order->addStatusHistoryComment(__(sprintf(
-                        'Partial %s webhook notification w/amount %s %s was processed, no invoice created. 
+                        'Partial %s webhook notification w/amount %s %s was processed, no invoice created.
                         Please create offline invoice.',
                         $notification->getEventCode(),
                         $notification->getAmountCurrency(),
@@ -281,7 +281,7 @@ class Invoice extends AbstractHelper
                             $notification->getAmountCurrency())
                     )), false);
                     throw new AdyenWebhookException(__(sprintf(
-                        'Unable to create adyen_invoice from CA partial capture linked to original reference %s, 
+                        'Unable to create adyen_invoice from CA partial capture linked to original reference %s,
                         psp reference %s, and order %s.',
                         $notification->getOriginalReference(),
                         $notification->getPspreference(),
@@ -290,7 +290,7 @@ class Invoice extends AbstractHelper
             }
         } elseif (is_null($adyenInvoice) && !$order->canInvoice()) {
             throw new AdyenWebhookException(__(sprintf(
-                'Unable to find adyen_invoice linked to original reference %s, psp reference %s, and order %s. 
+                'Unable to find adyen_invoice linked to original reference %s, psp reference %s, and order %s.
                 Cannot create invoice.',
                 $notification->getOriginalReference(),
                 $notification->getPspreference(),

--- a/Helper/Invoice.php
+++ b/Helper/Invoice.php
@@ -273,6 +273,12 @@ class Invoice extends AbstractHelper
                         $notification->getAmountCurrency(),
                         $this->adyenDataHelper->originalAmount($notification->getAmountValue(), $notification->getAmountCurrency())
                     )), false);
+                    throw new \Exception(sprintf(
+                        'Unable to create adyen_invoice from CA partial capture linked to original reference %s, psp reference %s, and order %s.',
+                        $notification->getOriginalReference(),
+                        $notification->getPspreference(),
+                        $order->getIncrementId()
+                    ));
             }
         } elseif (is_null($adyenInvoice) && !$order->canInvoice()) {
             throw new \Exception(sprintf(

--- a/Helper/Invoice.php
+++ b/Helper/Invoice.php
@@ -317,7 +317,8 @@ class Invoice extends AbstractHelper
         }
 
         /** @var AdyenInvoice $adyenInvoiceObject */
-        $adyenInvoiceObject = $adyenInvoiceObject ?? $invoiceFactory->load($adyenInvoice[InvoiceInterface::ENTITY_ID], InvoiceInterface::ENTITY_ID);
+        $adyenInvoiceObject = $adyenInvoiceObject
+            ?? $invoiceFactory->load($adyenInvoice[InvoiceInterface::ENTITY_ID], InvoiceInterface::ENTITY_ID);
 
         $additionalData = $notification->getAdditionalData();
         $acquirerReference = $additionalData[Notification::ADDITIONAL_DATA] ?? null;

--- a/Helper/Invoice.php
+++ b/Helper/Invoice.php
@@ -262,7 +262,7 @@ class Invoice extends AbstractHelper
     {
         $invoiceFactory = $this->adyenInvoiceFactory->create();
         $adyenInvoice = $this->adyenInvoiceResourceModel->getAdyenInvoiceByCaptureWebhook($order, $notification);
-        $fullAmountCaptured = $this->adyenDataHelper->originalAmount($notification->getAmountValue(), $notification->getAmountCurrency()) >= $order->getBaseGrandTotal();
+        $isFullAmountCaptured = $this->adyenDataHelper->originalAmount($notification->getAmountValue(), $notification->getAmountCurrency()) >= $order->getBaseGrandTotal();
 
         if (is_null($adyenInvoice) && $order->canInvoice()) {
                 if($fullAmountCaptured) {


### PR DESCRIPTION
**Description**
Currently in our plugin, if a capture request is triggered from the CA, the plugin is not handling the corresponding webhook and the order is not updated on Magento.
This PR introduces a solution where Adyen and Magento invoice are created during the processing of the CAPTURE webhook. This process creates entries in both `sales_invoice` and `adyen_invoice` tables. 
With this PR, only full capture flow is supported. In cases where partial capture is initiated from the Adyen Customer Area, the webhook gets processed but no invoice is created on Magento's end. The merchant has to create the offline invoice from the admin panel.

**Tested scenarios**
- process CAPTURE notification with full order amount and see whether both invoices are created and linked
- process CAPTURE notification with partial amount of the order and make sure no invoice is created and the order can still be invoiced offline

**Fixes**:  #1682 
