### PR TITLE
[PW-7261] Call to getAmount() failing in AdyenOrderPayment helper in develop branch

### DIFF
--- a/Helper/AdyenOrderPayment.php
+++ b/Helper/AdyenOrderPayment.php
@@ -267,7 +267,7 @@ class AdyenOrderPayment extends AbstractHelper
         $orderAmountCurrency = $this->adyenChargedCurrencyHelper->getOrderAmountCurrency($order);
 
         foreach ($adyenOrderPayments as $adyenOrderPayment) {
-            $adyenOrderPaymentsTotal += $adyenOrderPayment->getAmount();
+            $adyenOrderPaymentsTotal += $adyenOrderPayment[OrderPaymentInterface::AMOUNT];
         }
 
         $adyenOrderPaymentsTotalCents = $this->adyenDataHelper->formatAmount($adyenOrderPaymentsTotal, $orderAmountCurrency->getCurrencyCode());

--- a/Test/Unit/Helper/AdyenOrderPaymentTest.php
+++ b/Test/Unit/Helper/AdyenOrderPaymentTest.php
@@ -11,6 +11,7 @@
 
 namespace Adyen\Payment\Tests\Unit\Helper;
 
+use Adyen\Payment\Api\Data\OrderPaymentInterface;
 use Adyen\Payment\Helper\AdyenOrderPayment;
 use Adyen\Payment\Helper\ChargedCurrency;
 use Adyen\Payment\Helper\Data;
@@ -85,9 +86,7 @@ class AdyenOrderPaymentTest extends AbstractAdyenTestCase
            'getOrderAmountCurrency' => $orderAmountCurrency
         ]);
 
-        $adyenOrderPayment = $this->createConfiguredMock(AdyenPaymentModel::class, [
-            'getAmount' => 10.33
-        ]);
+        $adyenOrderPayment = [OrderPaymentInterface::AMOUNT => 10.33];
 
         $payment = $this->createConfiguredMock(Order\Payment::class, [
             'getEntityId' => 55
@@ -226,9 +225,7 @@ class AdyenOrderPaymentTest extends AbstractAdyenTestCase
             'getEntityId' => 55
         ]);
 
-        $adyenOrderPayment = $this->createConfiguredMock(\Adyen\Payment\Model\Order\Payment::class, [
-            'getAmount' => 10.33
-        ]);
+        $adyenOrderPayment = [OrderPaymentInterface::AMOUNT => 10.33];
 
         $order = $this->createConfiguredMock(Order::class, [
             'getPayment' => $payment


### PR DESCRIPTION
**Description**
Processing the AUTHORISATION notification fails due to a call to getAmount() in compareAdyenOrderPaymentsAmount(). Currently, this bug is only existing in develop branch and was not released.

**Tested scenarios**
- successfully processed AUTHORISATION notification
- successfully ran the unit tests

