### PR TITLE
[PW-7506] Correct unit tests namespace

### DIFF
--- a/Test/Unit/AbstractAdyenTestCase.php
+++ b/Test/Unit/AbstractAdyenTestCase.php
@@ -8,7 +8,7 @@
  *
  * Author: Adyen <magento@adyen.com>
  */
-namespace Adyen\Payment\Tests\Unit;
+namespace Adyen\Payment\Test\Unit;
 
 use Adyen\Payment\Api\Data\OrderPaymentInterface;
 use Adyen\Payment\Model\Notification;

--- a/Test/Unit/Block/Form/PayByLinkTest.php
+++ b/Test/Unit/Block/Form/PayByLinkTest.php
@@ -9,7 +9,7 @@
  * Author: Adyen <magento@adyen.com>
  */
 
-namespace Adyen\Payment\Tests\Block\Form;
+namespace Adyen\Payment\Test\Block\Form;
 
 use Adyen\Payment\Block\Form\PayByLink;
 use Adyen\Payment\Model\Ui\AdyenPayByLinkConfigProvider;

--- a/Test/Unit/Gateway/Validator/PayByLinkValidatorTest.php
+++ b/Test/Unit/Gateway/Validator/PayByLinkValidatorTest.php
@@ -9,7 +9,7 @@
  * Author: Adyen <magento@adyen.com>
  */
 
-namespace Adyen\Payment\Tests\Gateway\Validator;
+namespace Adyen\Payment\Test\Gateway\Validator;
 
 use Adyen\Payment\Gateway\Validator\PayByLinkValidator;
 use Adyen\Payment\Model\Ui\AdyenPayByLinkConfigProvider;

--- a/Test/Unit/Helper/AddressTest.php
+++ b/Test/Unit/Helper/AddressTest.php
@@ -9,12 +9,12 @@
  * Author: Adyen <magento@adyen.com>
  */
 
-namespace Adyen\Payment\Tests\Unit\Helper;
+namespace Adyen\Payment\Test\Unit\Helper;
 
 use Adyen\Payment\Gateway\Data\Order\AddressAdapter;
 use Adyen\Payment\Helper\Address;
 use Adyen\Payment\Logger\AdyenLogger;
-use Adyen\Payment\Tests\Unit\AbstractAdyenTestCase;
+use Adyen\Payment\Test\Unit\AbstractAdyenTestCase;
 use Magento\Payment\Gateway\Data\AddressAdapterInterface;
 
 class AddressTest extends AbstractAdyenTestCase

--- a/Test/Unit/Helper/AdyenOrderPaymentTest.php
+++ b/Test/Unit/Helper/AdyenOrderPaymentTest.php
@@ -9,7 +9,7 @@
  * Author: Adyen <magento@adyen.com>
  */
 
-namespace Adyen\Payment\Tests\Unit\Helper;
+namespace Adyen\Payment\Test\Unit\Helper;
 
 use Adyen\Payment\Api\Data\OrderPaymentInterface;
 use Adyen\Payment\Helper\AdyenOrderPayment;
@@ -22,7 +22,7 @@ use Adyen\Payment\Model\Notification;
 use Adyen\Payment\Model\Order\Payment as AdyenPaymentModel;
 use Adyen\Payment\Model\Order\PaymentFactory;
 use Adyen\Payment\Model\ResourceModel\Order\Payment;
-use Adyen\Payment\Tests\Unit\AbstractAdyenTestCase;
+use Adyen\Payment\Test\Unit\AbstractAdyenTestCase;
 use Magento\Framework\App\Helper\Context;
 use Magento\Sales\Model\Order;
 

--- a/Test/Unit/Helper/CaseManagementTest.php
+++ b/Test/Unit/Helper/CaseManagementTest.php
@@ -9,12 +9,12 @@
  * Author: Adyen <magento@adyen.com>
  */
 
-namespace Adyen\Payment\Tests\Unit\Helper;
+namespace Adyen\Payment\Test\Unit\Helper;
 
 use Adyen\Payment\Helper\CaseManagement;
 use Adyen\Payment\Helper\Config;
 use Adyen\Payment\Logger\AdyenLogger;
-use Adyen\Payment\Tests\Unit\AbstractAdyenTestCase;
+use Adyen\Payment\Test\Unit\AbstractAdyenTestCase;
 use Magento\Framework\App\Helper\Context;
 use PHPUnit\Framework\TestCase;
 

