### PR TITLE
[PW-4938] Add 3-digit padding helper method for shopperReference

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -1793,8 +1793,8 @@ class Data extends AbstractHelper
         }, ARRAY_FILTER_USE_KEY);
     }
 
-    public function padShopperReference($customerId)
+    public function padShopperReference($shopperReference)
     {
-        return str_pad($customerId, 3, '0', STR_PAD_LEFT);
+        return str_pad($shopperReference, 3, '0', STR_PAD_LEFT);
     }
 }

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -1793,7 +1793,11 @@ class Data extends AbstractHelper
         }, ARRAY_FILTER_USE_KEY);
     }
 
-    public function padShopperReference($shopperReference)
+    /**
+     * @param $shopperReference
+     * @return string
+     */
+    public function padShopperReference($shopperReference): string
     {
         return str_pad($shopperReference, 3, '0', STR_PAD_LEFT);
     }

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -1792,4 +1792,9 @@ class Data extends AbstractHelper
             return is_string($index);
         }, ARRAY_FILTER_USE_KEY);
     }
+
+    public function padShopperReference($customerId)
+    {
+        return str_pad($customerId, 3, '0', STR_PAD_LEFT);
+    }
 }

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -1797,7 +1797,7 @@ class Data extends AbstractHelper
      * @param $shopperReference
      * @return string
      */
-    public function padShopperReference($shopperReference): string
+    public function padShopperReference(string $shopperReference): string
     {
         return str_pad($shopperReference, 3, '0', STR_PAD_LEFT);
     }

--- a/Helper/PaymentMethods.php
+++ b/Helper/PaymentMethods.php
@@ -419,7 +419,8 @@ class PaymentMethods extends AbstractHelper
         ];
 
         if (!empty($this->getCurrentShopperReference())) {
-            $paymentMethodRequest["shopperReference"] = $this->adyenDataHelper->padShopperReference($this->getCurrentShopperReference());
+            $paymentMethodRequest["shopperReference"] =
+                $this->adyenDataHelper->padShopperReference($this->getCurrentShopperReference());
         }
 
         $amountValue = $this->adyenHelper->formatAmount($this->getCurrentPaymentAmount(), $currencyCode);

--- a/Helper/PaymentMethods.php
+++ b/Helper/PaymentMethods.php
@@ -33,7 +33,7 @@ use Magento\Framework\View\DesignInterface;
 use Magento\Payment\Helper\Data as MagentoDataHelper;
 use Magento\Quote\Api\CartRepositoryInterface;
 use Magento\Sales\Model\Order;
-use Adyen\Helper\Data as AdyenDataHelper;
+use Adyen\Payment\Helper\Data as AdyenDataHelper;
 
 /**
  * @SuppressWarnings(PHPMD.LongVariable)

--- a/Helper/PaymentMethods.php
+++ b/Helper/PaymentMethods.php
@@ -33,6 +33,7 @@ use Magento\Framework\View\DesignInterface;
 use Magento\Payment\Helper\Data as MagentoDataHelper;
 use Magento\Quote\Api\CartRepositoryInterface;
 use Magento\Sales\Model\Order;
+use Adyen\Helper\Data as AdyenDataHelper;
 
 /**
  * @SuppressWarnings(PHPMD.LongVariable)
@@ -86,6 +87,11 @@ class PaymentMethods extends AbstractHelper
      * @var AdyenLogger
      */
     protected $adyenLogger;
