### PR TITLE
[PW-7208] Update adyen method call for virtual products

### DIFF
--- a/view/frontend/web/js/view/payment/adyen-methods.js
+++ b/view/frontend/web/js/view/payment/adyen-methods.js
@@ -75,6 +75,9 @@ define(
                         console.log('Fetching the payment methods failed!');
                     });
                 };
+                if (quote.shippingAddress() === null) {
+                    retrievePaymentMethods();
+                }
                 //Retrieve payment methods to ensure the amount is updated, when applying the discount code
                 setCouponCodeAction.registerSuccessCallback(function () {
                     retrievePaymentMethods();

--- a/view/frontend/web/js/view/payment/adyen-methods.js
+++ b/view/frontend/web/js/view/payment/adyen-methods.js
@@ -75,9 +75,7 @@ define(
                         console.log('Fetching the payment methods failed!');
                     });
                 };
-                if (quote.shippingAddress() === null) {
-                    retrievePaymentMethods();
-                }
+                retrievePaymentMethods();
                 //Retrieve payment methods to ensure the amount is updated, when applying the discount code
                 setCouponCodeAction.registerSuccessCallback(function () {
                     retrievePaymentMethods();


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
The payment method call was not triggered for virtual products as the shipping information was missing.
It should be called for products without shipping information as well
**Tested scenarios**
- with virtual product
- with normal product and shipping address 
- changing the shipping address 


Co-authored-by: @candemiralp 