### PR TITLE
[PW-7452] - Use fundingSource parameter for combo cards

### DIFF
--- a/Gateway/Request/CheckoutDataBuilder.php
+++ b/Gateway/Request/CheckoutDataBuilder.php
@@ -192,13 +192,14 @@ class CheckoutDataBuilder implements BuilderInterface
         if ($numberOfInstallments > 0) {
             $requestBody['installments']['value'] = $numberOfInstallments;
         }
-        // if card type is debit then change the issuer type and unset the installments field
+
+        /*
+         * if the combo card type is debit then add the funding source
+         * and unset the installments & brand fields
+         */
         if ($comboCardType == 'debit') {
-            if ($selectedDebitBrand = $this->getSelectedDebitBrand($payment->getAdditionalInformation('cc_type'))) {
-                $requestBody['additionalData']['overwriteBrand'] = true;
-                $requestBody['selectedBrand'] = $selectedDebitBrand;
-                $requestBody['paymentMethod']['type'] = $selectedDebitBrand;
-            }
+            $requestBody['paymentMethod']['fundingSource'] = 'debit';
+            unset($requestBody['paymentMethod']['brand']);
             unset($requestBody['installments']);
         }
 
@@ -235,21 +236,6 @@ class CheckoutDataBuilder implements BuilderInterface
             "city" => $shippingAddress->getCity(),
             "country" => $shippingAddress->getCountryId()
         ];
-    }
-
-    /**
-     * @param string $brand
-     * @return string
-     */
-    private function getSelectedDebitBrand($brand)
-    {
-        if ($brand == 'VI') {
-            return 'electron';
-        }
-        if ($brand == 'MC') {
-            return 'maestro';
-        }
-        return null;
     }
 
     /**


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Previously, card type and brand were overridden to support debit rail of the combo cards. However, overriding the card type may create a confliction. Since, the card may have a different debit rail (ex: mcdebit instead of maestro).

Instead of overriding the card type and brand, `fundingSource` parameter is being used as suggested by Checkout API.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- Combo card payments with debit and credit card options with BRL and an address from Brazil.