### PR TITLE
[PW-7271] Enable refund from Adyen CA if payment invoiced in Magento

### DIFF
--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -571,27 +571,29 @@ class Order extends AbstractHelper
         $lastTransactionId = $order->getPayment()->getLastTransId();
         $matches = $this->dataHelper->parseTransactionId($lastTransactionId);
         if (($matches['pspReference'] ?? '') == $notification->getOriginalReference() && empty($matches['suffix'])) {
-            // refund is done through adyen backoffice so create a credit memo
-            if ($order->canCreditmemo()) {
-                $amount = $this->dataHelper->originalAmount($notification->getAmountValue(), $notification->getAmountCurrency());
-                $order->getPayment()->registerRefundNotification($amount);
+            if (empty($matches['suffix']) || $matches['suffix'] === '-capture') {
+                // refund is done through adyen backoffice so create a credit memo
+                if ($order->canCreditmemo()) {
+                    $amount = $this->dataHelper->originalAmount($notification->getAmountValue(), $notification->getAmountCurrency());
+                    $order->getPayment()->registerRefundNotification($amount);
 
-                $this->adyenLogger->addAdyenNotification(sprintf(
-                    'Created credit memo for order %s', $order->getIncrementId()),
-                    [
-                        'pspReference' => $notification->getPspreference(),
-                        'merchantReference' => $notification->getMerchantReference()
-                    ]
-                );
-            } else {
-                $this->adyenLogger->addAdyenNotification(sprintf(
-                    'Could not create a credit memo for order %s while processing notification %s',
-                    $order->getIncrementId(),
-                    $notification->getId()
-                ), [
-                    'pspReference' => $order->getPayment()->getData('adyen_psp_reference'),
-                    'merchantReference' => $order->getPayment()->getData('entity_id')
-                ]);
+                    $this->adyenLogger->addAdyenNotification(sprintf(
+                        'Created credit memo for order %s', $order->getIncrementId()),
+                        [
+                            'pspReference' => $notification->getPspreference(),
+                            'merchantReference' => $notification->getMerchantReference()
+                        ]
+                    );
+                } else {
+                    $this->adyenLogger->addAdyenNotification(sprintf(
+                        'Could not create a credit memo for order %s while processing notification %s',
+                        $order->getIncrementId(),
+                        $notification->getId()
+                    ), [
+                        'pspReference' => $order->getPayment()->getData('adyen_psp_reference'),
+                        'merchantReference' => $order->getPayment()->getData('entity_id')
+                    ]);
+                }
             }
         } else {
             $this->adyenLogger->addAdyenNotification(sprintf(


### PR DESCRIPTION
**Description**
Review the `empty($matches['suffix']` check in [this line](https://github.com/Adyen/adyen-magento2/blob/develop/Helper/Order.php#L573), added in [this PR](https://github.com/Adyen/adyen-magento2/blob/develop/Helper/Order.php#L573).
This check is incorrect in cases where the merchant manually invoices the payment from M2 admin panel (which appends the suffix `'-capture'`) and tries to refund the payment from CA. As the suffix is not empty, we won't create a credit memo in M2 admin panel, however we should. The reason for that is that the payment was captured, hence satisfying the criteria to be able to be refunded.

This PR introduces an additional check to see whether the suffix contains `'-capture'` string.

**Tested scenarios**
 - manual capture > full capture > invoice from magento > full refund from CA => successful, credit memo created
 - manual capture > full capture > invoice from magento > partial refund from CA => successfully processed notification, no credit memo created, admin asked to create offline credit memo
 - manual capture > partial capture > invoice from magento > full refund of the partially captured payment from CA => successful, credit memo created
 - manual capture > partial capture > invoice from magento > partial refund of the partially captured payment from CA => successfully processed notification, no credit memo created, admin asked to create offline credit memo
 - manual capture > full capture > capture from CA > full refund from CA => successful, credit memo created
 - manual capture > full capture > capture from CA > partial refund from CA => successfully processed notification, no credit memo created, admin asked to create offline credit memo
 - manual capture > partial capture > capture from CA > create offline invoice in magento > full refund of the partially captured payment from CA => successfully processed notification, no credit memo created, admin asked to create offline credit memo
 - manual capture > partial capture > capture from CA > create offline invoice in magento > partial refund of the partially captured payment from CA => successfully processed notification, no credit memo created, admin asked to create offline credit memo
 - manual capture > full capture > capture from CA > full refund from magento => successful, credit memo created
 - manual capture > full capture > capture from CA > partial refund from magento => refund not possible
 - manual capture > partial capture > capture from CA > create offline invoice in magento > full refund from magento => only an offline credit memo is possible 
 - manual capture > partial capture > capture from CA > create offline invoice in magento > partial refund from magento => only an offline credit memo is possible
 - auto capture > full refund from CA => successful, credit memo created
 - auto capture > partial refund from CA => successfully processed notification, no credit memo created, admin asked to create offline credit memo
 - auto capture > full refund from magento => successful, credit memo created
 - auto capture > partial refund from magento => successful, credit memos created


**Fixes**:  <!-- #-prefixed issue number -->