+
+    /**
+     * @var AdyenDataHelper
+     */
+    protected $adyenDataHelper;
 
     /**
      * @var Repository
@@ -147,7 +153,8 @@ class PaymentMethods extends AbstractHelper
         Config $configHelper,
         MagentoDataHelper $dataHelper,
         ManualCapture $manualCapture,
-        SerializerInterface $serializer
+        SerializerInterface $serializer,
+        AdyenDataHelper $adyenDataHelper
     ) {
         parent::__construct($context);
         $this->quoteRepository = $quoteRepository;
@@ -165,6 +172,7 @@ class PaymentMethods extends AbstractHelper
         $this->dataHelper = $dataHelper;
         $this->manualCapture = $manualCapture;
         $this->serializer = $serializer;
+        $this->adyenDataHelper = $adyenDataHelper;
     }
 
     /**
@@ -411,12 +419,7 @@ class PaymentMethods extends AbstractHelper
         ];
 
         if (!empty($this->getCurrentShopperReference())) {
-            $paymentMethodRequest["shopperReference"] = str_pad(
-                $this->getCurrentShopperReference(),
-                3,
-                '0',
-                STR_PAD_LEFT
-            );
+            $paymentMethodRequest["shopperReference"] = $this->adyenDataHelper->padShopperReference($this->getCurrentShopperReference());
         }
 
         $amountValue = $this->adyenHelper->formatAmount($this->getCurrentPaymentAmount(), $currencyCode);

--- a/Helper/PointOfSale.php
+++ b/Helper/PointOfSale.php
@@ -70,7 +70,6 @@ class PointOfSale
             if (!empty($recurringContract) && !empty($shopperEmail)) {
                 $saleToAcquirerData['shopperEmail'] = $shopperEmail;
                 $saleToAcquirerData['shopperReference'] = $this->dataHelper->padShopperReference($customerId);
-//                    str_pad((string)$customerId, 3, '0', STR_PAD_LEFT);
                 $saleToAcquirerData['recurringContract'] = $recurringContract;
             }
         }

--- a/Helper/PointOfSale.php
+++ b/Helper/PointOfSale.php
@@ -69,7 +69,8 @@ class PointOfSale
 
             if (!empty($recurringContract) && !empty($shopperEmail)) {
                 $saleToAcquirerData['shopperEmail'] = $shopperEmail;
-                $saleToAcquirerData['shopperReference'] = str_pad((string)$customerId, 3, '0', STR_PAD_LEFT);
+                $saleToAcquirerData['shopperReference'] = $this->dataHelper->padShopperReference($customerId);
+//                    str_pad((string)$customerId, 3, '0', STR_PAD_LEFT);
                 $saleToAcquirerData['recurringContract'] = $recurringContract;
             }
         }

--- a/Helper/Requests.php
+++ b/Helper/Requests.php
@@ -54,11 +54,6 @@ class Requests extends AbstractHelper
     private $vaultHelper;
 
     /**
-     * @var Data
-     */
-    private $dataHelper;
-
-    /**
      * Requests constructor.
      *
      * @param Data $adyenHelper
@@ -74,8 +69,7 @@ class Requests extends AbstractHelper
         Address $addressHelper,
         StateData $stateData,
         PaymentMethods $paymentMethodsHelper,
-        Vault $vaultHelper,
-        Data $dataHelper
+        Vault $vaultHelper
     ) {
         $this->adyenHelper = $adyenHelper;
         $this->adyenConfig = $adyenConfig;
@@ -83,7 +77,6 @@ class Requests extends AbstractHelper
         $this->stateData = $stateData;
         $this->paymentMethodsHelper = $paymentMethodsHelper;
         $this->vaultHelper = $vaultHelper;
-        $this->dataHelper = $dataHelper;
     }
 
     /**
@@ -434,7 +427,7 @@ class Requests extends AbstractHelper
     public function getShopperReference($customerId, $orderIncrementId): string
     {
         if ($customerId) {
-            $shopperReference = $this->dataHelper->padShopperReference($customerId);
+            $shopperReference = $this->adyenHelper->padShopperReference($customerId);
         } else {
             $uuid = Uuid::generateV4();
             $guestCustomerId = $orderIncrementId . $uuid;

--- a/Helper/Requests.php
+++ b/Helper/Requests.php
@@ -54,6 +54,11 @@ class Requests extends AbstractHelper
     private $vaultHelper;
 
     /**
+     * @var Data
+     */
+    private $dataHelper;
+
+    /**
      * Requests constructor.
      *
      * @param Data $adyenHelper
@@ -69,7 +74,8 @@ class Requests extends AbstractHelper
         Address $addressHelper,
         StateData $stateData,
         PaymentMethods $paymentMethodsHelper,
-        Vault $vaultHelper
+        Vault $vaultHelper,
+        Data $dataHelper
     ) {
         $this->adyenHelper = $adyenHelper;
         $this->adyenConfig = $adyenConfig;
@@ -77,6 +83,7 @@ class Requests extends AbstractHelper
         $this->stateData = $stateData;
         $this->paymentMethodsHelper = $paymentMethodsHelper;
         $this->vaultHelper = $vaultHelper;
+        $this->dataHelper = $dataHelper;
     }
 
     /**
@@ -427,7 +434,7 @@ class Requests extends AbstractHelper
     public function getShopperReference($customerId, $orderIncrementId): string
     {
         if ($customerId) {
-            $shopperReference = str_pad($customerId, 3, '0', STR_PAD_LEFT);
+            $shopperReference = $this->dataHelper->padShopperReference($customerId);
         } else {
             $uuid = Uuid::generateV4();
             $guestCustomerId = $orderIncrementId . $uuid;

--- a/Model/AdyenInitiateTerminalApi.php
+++ b/Model/AdyenInitiateTerminalApi.php
@@ -263,7 +263,6 @@ class AdyenInitiateTerminalApi implements AdyenInitiateTerminalApiInterface
             if (!empty($recurringContract) && !empty($shopperEmail)) {
                 $saleToAcquirerData['shopperEmail'] = $shopperEmail;
                 $saleToAcquirerData['shopperReference'] = $this->adyenHelper->padShopperReference($customerId);
-//                                    str_pad((string)$customerId, 3, '0', STR_PAD_LEFT);
                 $saleToAcquirerData['recurringContract'] = $recurringContract;
             }
         }

--- a/Model/AdyenInitiateTerminalApi.php
+++ b/Model/AdyenInitiateTerminalApi.php
@@ -262,7 +262,8 @@ class AdyenInitiateTerminalApi implements AdyenInitiateTerminalApiInterface
 
             if (!empty($recurringContract) && !empty($shopperEmail)) {
                 $saleToAcquirerData['shopperEmail'] = $shopperEmail;
-                $saleToAcquirerData['shopperReference'] = str_pad((string)$customerId, 3, '0', STR_PAD_LEFT);
+                $saleToAcquirerData['shopperReference'] = $this->adyenHelper->padShopperReference($customerId);
+//                                    str_pad((string)$customerId, 3, '0', STR_PAD_LEFT);
                 $saleToAcquirerData['recurringContract'] = $recurringContract;
             }
         }

--- a/Model/Api/AdyenDonations.php
+++ b/Model/Api/AdyenDonations.php
@@ -13,6 +13,7 @@
 namespace Adyen\Payment\Model\Api;
 
 use Adyen\Payment\Api\AdyenDonationsInterface;
+use Adyen\Payment\Helper\Data;
 use Adyen\Util\Uuid;
 use Magento\Checkout\Model\Session;
 use Magento\Framework\Exception\LocalizedException;
@@ -22,6 +23,7 @@ use Magento\Payment\Gateway\Command\CommandException;
 use Magento\Payment\Gateway\Command\CommandPoolInterface;
 use Magento\Sales\Model\Order;
 use Magento\Sales\Model\OrderFactory;
+
 
 class AdyenDonations implements AdyenDonationsInterface
 {
@@ -55,16 +57,23 @@ class AdyenDonations implements AdyenDonationsInterface
      */
     private $donationTryCount;
 