--- a/Test/Unit/Helper/ChargedCurrencyTest.php
+++ b/Test/Unit/Helper/ChargedCurrencyTest.php
@@ -9,12 +9,12 @@
  * Author: Adyen <magento@adyen.com>
  */
 
-namespace Adyen\Payment\Tests\Helper\Unit;
+namespace Adyen\Payment\Test\Helper\Unit;
 
 use Adyen\Payment\Helper\ChargedCurrency;
 use Adyen\Payment\Helper\Config;
 use Adyen\Payment\Model\AdyenAmountCurrency;
-use Adyen\Payment\Tests\Unit\AbstractAdyenTestCase;
+use Adyen\Payment\Test\Unit\AbstractAdyenTestCase;
 use Magento\Quote\Model\Quote;
 use Magento\Sales\Api\Data\CreditmemoInterface;
 use Magento\Sales\Api\Data\CreditmemoItemInterface;

--- a/Test/Unit/Helper/DataTest.php
+++ b/Test/Unit/Helper/DataTest.php
@@ -8,7 +8,7 @@
  * Author: Adyen <magento@adyen.com>
  */
 
-namespace Adyen\Payment\Tests\Unit\Helper;
+namespace Adyen\Payment\Test\Unit\Helper;
 
 use Adyen\Payment\Helper\Config as ConfigHelper;
 use Adyen\Payment\Helper\Data;
@@ -16,7 +16,7 @@ use Adyen\Payment\Helper\Locale;
 use Adyen\Payment\Logger\AdyenLogger;
 use Adyen\Payment\Model\ResourceModel\Billing\Agreement\CollectionFactory as BillingAgreementCollectionFactory;
 use Adyen\Payment\Model\ResourceModel\Notification\CollectionFactory as NotificationCollectionFactory;
-use Adyen\Payment\Tests\Unit\AbstractAdyenTestCase;
+use Adyen\Payment\Test\Unit\AbstractAdyenTestCase;
 use Magento\Backend\Helper\Data as BackendHelper;
 use Magento\Directory\Model\Config\Source\Country;
 use Magento\Framework\App\CacheInterface;

--- a/Test/Unit/Helper/InvoiceTest.php
+++ b/Test/Unit/Helper/InvoiceTest.php
@@ -9,7 +9,7 @@
  * Author: Adyen <magento@adyen.com>
  */
 
-namespace Adyen\Payment\Tests\Unit\Helper;
+namespace Adyen\Payment\Test\Unit\Helper;
 
 use Adyen\Payment\Api\Data\InvoiceInterface;
 use Adyen\Payment\Helper\Config;
@@ -17,7 +17,7 @@ use Adyen\Payment\Helper\Data;
 use Adyen\Payment\Helper\Invoice;
 use Adyen\Payment\Model\InvoiceFactory;
 use Adyen\Payment\Model\Order\Payment;
-use Adyen\Payment\Tests\Unit\AbstractAdyenTestCase;
+use Adyen\Payment\Test\Unit\AbstractAdyenTestCase;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\Exception\AlreadyExistsException;
 use Magento\Framework\Exception\LocalizedException;

--- a/Test/Unit/Helper/IpAddressTest.php
+++ b/Test/Unit/Helper/IpAddressTest.php
@@ -9,12 +9,12 @@
  * Author: Adyen <magento@adyen.com>
  */
 
-namespace Adyen\Payment\Tests\Unit\Helper;
+namespace Adyen\Payment\Test\Unit\Helper;
 
 use Adyen\Payment\Helper\Config;
 use Adyen\Payment\Helper\IpAddress;
 use Adyen\Payment\Logger\AdyenLogger;
-use Adyen\Payment\Tests\Unit\AbstractAdyenTestCase;
+use Adyen\Payment\Test\Unit\AbstractAdyenTestCase;
 use Magento\Framework\App\CacheInterface;
 use Magento\Framework\Serialize\SerializerInterface;
 

--- a/Test/Unit/Helper/LocaleTest.php
+++ b/Test/Unit/Helper/LocaleTest.php
@@ -9,10 +9,10 @@
  * Author: Adyen <magento@adyen.com>
  */
 
-namespace Adyen\Payment\Tests\Unit\Helper;
+namespace Adyen\Payment\Test\Unit\Helper;
 
 use Adyen\Payment\Helper\Locale;
