### PR TITLE
[PW-7476] Fetch CC brands array from paymentMethods response for multishipping

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/multishipping/adyen-cc-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/multishipping/adyen-cc-method.js
@@ -33,7 +33,7 @@ define([
             }
             self.cardComponent = self.checkoutComponent.create('card', {
                 enableStoreDetails: self.getEnableStoreDetails(),
-                brands: self.getAvailableCardTypeAltCodes(),
+                brands: self.getBrands(),
                 hasHolderName: adyenConfiguration.getHasHolderName(),
                 holderNameRequired: adyenConfiguration.getHasHolderName() &&
                   adyenConfiguration.getHolderNameRequired(),


### PR DESCRIPTION
**Description**
This PR introduces a change in how we are fetching the available credit card brands array for the multishipping credit card component. We are now making use of getBrands() method of the extended component.

**Tested scenarios**
- made sure the brands array is fetched from the Adyen CA directly