+    /**
+     * @var Data
+     */
+    protected $dataHelper;
+
     public function __construct(
         CommandPoolInterface $commandPool,
         OrderFactory $orderFactory,
         Session $checkoutSession,
-        Json $jsonSerializer
+        Json $jsonSerializer,
+        Data $dataHelper
     ) {
         $this->commandPool = $commandPool;
         $this->orderFactory = $orderFactory;
         $this->checkoutSession = $checkoutSession;
         $this->jsonSerializer = $jsonSerializer;
+        $this->dataHelper = $dataHelper;
     }
 
     /**
@@ -88,7 +97,7 @@ class AdyenDonations implements AdyenDonationsInterface
 
         $customerId = $order->getCustomerId();
         if ($customerId) {
-            $payload['shopperReference'] = str_pad($customerId, 3, '0', STR_PAD_LEFT);
+            $payload['shopperReference'] = $this->dataHelper->padShopperReference($customerId);
         } else {
             $guestCustomerId = $order->getIncrementId() . Uuid::generateV4();
             $payload['shopperReference'] = $guestCustomerId;

--- a/Model/Api/PaymentRequest.php
+++ b/Model/Api/PaymentRequest.php
@@ -12,6 +12,7 @@
 namespace Adyen\Payment\Model\Api;
 
 use Magento\Framework\DataObject;
+use Adyen\Helper\Data;
 
 class PaymentRequest extends DataObject
 {
@@ -41,6 +42,11 @@ class PaymentRequest extends DataObject
     protected $_appState;
 
     /**
+     * @var Data
+     */
+    protected $dataHelper;
+
+    /**
      * PaymentRequest constructor.
      *
      * @param \Magento\Framework\Model\Context $context
@@ -56,6 +62,7 @@ class PaymentRequest extends DataObject
         \Adyen\Payment\Helper\Data $adyenHelper,
         \Adyen\Payment\Logger\AdyenLogger $adyenLogger,
         \Adyen\Payment\Model\RecurringType $recurringType,
+        Data $dataHelper,
         array $data = []
     ) {
         $this->_encryptor = $encryptor;
@@ -63,6 +70,7 @@ class PaymentRequest extends DataObject
         $this->_adyenLogger = $adyenLogger;
         $this->_recurringType = $recurringType;
         $this->_appState = $context->getAppState();
+        $this->dataHelper = $dataHelper;
     }
 
     /**
@@ -182,7 +190,7 @@ class PaymentRequest extends DataObject
         $contract = ['contract' => $recurringType];
         $request = [
             "merchantAccount" => $this->_adyenHelper->getAdyenAbstractConfigData('merchant_account', $storeId),
-            "shopperReference" => $this->getShopperReferencePadding($shopperReference),
+            "shopperReference" => $this->dataHelper->padShopperReference($shopperReference),
             "recurring" => $contract,
         ];
 
@@ -230,12 +238,12 @@ class PaymentRequest extends DataObject
         }
     }
 
-    /**
-     * @param $shopperReference
-     * @return string
-     */
-    private function getShopperReferencePadding($shopperReference)
-    {
-        return str_pad($shopperReference, 3, '0', STR_PAD_LEFT);
-    }
+//    /**
+//     * @param $shopperReference
+//     * @return string
+//     */
+//    private function getShopperReferencePadding($shopperReference)
+//    {
+//        return str_pad($shopperReference, 3, '0', STR_PAD_LEFT);
+//    }
 }