-use Adyen\Payment\Tests\Unit\AbstractAdyenTestCase;
+use Adyen\Payment\Test\Unit\AbstractAdyenTestCase;
 
 class LocaleTest extends AbstractAdyenTestCase
 {

--- a/Test/Unit/Helper/OrderTest.php
+++ b/Test/Unit/Helper/OrderTest.php
@@ -8,7 +8,7 @@
  *
  * Author: Adyen <magento@adyen.com>
  */
-namespace Adyen\Payment\Tests\Unit\Helper;
+namespace Adyen\Payment\Test\Unit\Helper;
 
 use Adyen\Payment\Helper\AdyenOrderPayment;
 use Adyen\Payment\Helper\ChargedCurrency;
@@ -23,7 +23,7 @@ use Adyen\Payment\Model\ResourceModel\Creditmemo\Creditmemo as AdyenCreditMemoRe
 use Adyen\Payment\Model\ResourceModel\Order\Payment\Collection;
 use Adyen\Payment\Model\ResourceModel\Order\Payment\CollectionFactory as OrderPaymentCollectionFactory;
 use Adyen\Payment\Logger\AdyenLogger;
-use Adyen\Payment\Tests\Unit\AbstractAdyenTestCase;
+use Adyen\Payment\Test\Unit\AbstractAdyenTestCase;
 use Magento\Framework\Api\SearchCriteriaBuilder;
 use Magento\Framework\App\Helper\Context;
 use Magento\Framework\DB\TransactionFactory;

--- a/Test/Unit/Helper/OrderTest.php
+++ b/Test/Unit/Helper/OrderTest.php
@@ -211,40 +211,6 @@ class OrderTest extends AbstractAdyenTestCase
         $orderHelper->refundOrder($order, $notification);
     }
 
-    public function testRefundOrderAdyenOrderPaymentNotFound()
-    {
-        // TypeError will be thrown from `refundAdyenOrderPayment()` method for null $orderPayment
-        $this->expectError();
-
-        $adyenOrderPaymentCollection = $this->createConfiguredMock(Collection::class, [
-            'getFirstItem' => null
-        ]);
-        $adyenOrderPaymentCollection->method('addFieldToFilter')->willReturn($adyenOrderPaymentCollection);
-
-        $adyenOrderPaymentCollectionFactory = $this->createGeneratedMock(
-            OrderPaymentCollectionFactory::class,
-            ['create']
-        );
-        $adyenOrderPaymentCollectionFactory->method('create')->willReturn($adyenOrderPaymentCollection);
-
-        $dataHelper = $this->createPartialMock(Data::class, []);
-        $adyenOrderPaymentHelper = $this->createPartialMock(AdyenOrderPayment::class, []);
-
-        $orderHelper = $this->createOrderHelper(
-            null,
-            null,
-            $adyenOrderPaymentHelper,
-            null,
-            $dataHelper,
-            $adyenOrderPaymentCollectionFactory
-        );
-
-        $order = $this->createOrder();
-        $notification = $this->createWebhook('123-refund');
-
-        $orderHelper->refundOrder($order, $notification);
-    }
-
     protected function createOrderHelper(
         $orderStatusCollectionFactory = null,
         $configHelper = null,

--- a/Test/Unit/Helper/RequestsTest.php
+++ b/Test/Unit/Helper/RequestsTest.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Adyen\Payment\Tests\Unit\Helper;
+namespace Adyen\Payment\Test\Unit\Helper;
 
 use Adyen\Payment\Helper\Address;
 use Adyen\Payment\Helper\Config;
@@ -10,7 +10,7 @@ use Adyen\Payment\Helper\Recurring;
 use Adyen\Payment\Helper\Requests;
 use Adyen\Payment\Helper\StateData;
 use Adyen\Payment\Helper\Vault;
-use Adyen\Payment\Tests\Unit\AbstractAdyenTestCase;
+use Adyen\Payment\Test\Unit\AbstractAdyenTestCase;
 use Magento\Sales\Model\Order;
 use Magento\Sales\Model\Order\Payment;
 


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
Currently, when running the unit tests from the mageneto directory, the tests are failing since the parent class is not found. The issue is that the folder was renamed from `\Tests` to `\Test` which the magento standard but the namespaces were not refactored
Also removed not applicable unit tests

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- Unit tests are passing

Fixes  <!-- #-prefixed github issue number -->
fixes #1739