### PR TITLE
[PW-7268] Change the way we are comparing payment amounts in \Helper\Invoice::handleCaptureWebhook

### DIFF
--- a/Helper/Invoice.php
+++ b/Helper/Invoice.php
@@ -280,10 +280,9 @@ class Invoice extends AbstractHelper
     {
         $invoiceFactory = $this->adyenInvoiceFactory->create();
         $adyenInvoice = $this->adyenInvoiceResourceModel->getAdyenInvoiceByCaptureWebhook($order, $notification);
-        $isFullAmountCaptured = $this->adyenDataHelper->originalAmount(
-            $notification->getAmountValue(),
-            $notification->getAmountCurrency()
-            ) === floatval($order->getBaseGrandTotal());
+        $formattedAdyenOrderAmount = $this->adyenDataHelper->formatAmount($order->getBaseGrandTotal(), $order->getOrderCurrencyCode());
+        $notificationAmount = $notification->getAmountValue();
+        $isFullAmountCaptured = $formattedAdyenOrderAmount == $notificationAmount;
 
         if (is_null($adyenInvoice) && $order->canInvoice()) {
                 if ($isFullAmountCaptured) {


### PR DESCRIPTION
**Description**
Following [this PR](https://github.com/Adyen/adyen-magento2/pull/1742), currently, in order to check whether the capture is partial or full, we are comparing the amount value of the notification against the amount value in the order. In order to cover the decimal values, we are calling `floatval()` on the order amount. As comparing floating points is not the best practice, and `$isFullAmountCaptured`doesn't always return the have value (therefore the invoice is not created in Magento upon capturing from CA), the proposed change would be to refactor that part of the code.

**Tested scenarios**
 - manual full capture from CA > integer 
 - manual full capture from CA > floating point
 - manual partial capture from CA > integer
 - manual partial capture from CA > floating point