--- a/Model/Api/PaymentRequest.php
+++ b/Model/Api/PaymentRequest.php
@@ -190,7 +190,7 @@ class PaymentRequest extends DataObject
         $contract = ['contract' => $recurringType];
         $request = [
             "merchantAccount" => $this->_adyenHelper->getAdyenAbstractConfigData('merchant_account', $storeId),
-            "shopperReference" => $this->dataHelper->padShopperReference($shopperReference),
+            "shopperReference" => $this->_adyenHelper->padShopperReference($shopperReference),
             "recurring" => $contract,
         ];
 
@@ -214,7 +214,7 @@ class PaymentRequest extends DataObject
     public function disableRecurringContract($recurringDetailReference, $shopperReference, $storeId)
     {
         $merchantAccount = $this->_adyenHelper->getAdyenAbstractConfigData("merchant_account", $storeId);
-        $shopperReference = $this->getShopperReferencePadding($shopperReference);
+        $shopperReference = $this->_adyenHelper->padShopperReference($shopperReference);
         $request = [
             "merchantAccount" => $merchantAccount,
             "shopperReference" => $shopperReference,
@@ -237,13 +237,4 @@ class PaymentRequest extends DataObject
             throw new \Magento\Framework\Exception\LocalizedException(__('Failed to disable this contract'));
         }
     }
-
-//    /**
-//     * @param $shopperReference
-//     * @return string
-//     */
-//    private function getShopperReferencePadding($shopperReference)
-//    {
-//        return str_pad($shopperReference, 3, '0', STR_PAD_LEFT);
-//    }
 }

--- a/Model/Api/PaymentRequest.php
+++ b/Model/Api/PaymentRequest.php
@@ -12,7 +12,6 @@
 namespace Adyen\Payment\Model\Api;
 
 use Magento\Framework\DataObject;
-use Adyen\Helper\Data;
 
 class PaymentRequest extends DataObject
 {
@@ -42,11 +41,6 @@ class PaymentRequest extends DataObject
     protected $_appState;
 
     /**
-     * @var Data
-     */
-    protected $dataHelper;
-
-    /**
      * PaymentRequest constructor.
      *
      * @param \Magento\Framework\Model\Context $context
@@ -62,7 +56,6 @@ class PaymentRequest extends DataObject
         \Adyen\Payment\Helper\Data $adyenHelper,
         \Adyen\Payment\Logger\AdyenLogger $adyenLogger,
         \Adyen\Payment\Model\RecurringType $recurringType,
-        Data $dataHelper,
         array $data = []
     ) {
         $this->_encryptor = $encryptor;
@@ -70,7 +63,6 @@ class PaymentRequest extends DataObject
         $this->_adyenLogger = $adyenLogger;
         $this->_recurringType = $recurringType;
         $this->_appState = $context->getAppState();
-        $this->dataHelper = $dataHelper;
     }
 
     /**

--- a/Test/Unit/Model/AdyenInitiateTerminalApiTest.php
+++ b/Test/Unit/Model/AdyenInitiateTerminalApiTest.php
@@ -57,6 +57,9 @@ class AdyenInitiateTerminalApiTest extends \PHPUnit\Framework\TestCase
         $adyenHelper->method('getAdyenPosCloudConfigData')
             ->will($this->returnValueMap($map));
 
+        $adyenHelper->method('padShopperReference')
+            ->will($this->returnValue(self::CUSTOMER_ID));
+
         $adyenHelper->method('getModuleName')
             ->will($this->returnValue(self::MODULE_NAME));
 


### PR DESCRIPTION
**Description**
Since checkout v66 Shopper reference should be 3 digits and above which means in cases that is less the api returns error. Add a method that pads all the shopper reference before adding it to any request.


**Tested scenarios**
- made sure all the requests where the $shopperReference is relevant, have that variable padded