### PR TITLE
[PW-7195] Add new e2e workflow for integration tests

### DIFF
--- a/.github/workflows/e2e-only.yml
+++ b/.github/workflows/e2e-only.yml
@@ -1,0 +1,63 @@
+name: E2E Tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      testBranch:
+        description: "Test Branch from Integration Tools Repo"
+        required: true
+        default: "develop"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      PHP_VERSION: "8.1"
+      MAGENTO_VERSION: "2.4.5"
+      ADMIN_USERNAME: ${{secrets.MAGENTO_ADMIN_USERNAME}}
+      ADMIN_PASSWORD: ${{secrets.MAGENTO_ADMIN_PASSWORD}}
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install Magento
+        run: docker-compose -f .github/workflows/templates/docker-compose.yml run --rm web make magento
+
+      - name: Start web server in background
+        run: docker-compose -f .github/workflows/templates/docker-compose.yml up -d web
+        env:
+          DONATION_ACCOUNT: ${{secrets.DONATION_ACCOUNT}}
+          ADYEN_MERCHANT: ${{secrets.ADYEN_MERCHANT}}
+          ADYEN_API_KEY: ${{secrets.ADYEN_API_KEY}}
+          ADYEN_CLIENT_KEY: ${{secrets.ADYEN_CLIENT_KEY}}
+
+      - name: Setup permissions
+        run: docker exec magento2-container make fs
+
+      - name: Check install
+        run: docker exec magento2-container make sys-check
+
+      - name: Install plugin
+        run: docker exec -u www-data magento2-container make plugin
+
+      - name: Switch to production mode
+        run: docker exec -u www-data magento2-container make production
+
+      - name: Setup permissions
+        run: docker exec magento2-container make fs
+
+      - name: Run E2E tests
+        continue-on-error: true
+        run: docker-compose -f .github/workflows/templates/docker-compose.yml run --rm playwright /e2e.sh
+        env:
+          INTEGRATION_TESTS_BRANCH: ${{inputs.testBranch}}
+          MAGENTO_ADMIN_USERNAME: ${{secrets.MAGENTO_ADMIN_USERNAME}}
+          MAGENTO_ADMIN_PASSWORD: ${{secrets.MAGENTO_ADMIN_PASSWORD}}
+          MAGENTO_BASE_URL: ${{secrets.MAGENTO_BASE_URL}}
+          PAYPAL_USERNAME: ${{secrets.PLAYWRIGHT_PAYPAL_USERNAME}}
+          PAYPAL_PASSWORD: ${{secrets.PLAYWRIGHT_PAYPAL_PASSWORD}}
+
+      - name: Archive test result artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: html-report
+          path: test-report


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Added a new workflow for only E2E tests to be triggered remotely by test branch

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

**Fixes**:  <!-- #-prefixed issue number -->
PW-7195
