### PR TITLE
[PW-7472] Vault token can't be generated from 3DS2 payments

### DIFF
--- a/Helper/PaymentResponseHandler.php
+++ b/Helper/PaymentResponseHandler.php
@@ -15,7 +15,6 @@ use Adyen\Payment\Exception\PaymentMethodException;
 use Adyen\Payment\Helper\PaymentMethods\AbstractWalletPaymentMethod;
 use Adyen\Payment\Helper\PaymentMethods\PaymentMethodFactory;
 use Adyen\Payment\Logger\AdyenLogger;
-use Adyen\Payment\Model\Ui\AdyenCcConfigProvider;
 use Adyen\Payment\Model\Ui\AdyenHppConfigProvider;
 use Adyen\Payment\Model\Ui\AdyenOneclickConfigProvider;
 use Adyen\Payment\Observer\AdyenHppDataAssignObserver;
@@ -37,8 +36,6 @@ class PaymentResponseHandler
     const PRESENT_TO_SHOPPER = 'PresentToShopper';
     const ERROR = 'Error';
     const CANCELLED = 'Cancelled';
-    const ADYEN_TOKENIZATION = 'Adyen Tokenization';
-    const VAULT = 'Magento Vault';
 
     /**
      * @var AdyenLogger
@@ -250,19 +247,11 @@ class PaymentResponseHandler
                         }
                     } else {
                         $order = $payment->getOrder();
-                        $recurringMode = $this->configHelper->getCardRecurringMode($storeId);
-
-                        // if adyen tokenization set up, create entry in paypal_billing_agreement table
-                        if ($recurringMode === self::ADYEN_TOKENIZATION) {
-                            $this->recurringHelper->createAdyenBillingAgreement(
-                                $order,
-                                $paymentsResponse['additionalData'],
-                                $payment->getAdditionalInformation()
-                            );
-                        // if vault set up, create entry in vault_payment_token table
-                        } elseif ($recurringMode === self::VAULT  && $paymentInstanceCode === AdyenCcConfigProvider::CODE) {
-                            $this->vaultHelper->saveRecurringCardDetails($payment, $paymentsResponse['additionalData']);
-                        }
+                        $this->recurringHelper->createAdyenBillingAgreement(
+                            $order,
+                            $paymentsResponse['additionalData'],
+                            $payment->getAdditionalInformation()
+                        );
                     }
                 }
 

--- a/Helper/PaymentResponseHandler.php
+++ b/Helper/PaymentResponseHandler.php
@@ -15,6 +15,7 @@ use Adyen\Payment\Exception\PaymentMethodException;
 use Adyen\Payment\Helper\PaymentMethods\AbstractWalletPaymentMethod;
 use Adyen\Payment\Helper\PaymentMethods\PaymentMethodFactory;
 use Adyen\Payment\Logger\AdyenLogger;
+use Adyen\Payment\Model\Ui\AdyenCcConfigProvider;
 use Adyen\Payment\Model\Ui\AdyenHppConfigProvider;
 use Adyen\Payment\Model\Ui\AdyenOneclickConfigProvider;
 use Adyen\Payment\Observer\AdyenHppDataAssignObserver;
@@ -36,6 +37,8 @@ class PaymentResponseHandler
     const PRESENT_TO_SHOPPER = 'PresentToShopper';
     const ERROR = 'Error';
     const CANCELLED = 'Cancelled';
+    const ADYEN_TOKENIZATION = 'Adyen Tokenization';
+    const VAULT = 'Magento Vault';
 
     /**
      * @var AdyenLogger
@@ -247,11 +250,19 @@ class PaymentResponseHandler
                         }
                     } else {
                         $order = $payment->getOrder();
-                        $this->recurringHelper->createAdyenBillingAgreement(
-                            $order,
-                            $paymentsResponse['additionalData'],
-                            $payment->getAdditionalInformation()
-                        );
+                        $recurringMode = $this->configHelper->getCardRecurringMode($storeId);
+
+                        // if adyen tokenization set up, create entry in paypal_billing_agreement table
+                        if ($recurringMode === self::ADYEN_TOKENIZATION) {
+                            $this->recurringHelper->createAdyenBillingAgreement(
+                                $order,
+                                $paymentsResponse['additionalData'],
+                                $payment->getAdditionalInformation()
+                            );
+                        // if vault set up, create entry in vault_payment_token table
+                        } elseif ($recurringMode === self::VAULT  && $paymentInstanceCode === AdyenCcConfigProvider::CODE) {
+                            $this->vaultHelper->saveRecurringCardDetails($payment, $paymentsResponse['additionalData']);
+                        }
                     }
                 }
 


### PR DESCRIPTION
**Description**
This PR addresses a bug in the recurring flow. Currently, when a shopper tries to save the card details for future payments using a 3DS2 card, the token is not created and we are not populating `vault_payment_token` table. The reason for this is that within the 3DS2 payment flow, in the response to `/payment/details` endpoint we are checking whether the payment is done with a stored alternative payment method. As this is not the case with credit card payments, this function returns false. Therefore, we execute the part of the code that creates a billing agreement.
This is not correct, hence this PR. The implemented solution checks whether the payment is done with a credit card and also recurring mode (Adyen Tokenization or Vault). If Vault, it creates a new entry in the `vault_payment_token` table, otherwise it proceeds with creation of billing agreement.

**Tested scenarios**
- 3DS2 payment, make sure the token is saved and can be used later
