### PR TITLE
[PW-6589] - Validate only Adyen payment methods in Multishipping

### DIFF
--- a/view/frontend/web/js/view/checkout/multishipping/payment-mixin.js
+++ b/view/frontend/web/js/view/checkout/multishipping/payment-mixin.js
@@ -30,7 +30,14 @@ define([
             widgetFullName,
             jQuery[originalWidget.prototype.namespace][originalWidget.prototype.widgetName], {
                 _validatePaymentMethod: function () {
-                    return !!$('#stateData').val() && this._super();
+                    let isValid;
+                    let selectedPaymentMethod = $('#payment-methods input[name="payment[method]"]:checked').val();
+                    if (!!selectedPaymentMethod && selectedPaymentMethod.startsWith('adyen')) {
+                        isValid = !!$('#stateData').val();
+                    } else {
+                        isValid = true;
+                    }
+                    return isValid && this._super();
                 }
             });
     }


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
`payment-mixin.js` file tries to validate non-Adyen payment methods. This results in blocking other payment methods. Now, this file only validates Adyen payment methods.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

**Fixes**:  #1475 