### PR TITLE
[PW-7394] - Clear brand_code information before setting in the observer

### DIFF
--- a/Observer/AdyenBoletoDataAssignObserver.php
+++ b/Observer/AdyenBoletoDataAssignObserver.php
@@ -63,8 +63,8 @@ class AdyenBoletoDataAssignObserver extends AbstractDataAssignObserver
 
         $paymentInfo = $this->readPaymentModelArgument($observer);
 
-        // Remove remaining additional information from the previous payment
-        $paymentInfo->unsAdditionalInformation();
+        // Remove remaining brand_code information from the previous payment
+        $paymentInfo->unsAdditionalInformation('brand_code');
 
         if (!empty($additionalData[self::BOLETO_TYPE])) {
             $paymentInfo->setCcType($additionalData[self::BOLETO_TYPE]);

--- a/Observer/AdyenCcDataAssignObserver.php
+++ b/Observer/AdyenCcDataAssignObserver.php
@@ -85,8 +85,8 @@ class AdyenCcDataAssignObserver extends AbstractDataAssignObserver
         $data = $this->readDataArgument($observer);
         $paymentInfo = $this->readPaymentModelArgument($observer);
 
-        // Remove remaining additional information from the previous payment
-        $paymentInfo->unsAdditionalInformation();
+        // Remove remaining brand_code information from the previous payment
+        $paymentInfo->unsAdditionalInformation('brand_code');
 
         // Get additional data array
         $additionalData = $data->getData(PaymentInterface::KEY_ADDITIONAL_DATA);

--- a/Observer/AdyenHppDataAssignObserver.php
+++ b/Observer/AdyenHppDataAssignObserver.php
@@ -89,8 +89,8 @@ class AdyenHppDataAssignObserver extends AbstractDataAssignObserver
         $data = $this->readDataArgument($observer);
         $paymentInfo = $this->readPaymentModelArgument($observer);
 
-        // Remove remaining additional information from the previous payment
-        $paymentInfo->unsAdditionalInformation();
+        // Remove remaining brand_code information from the previous payment
+        $paymentInfo->unsAdditionalInformation('brand_code');
 
         // Get additional data array
         $additionalData = $data->getData(PaymentInterface::KEY_ADDITIONAL_DATA);

--- a/Observer/AdyenOneclickDataAssignObserver.php
+++ b/Observer/AdyenOneclickDataAssignObserver.php
@@ -98,8 +98,8 @@ class AdyenOneclickDataAssignObserver extends AbstractDataAssignObserver
         $data = $this->readDataArgument($observer);
         $paymentInfo = $this->readPaymentModelArgument($observer);
 
-        // Remove remaining additional information from the previous payment
-        $paymentInfo->unsAdditionalInformation();
+        // Remove remaining brand_code information from the previous payment
+        $paymentInfo->unsAdditionalInformation('brand_code');
 
         // Get additional data array
         $additionalData = $data->getData(PaymentInterface::KEY_ADDITIONAL_DATA);


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
This issue was first handled in PR #1784 however clearing all of the additional information also deletes the required information for vault payments.

Only `brand_code` is being cleared as suggested in the original Github [issue](https://github.com/Adyen/adyen-magento2/issues/1736).

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- Failing PayPal payment followed by a successful credit card payment
- Card tokenisation and vault payment