### PR TITLE
[PW-7274] - Clear additional information before setting in the observer

### DIFF
--- a/Observer/AdyenBoletoDataAssignObserver.php
+++ b/Observer/AdyenBoletoDataAssignObserver.php
@@ -62,6 +62,10 @@ class AdyenBoletoDataAssignObserver extends AbstractDataAssignObserver
         }
 
         $paymentInfo = $this->readPaymentModelArgument($observer);
+
+        // Remove remaining additional information from the previous payment
+        $paymentInfo->unsAdditionalInformation();
+
         if (!empty($additionalData[self::BOLETO_TYPE])) {
             $paymentInfo->setCcType($additionalData[self::BOLETO_TYPE]);
         } else {

--- a/Observer/AdyenCcDataAssignObserver.php
+++ b/Observer/AdyenCcDataAssignObserver.php
@@ -85,6 +85,9 @@ class AdyenCcDataAssignObserver extends AbstractDataAssignObserver
         $data = $this->readDataArgument($observer);
         $paymentInfo = $this->readPaymentModelArgument($observer);
 
+        // Remove remaining additional information from the previous payment
+        $paymentInfo->unsAdditionalInformation();
+
         // Get additional data array
         $additionalData = $data->getData(PaymentInterface::KEY_ADDITIONAL_DATA);
         if (!is_array($additionalData)) {

--- a/Observer/AdyenHppDataAssignObserver.php
+++ b/Observer/AdyenHppDataAssignObserver.php
@@ -89,6 +89,9 @@ class AdyenHppDataAssignObserver extends AbstractDataAssignObserver
         $data = $this->readDataArgument($observer);
         $paymentInfo = $this->readPaymentModelArgument($observer);
 
+        // Remove remaining additional information from the previous payment
+        $paymentInfo->unsAdditionalInformation();
+
         // Get additional data array
         $additionalData = $data->getData(PaymentInterface::KEY_ADDITIONAL_DATA);
         if (!is_array($additionalData)) {

--- a/Observer/AdyenOneclickDataAssignObserver.php
+++ b/Observer/AdyenOneclickDataAssignObserver.php
@@ -98,6 +98,9 @@ class AdyenOneclickDataAssignObserver extends AbstractDataAssignObserver
         $data = $this->readDataArgument($observer);
         $paymentInfo = $this->readPaymentModelArgument($observer);
 
+        // Remove remaining additional information from the previous payment
+        $paymentInfo->unsAdditionalInformation();
+
         // Get additional data array
         $additionalData = $data->getData(PaymentInterface::KEY_ADDITIONAL_DATA);
         if (!is_array($additionalData)) {


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Additional information in the observer collects all the information during the payment attempts. It causes unrelated information to be saved in the `additionalInformation` column of `sales_order_payment` table. That information comes from the previous payment attempts and observer doesn't clean it up. 

Before setting an additional information in the observer, now plugin clears it first.

**Fixes**:  #1736
