### PR TITLE
[PW-7252] Fix comparison when handling capture webhook from CA

### DIFF
--- a/Helper/Invoice.php
+++ b/Helper/Invoice.php
@@ -283,7 +283,7 @@ class Invoice extends AbstractHelper
         $isFullAmountCaptured = $this->adyenDataHelper->originalAmount(
             $notification->getAmountValue(),
             $notification->getAmountCurrency()
-            ) === $order->getBaseGrandTotal();
+            ) === floatval($order->getBaseGrandTotal());
 
         if (is_null($adyenInvoice) && $order->canInvoice()) {
                 if ($isFullAmountCaptured) {


### PR DESCRIPTION
**Description**
Currently in Invoice::handleCaptureWebhook we have the following check:
```
$isFullAmountCaptured = $this->adyenDataHelper->originalAmount(
      $notification->getAmountValue(),
      $notification->getAmountCurrency()
) === $order->getBaseGrandTotal();
```
This check will always return false (and hence webhook will always be treated as partial) since $order->getBaseGrandTotal() will return a string, instead of an int. The solution is to call `floatval()` on `$order->getBaseGrandTotal()`.

**Tested scenarios**
- manual full capture with floating points from Adyen CA
- manual full capture with int from Adyen CA
- manual partial capture with floating points from Adyen CA
- manual partial capture with int from Adyen CA
