### PR TITLE
[PW-7276] - Remove X-cross button from payment action modal

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/adyen-hpp-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-hpp-method.js
@@ -415,6 +415,7 @@ define(
                 } else {
                     if (resultCode !== 'RedirectShopper') {
                         self.popupModal = adyenPaymentModal.showModal(adyenPaymentService, fullScreenLoader, this.messageContainer, this.orderId, this.modalLabel, this.isPlaceOrderActionAllowed)
+                        $("." + this.modalLabel + " .action-close").hide();
                     }
                     self.actionComponent = self.checkoutComponent.createFromAction(action).mount(actionNode);
                 }


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
X-cross button was responsible for cancelling the order to allow the shopper to change the payment method. However, during the slow internet connections and after completing the payment according to the instructions on the modal, if shopper closes the modal manually, payment is cancelled on Magento and successful on Adyen side. To handle that tricky situation, cross button is removed from alternative payment method's payment action modal.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- Bancontact Mobile
