### PR TITLE
Revert the one_click in recurring data builder

### DIFF
--- a/Gateway/Request/RecurringDataBuilder.php
+++ b/Gateway/Request/RecurringDataBuilder.php
@@ -21,24 +21,25 @@ use Magento\Payment\Gateway\Request\BuilderInterface;
 
 class RecurringDataBuilder implements BuilderInterface
 {
-    /** @var Requests  */
+    /** @var Requests */
     private $adyenRequestsHelper;
 
-    /** @var AdyenLogger  */
+    /** @var AdyenLogger */
     private $adyenLogger;
 
-    /** @var Vault  */
+    /** @var Vault */
     private $vaultHelper;
 
-    /** @var StateData  */
+    /** @var StateData */
     private $stateData;
 
     public function __construct(
-        Requests $adyenRequestsHelper,
+        Requests    $adyenRequestsHelper,
         AdyenLogger $adyenLogger,
-        Vault $vaultHelper,
-        StateData $stateData
-    ) {
+        Vault       $vaultHelper,
+        StateData   $stateData
+    )
+    {
         $this->adyenRequestsHelper = $adyenRequestsHelper;
         $this->adyenLogger = $adyenLogger;
         $this->vaultHelper = $vaultHelper;
@@ -63,6 +64,8 @@ class RecurringDataBuilder implements BuilderInterface
         } elseif ($method === PaymentMethods::ADYEN_HPP) {
             $brand = $this->stateData->getPaymentMethodVariant($order->getQuoteId());
             $body = $this->vaultHelper->buildPaymentMethodRecurringData($storeId, $brand);
+        } elseif ($method === PaymentMethods::ADYEN_ONE_CLICK) {
+            $body = $this->adyenRequestsHelper->buildAdyenTokenizedPaymentRecurringData($storeId, $payment);
         } elseif ($method !== PaymentMethods::ADYEN_PAY_BY_LINK) {
             $this->adyenLogger->addAdyenWarning(
                 sprintf('Unknown payment method: %s', $payment->getMethod()),


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
In this [PR](https://github.com/Adyen/adyen-magento2/pull/1762) the recurring builder for one click was removed. With this PR we are adding it again
**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

**Fixes**:  <!-- #-prefixed issue number -->
Release [8.8.0](https://github.com/Adyen/adyen-magento2/pull/1771)