### PR TITLE
Issue #1787 - Improved handling of transient exceptions when saving an order during webhook processing

### DIFF
--- a/Helper/Webhook.php
+++ b/Helper/Webhook.php
@@ -27,6 +27,7 @@ use Magento\Framework\Serialize\SerializerInterface;
 use Magento\Framework\Stdlib\DateTime\TimezoneInterface;
 use Magento\Sales\Model\Order;
 use Magento\Sales\Model\OrderRepository;
+use Magento\Framework\DB\Adapter;
 
 class Webhook
 {
@@ -173,6 +174,7 @@ class Webhook
                 $this->orderRepository->save($order);
             } catch (Exception $e) {
                 $this->logger->addAdyenWarning($e->getMessage());
+				if($this->isTransient($e)) throw $e;
             }
 
             $this->updateNotification($notification, false, true);
@@ -558,4 +560,12 @@ class Webhook
 
         return $order;
     }
+
+	private function isTransient(\Exception $e)
+	{
+		return ($e instanceof Adapter\LockWaitException
+		 || $e instanceof Adapter\DeadlockException
+		 || $e instanceof Adapter\ConnectionException
+		);
+	}
 }


### PR DESCRIPTION
**Description**
These changes address concerns outlines in issue #1787  regarding generic exception catching during the order save operation when processing a webhook and the current approach of ignoring transient exceptions and assuming all exceptions are not recoverable.

**Tested scenarios**
This has been tested by throwing a Deadlock exception in Magento\Sales\Model\Order\ItemRepository::save() and checking the webhook logs the error, does not mark the webhook as procesed, and increments the error count.

**Fixes**:  #1787  
