### PR TITLE
[PW-7127] Replace the base currency with notification currency code

### DIFF
--- a/Helper/AdyenOrderPayment.php
+++ b/Helper/AdyenOrderPayment.php
@@ -203,7 +203,8 @@ class AdyenOrderPayment extends AbstractHelper
     {
         $adyenOrderPayment = null;
         $payment = $order->getPayment();
-        $amount = $this->adyenDataHelper->originalAmount($notification->getAmountValue(), $order->getBaseCurrencyCode());
+        $amount = $this->adyenDataHelper->originalAmount($notification->getAmountValue(),
+            $notification->getAmountCurrency());
         $captureStatus = $autoCapture ? Payment::CAPTURE_STATUS_AUTO_CAPTURE : Payment::CAPTURE_STATUS_NO_CAPTURE;
         $merchantReference = $notification->getMerchantReference();
         $pspReference = $notification->getPspreference();


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Plugin adds a decimal for specific currencies and causes missmatch error. The issue is that some currencies do not have decimal digits like `JPY` which has no decimals, so in minor units submit an amount of 10. The comparison between notification value and order amount is failing for this [line](https://github.com/Adyen/adyen-magento2/blob/59311469024c8c3e399a2af7c06113cc0b1c27c1/Helper/AdyenOrderPayment.php#L294) as the amounts are formatted in different types int or float. That cause the comparison for `isFullAmountFinalized` to fail. The problem is that the formatting is using the base amount and not the notification amout


**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
Tested for notifications with currency:
- JPY
- EUR
- GBP
