### PR TITLE
[PW-7189] - Disable cross button and ESC key on action modal

### DIFF
--- a/view/frontend/web/js/model/adyen-payment-modal.js
+++ b/view/frontend/web/js/model/adyen-payment-modal.js
@@ -21,6 +21,10 @@ define(
                 let popupModal = $('#' + modalLabel).modal({
                     // disable user to hide popup
                     clickableOverlay: false,
+                    // disable escape key to hide popup
+                    keyEventHandlers: {
+                        escapeKey: function () { return; }
+                    },
                     responsive: true,
                     innerScroll: false,
                     // empty buttons, we don't need that

--- a/view/frontend/web/js/view/payment/method-renderer/adyen-cc-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-cc-method.js
@@ -211,7 +211,7 @@ define(
                 }
             },
             showModal: function() {
-                var actionModal = AdyenPaymentModal.showModal(adyenPaymentService, fullScreenLoader, this.messageContainer, this.orderId, this.modalLabel, this.isPlaceOrderActionAllowed);
+                let actionModal = AdyenPaymentModal.showModal(adyenPaymentService, fullScreenLoader, this.messageContainer, this.orderId, this.modalLabel, this.isPlaceOrderActionAllowed);
                 $("." + this.modalLabel + " .action-close").hide();
 
                 return actionModal;

--- a/view/frontend/web/js/view/payment/method-renderer/adyen-cc-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-cc-method.js
@@ -211,7 +211,10 @@ define(
                 }
             },
             showModal: function() {
-                return AdyenPaymentModal.showModal(adyenPaymentService, fullScreenLoader, this.messageContainer, this.orderId, this.modalLabel, this.isPlaceOrderActionAllowed)
+                var actionModal = AdyenPaymentModal.showModal(adyenPaymentService, fullScreenLoader, this.messageContainer, this.orderId, this.modalLabel, this.isPlaceOrderActionAllowed);
+                $("." + this.modalLabel + " .action-close").hide();
+
+                return actionModal;
             },
             /**
              * This method is a workaround to close the modal in the right way and reconstruct the threeDS2Modal.
@@ -309,8 +312,6 @@ define(
                 }
             },
             handleOnAdditionalDetails: function(result) {
-                $('.action-close').hide();
-
                 var self = this;
 
                 var request = result.data;

--- a/view/frontend/web/js/view/payment/method-renderer/adyen-oneclick-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-oneclick-method.js
@@ -511,7 +511,10 @@ define(
                 return true;
             },
             showModal: function() {
-                return adyenPaymentModal.showModal(adyenPaymentService, fullScreenLoader, this.messageContainer, this.orderId, this.modalLabel, this.isPlaceOrderActionAllowed)
+                var actionModal = adyenPaymentModal.showModal(adyenPaymentService, fullScreenLoader, this.messageContainer, this.orderId, this.modalLabel, this.isPlaceOrderActionAllowed)
+                $("." + this.modalLabel + " .action-close").hide();
+
+                return actionModal;
             },
             closeModal: function(popupModal) {
                 adyenPaymentModal.closeModal(popupModal, this.modalLabel)

--- a/view/frontend/web/js/view/payment/method-renderer/adyen-oneclick-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-oneclick-method.js
@@ -511,7 +511,7 @@ define(
                 return true;
             },
             showModal: function() {
-                var actionModal = adyenPaymentModal.showModal(adyenPaymentService, fullScreenLoader, this.messageContainer, this.orderId, this.modalLabel, this.isPlaceOrderActionAllowed)
+                let actionModal = adyenPaymentModal.showModal(adyenPaymentService, fullScreenLoader, this.messageContainer, this.orderId, this.modalLabel, this.isPlaceOrderActionAllowed)
                 $("." + this.modalLabel + " .action-close").hide();
 
                 return actionModal;


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Cross button and ESC key are disabled to prevent inconsistent behaviours due to slow network connection. Those payments can still be cancelled from the `Cancel` or `Go Back` button of the 3DS challenge view provided by the issuer.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- [x] 3DS2 success/fail cases
- [x] One click success/fail cases