### PR TITLE
PW-7447 - Return empty array if additionalData is empty

### DIFF
--- a/Helper/Webhook.php
+++ b/Helper/Webhook.php
@@ -279,7 +279,7 @@ class Webhook
     {
         $additionalData = !empty($notification->getAdditionalData()) ? $this->serializer->unserialize(
             $notification->getAdditionalData()
-        ) : "";
+        ) : [];
 
         if (is_array($additionalData)) {
             $additionalData2 = $additionalData['additionalData'] ?? null;

--- a/Helper/Webhook.php
+++ b/Helper/Webhook.php
@@ -281,7 +281,7 @@ class Webhook
             $notification->getAdditionalData()
         ) : [];
 
-        if (is_array($additionalData)) {
+        if (!empty($additionalData)) {
             $additionalData2 = $additionalData['additionalData'] ?? null;
             if ($additionalData2 && is_array($additionalData2)) {
                 $this->klarnaReservationNumber = isset($additionalData2['acquirerReference']) ? trim(
@@ -406,7 +406,7 @@ class Webhook
 
         $additionalData = !empty($notification->getAdditionalData()) ? $this->serializer->unserialize(
             $notification->getAdditionalData()
-        ) : "";
+        ) : [];
 
         if ($notification->getEventCode() == Notification::AUTHORISATION
             || $notification->getEventCode() == Notification::HANDLED_EXTERNALLY


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
Currently, if a webhook has no additionalData, an empty string [is returned](https://github.com/Adyen/adyen-magento2/blob/a72ed17dbd0d1bfe58fa9ab101f0910c68a90887/Helper/Webhook.php#L407). This will then cause an issue when the `updateOrderPaymentWithAdyenAttributes` function, which requires an array as its third parameter is then called.

**Tested scenarios**
* Auth webhook
* Webhook w/o additional data
