### PR TITLE
[PW-7451] Incorrect return type getOrderByIncrementId

### DIFF
--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -617,7 +617,7 @@ class Order extends AbstractHelper
 
         $orders = $this->orderRepository->getList($searchCriteria)->getItems();
 
-        return reset($orders);
+        return reset($orders) ?? null;
     }
 
     /**

--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -23,6 +23,7 @@ use Magento\Framework\App\Helper\Context;
 use Magento\Framework\DB\TransactionFactory;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Notification\NotifierPool;
+use Magento\Sales\Api\Data\OrderInterface;
 use Magento\Sales\Api\Data\TransactionInterface;
 use Magento\Sales\Model\Order as MagentoOrder;
 use Magento\Sales\Model\Order\Email\Sender\OrderSender;
@@ -609,7 +610,7 @@ class Order extends AbstractHelper
         return $order;
     }
 
-    public function getOrderByIncrementId(string $incrementId): ?MagentoOrder
+    public function getOrderByIncrementId(string $incrementId): ?OrderInterface
     {
         $searchCriteria = $this->searchCriteriaBuilder
             ->addFilter('increment_id', $incrementId)
@@ -617,7 +618,7 @@ class Order extends AbstractHelper
 
         $orders = $this->orderRepository->getList($searchCriteria)->getItems();
 
-        return reset($orders) ?? null;
+        return $orders ? reset($orders) : null;
     }
 
     /**


### PR DESCRIPTION
**Description**
Currently in the getOrderByIncrementId function, if no order is found we are returning false instead of null (as expected by the function signature). We should handle false, and if that is the case transform it to null.

**Tested scenarios**
- happy flow -> create new payment, proceed with processing the notification and make sure the order from the `sales_order` table is fetched
- unhappy flow-> create new payment, manually remove the related record in the `sales_order` table, try to process the notification and make sure the value returned is `null` as opposed to `false`

