### PR TITLE
Revert magento version to 2.4.4 for MFTF tests

### DIFF
--- a/.github/workflows/mftf-test.yml
+++ b/.github/workflows/mftf-test.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         include:
           - php-version: "8.1"
-            magento-version: "2.4.5"
+            magento-version: "2.4.4"
     runs-on: ubuntu-latest
     env:
       PHP_VERSION: ${{ matrix.php-version }}


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Fix MFTF test pipeline

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

Fixes  <!-- #-prefixed github issue number -->
Revert magento version to 2.4.4 for MFTF tests
