### PR TITLE
PW-7197: Display merchant ID instead of name

### DIFF
--- a/Helper/ManagementHelper.php
+++ b/Helper/ManagementHelper.php
@@ -83,7 +83,7 @@ class ManagementHelper
                 });
                 $merchantAccounts[] = [
                     'id' => $merchantAccount['id'],
-                    'name' => $merchantAccount['name'],
+                    'name' => $merchantAccount['name'] ?? $merchantAccount['id'],
                     'liveEndpointPrefix' => !empty($defaultDC) ? $defaultDC[0]['livePrefix'] : ''
                 ];
             }

--- a/Helper/ManagementHelper.php
+++ b/Helper/ManagementHelper.php
@@ -83,7 +83,7 @@ class ManagementHelper
                 });
                 $merchantAccounts[] = [
                     'id' => $merchantAccount['id'],
-                    'name' => $merchantAccount['name'] ?? $merchantAccount['id'],
+                    'name' => $merchantAccount['id'],
                     'liveEndpointPrefix' => !empty($defaultDC) ? $defaultDC[0]['livePrefix'] : ''
                 ];
             }


### PR DESCRIPTION
**Description**

The merchant [name](https://docs.adyen.com/api-explorer-beta/Management/1/get/merchants#responses-200-data-name) field is optional or can be duplicated e.g:

| id  | name |
|-----|------|
| UserDemo | UsersDemo  |
| UsersDemo | UsersDemo  |

Let's use ID instead.  