### PR TITLE
[PW-7428] Run e2e tests only against v8 of the plugin

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -51,7 +51,7 @@ jobs:
         run: docker exec magento2-container make fs
 
       - name: Run E2E tests
-        if: ${{ matrix.php-version }} == "8.1"
+        if: ${{ matrix.php-version == '8.1'}} 
         run: docker-compose -f .github/workflows/templates/docker-compose.yml run --rm playwright /e2e.sh
         env:
           INTEGRATION_TESTS_BRANCH: develop


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
[PW-7428]  Run e2e tests only against Adyen Magento Plugin v8
