### PR TITLE
Adding number format to getAmountIncludingTax in test

### DIFF
--- a/Test/Unit/Helper/ChargedCurrencyTest.php
+++ b/Test/Unit/Helper/ChargedCurrencyTest.php
@@ -430,7 +430,7 @@ class ChargedCurrencyTest extends AbstractAdyenTestCase
                     $result->getCurrencyCode(),
                     $result->getDiscountAmount(),
                     $result->getTaxAmount(),
-                    $result->getAmountIncludingTax()
+                    number_format($result->getAmountIncludingTax(), 2, '.')
                 ]
             );
         } else {

--- a/Test/Unit/Helper/ChargedCurrencyTest.php
+++ b/Test/Unit/Helper/ChargedCurrencyTest.php
@@ -429,8 +429,8 @@ class ChargedCurrencyTest extends AbstractAdyenTestCase
                     $result->getAmount(),
                     $result->getCurrencyCode(),
                     $result->getDiscountAmount(),
-                    $result->getTaxAmount(),
-                    number_format($result->getAmountIncludingTax(), 2, '.')
+                    number_format($result->getTaxAmount(), 2, '.', ','),
+                    $result->getAmountIncludingTax()
                 ]
             );
         } else {


### PR DESCRIPTION
**Description**
Recently we [changed the PHPUnit version constraint](https://github.com/Adyen/adyen-magento2/pull/1539). And [this update](https://github.com/sebastianbergmann/phpunit/pull/4972) to the constant used in PHPUnit for float comparison messes up with the `testGetQuoteItemAmountCurrency` assertion.

`getTaxAmount()` is only used with `number_format` and 2 decimals, so a quick fix is to add this to the test as well.

**Tested scenarios**
Unit tests

**Fixes**:  PW-7207
