### PR TITLE
[PW-7296] - Applied Rector rules and composer.json updated for PHP 8.1 support

### DIFF
--- a/.github/docker-compose.yml
+++ b/.github/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       MARIADB_USER: magento
       MARIADB_PASSWORD: magento
   elastic:
-    image: elasticsearch:7.16.2
+    image: elasticsearch:7.17.5
     container_name: elasticsearch
     networks:
       - backend

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,7 +11,9 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: larger-runners
+      labels: ubuntu-latest-8-cores
     env:
       PHP_VERSION: "8.1"
       MAGENTO_VERSION: "2.4.5"

--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         include:
           - php-version: '8.1'
-            magento-version: '2.4.4'
+            magento-version: '2.4.5'
     runs-on: ubuntu-latest
     env:
       PHP_VERSION: ${{ matrix.php-version }}

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -5,11 +5,8 @@ jobs:
   build:
     strategy:
       matrix:
-        php-version: ["7.4"]
-        magento-version: ["2.3.7", "2.4.3"]
-        include:
-          - php-version: "8.1"
-            magento-version: "2.4.5"
+        php-version: ["8.1"]
+        magento-version: ["2.4.5"]
     runs-on: ubuntu-latest
     env:
       PHP_VERSION: ${{ matrix.php-version }}
@@ -51,7 +48,6 @@ jobs:
         run: docker exec magento2-container make fs
 
       - name: Run E2E tests
-        if: ${{ matrix.php-version == '8.1'}} 
         run: docker-compose -f .github/workflows/templates/docker-compose.yml run --rm playwright /e2e.sh
         env:
           INTEGRATION_TESTS_BRANCH: develop

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     
     strategy:
       matrix:
-        php-version: [7.3, 7.4, 8.1]
+        php-version: [8.1]
     
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/templates/docker-compose.yml
+++ b/.github/workflows/templates/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     networks:
       - backend
   elastic:
-    image: elasticsearch:7.16.2
+    image: elasticsearch:7.17.5
     container_name: elasticsearch
     ports:
       - 9200:9200

--- a/.github/workflows/templates/docker-compose.yml
+++ b/.github/workflows/templates/docker-compose.yml
@@ -59,7 +59,7 @@ services:
         aliases:
           - magento2.test.com
   playwright:
-    image: mcr.microsoft.com/playwright:v1.27.1-focal
+    image: mcr.microsoft.com/playwright:focal
     shm_size: 1gb
     ipc: host
     cap_add:

--- a/Block/Checkout/Success.php
+++ b/Block/Checkout/Success.php
@@ -153,7 +153,7 @@ class Success extends Template
     {
         $storeId = $this->storeManager->getStore()->getId();
         $imageBaseUrl = $this->storeManager->getStore()->getBaseUrl(\Magento\Framework\UrlInterface::URL_TYPE_MEDIA).'adyen/';
-        $donationAmounts = explode(',', $this->configHelper->getAdyenGivingDonationAmounts($storeId));
+        $donationAmounts = explode(',', (string) $this->configHelper->getAdyenGivingDonationAmounts($storeId));
         $donationAmounts = array_map(function ($amount) {
             return $this->adyenHelper->formatAmount($amount, $this->getOrder()->getOrderCurrencyCode());
         }, $donationAmounts);

--- a/Block/Form/Moto.php
+++ b/Block/Form/Moto.php
@@ -115,7 +115,7 @@ class Moto extends \Magento\Payment\Block\Form\Cc
     {
         $types = [];
         $ccTypes = $this->adyenHelper->getAdyenCcTypes();
-        $availableTypes = explode(',', $this->adyenHelper->getAdyenCcConfigData('cctypes'));
+        $availableTypes = explode(',', (string) $this->adyenHelper->getAdyenCcConfigData('cctypes'));
 
         foreach ($ccTypes as $code => $ccType) {
             if (in_array($code, $availableTypes)) {

--- a/Controller/Adminhtml/Configuration/MerchantAccounts.php
+++ b/Controller/Adminhtml/Configuration/MerchantAccounts.php
@@ -62,7 +62,7 @@ class MerchantAccounts extends Action
             $apiKey = $this->getRequest()->getParam('apiKey', '');
             $demoMode = (int) $this->getRequest()->getParam('demoMode');
             //Use the stored xapi key if the return value is encrypted chars only or it is empty,
-            if (!empty($apiKey) && preg_match('/^\*+$/', $apiKey)) {
+            if (!empty($apiKey) && preg_match('/^\*+$/', (string) $apiKey)) {
                 $apiKey = '';
             }
             $response = $this->managementHelper->getMerchantAccountsAndClientKey($apiKey, (bool) $demoMode);

--- a/Controller/Process/Json.php
+++ b/Controller/Process/Json.php
@@ -155,7 +155,7 @@ class Json extends Action
         }
 
         // Read JSON encoded notification body
-        $notificationItems = json_decode($this->getRequest()->getContent(), true);
+        $notificationItems = json_decode((string) $this->getRequest()->getContent(), true);
 
         // Check notification mode
         if (!isset($notificationItems['live'])) {
@@ -371,12 +371,12 @@ class Json extends Action
     {
         $originalReference = null;
         if (isset($response['originalReference'])) {
-            $originalReference = trim($response['originalReference']);
+            $originalReference = trim((string) $response['originalReference']);
         }
         $notification = $this->notificationFactory->create();
-        $notification->setPspreference(trim($response['pspReference']));
-        $notification->setEventCode(trim($response['eventCode']));
-        $notification->setSuccess(trim($response['success']));
+        $notification->setPspreference(trim((string) $response['pspReference']));
+        $notification->setEventCode(trim((string) $response['eventCode']));
+        $notification->setSuccess(trim((string) $response['success']));
         $notification->setOriginalReference($originalReference);
 
         return $notification->isDuplicate();
@@ -396,27 +396,27 @@ class Json extends Action
             list(
                 $_SERVER['PHP_AUTH_USER'], $_SERVER['PHP_AUTH_PW']
                 ) =
-                explode(':', base64_decode($_SERVER['REDIRECT_REMOTE_AUTHORIZATION']), 2);
+                explode(':', base64_decode((string) $_SERVER['REDIRECT_REMOTE_AUTHORIZATION']), 2);
         } elseif (!empty($_SERVER['REDIRECT_HTTP_AUTHORIZATION'])) {
             list(
                 $_SERVER['PHP_AUTH_USER'], $_SERVER['PHP_AUTH_PW']
                 ) =
-                explode(':', base64_decode(substr($_SERVER['REDIRECT_HTTP_AUTHORIZATION'], 6)), 2);
+                explode(':', base64_decode(substr((string) $_SERVER['REDIRECT_HTTP_AUTHORIZATION'], 6)), 2);
         } elseif (!empty($_SERVER['HTTP_AUTHORIZATION'])) {
             list(
                 $_SERVER['PHP_AUTH_USER'], $_SERVER['PHP_AUTH_PW']
                 ) =
-                explode(':', base64_decode(substr($_SERVER['HTTP_AUTHORIZATION'], 6)), 2);
+                explode(':', base64_decode(substr((string) $_SERVER['HTTP_AUTHORIZATION'], 6)), 2);
         } elseif (!empty($_SERVER['REMOTE_USER'])) {
             list(
                 $_SERVER['PHP_AUTH_USER'], $_SERVER['PHP_AUTH_PW']
                 ) =
-                explode(':', base64_decode(substr($_SERVER['REMOTE_USER'], 6)), 2);
+                explode(':', base64_decode(substr((string) $_SERVER['REMOTE_USER'], 6)), 2);
         } elseif (!empty($_SERVER['REDIRECT_REMOTE_USER'])) {
             list(
                 $_SERVER['PHP_AUTH_USER'], $_SERVER['PHP_AUTH_PW']
                 ) =
-                explode(':', base64_decode(substr($_SERVER['REDIRECT_REMOTE_USER'], 6)), 2);
+                explode(':', base64_decode(substr((string) $_SERVER['REDIRECT_REMOTE_USER'], 6)), 2);
         }
     }
 

--- a/Controller/Process/Result.php
+++ b/Controller/Process/Result.php
@@ -327,7 +327,7 @@ class Result extends \Magento\Framework\App\Action\Action
             $paymentMethod = '';
         }
 
-        $pspReference = isset($response['pspReference']) ? trim($response['pspReference']) : '';
+        $pspReference = isset($response['pspReference']) ? trim((string) $response['pspReference']) : '';
 
         $type = 'Adyen Result URL response:';
         $comment = __(
@@ -346,14 +346,14 @@ class Result extends \Magento\Framework\App\Action\Action
         $orderPayment->setAdditionalInformation('resultCode', $authResult);
         $this->orderResourceModel->save($order);
 
-        switch (strtoupper($authResult)) {
+        switch (strtoupper((string) $authResult)) {
             case Notification::AUTHORISED:
                 $result = true;
                 $this->_adyenLogger->addAdyenResult('Do nothing wait for the notification');
                 break;
             case Notification::RECEIVED:
                 $result = true;
-                if (strpos($paymentMethod, "alipay_hk") !== false) {
+                if (strpos((string) $paymentMethod, "alipay_hk") !== false) {
                     $result = false;
                 }
                 $this->_adyenLogger->addAdyenResult('Do nothing wait for the notification');
@@ -361,7 +361,7 @@ class Result extends \Magento\Framework\App\Action\Action
             case Notification::PENDING:
                 // do nothing wait for the notification
                 $result = true;
-                if (strpos($paymentMethod, "bankTransfer") !== false) {
+                if (strpos((string) $paymentMethod, "bankTransfer") !== false) {
                     $comment .= "<br /><br />Waiting for the customer to transfer the money.";
                 } elseif ($paymentMethod == "sepadirectdebit") {
                     $comment .= "<br /><br />This request will be send to the bank at the end of the day.";
@@ -432,7 +432,7 @@ class Result extends \Magento\Framework\App\Action\Action
         // do it like this because $_GET is converting dot to underscore
         $queryString = $_SERVER['QUERY_STRING'];
         $result = [];
-        $pairs = explode("&", $queryString);
+        $pairs = explode("&", (string) $queryString);
 
         foreach ($pairs as $pair) {
             $nv = explode("=", $pair);
@@ -448,7 +448,7 @@ class Result extends \Magento\Framework\App\Action\Action
         $hmacKey = $this->_adyenHelper->getHmac();
         $merchantSig = \Adyen\Util\Util::calculateSha256Signature($hmacKey, $result);
 
-        if (strcmp($merchantSig, $merchantSigNotification) === 0) {
+        if (strcmp($merchantSig, (string) $merchantSigNotification) === 0) {
             return true;
         }
 
@@ -463,7 +463,7 @@ class Result extends \Magento\Framework\App\Action\Action
      */
     protected function escapeString($val)
     {
-        return str_replace(':', '\\:', str_replace('\\', '\\\\', $val));
+        return str_replace(':', '\\:', str_replace('\\', '\\\\', (string) $val));
     }
 
     /**

--- a/Gateway/Request/CheckoutDataBuilder.php
+++ b/Gateway/Request/CheckoutDataBuilder.php
@@ -99,7 +99,7 @@ class CheckoutDataBuilder implements BuilderInterface
         $requestBody = $this->stateData->getStateData($order->getQuoteId());
 
         if (empty($requestBody) && !is_null($payment->getCcNumber())) {
-            $requestBody = json_decode($payment->getCcNumber(), true);
+            $requestBody = json_decode((string) $payment->getCcNumber(), true);
         }
 
         $order->setCanSendNewEmailFlag(in_array($payment->getMethod(), self::ORDER_EMAIL_REQUIRED_METHODS));
@@ -151,7 +151,7 @@ class CheckoutDataBuilder implements BuilderInterface
 
         if ($payment->getMethod() == AdyenBoletoConfigProvider::CODE) {
             $boletoTypes = $this->adyenHelper->getAdyenBoletoConfigData('boletotypes');
-            $boletoTypes = explode(',', $boletoTypes);
+            $boletoTypes = explode(',', (string) $boletoTypes);
 
             if (count($boletoTypes) == 1) {
                 $requestBody['selectedBrand'] = $boletoTypes[0];

--- a/Gateway/Request/RecurringVaultDataBuilder.php
+++ b/Gateway/Request/RecurringVaultDataBuilder.php
@@ -30,7 +30,7 @@ class RecurringVaultDataBuilder implements BuilderInterface
         $payment = $paymentDataObject->getPayment();
         $extensionAttributes = $payment->getExtensionAttributes();
         $paymentToken = $extensionAttributes->getVaultPaymentToken();
-        $details = json_decode($paymentToken->getTokenDetails() ?: '{}', true);
+        $details = json_decode((string) ($paymentToken->getTokenDetails() ?: '{}'), true);
 
         // Add paymentMethod object in array, since currently checkout component is not loaded for vault payment methods
         $requestBody['paymentMethod'] = ['storedPaymentMethodId' => $paymentToken->getGatewayToken()];

--- a/Gateway/Response/PaymentPosCloudHandler.php
+++ b/Gateway/Response/PaymentPosCloudHandler.php
@@ -71,7 +71,7 @@ class PaymentPosCloudHandler implements HandlerInterface
 
         if (!empty($paymentResponse['Response']['AdditionalResponse'])
         ) {
-            $pairs = \explode('&', $paymentResponse['Response']['AdditionalResponse']);
+            $pairs = \explode('&', (string) $paymentResponse['Response']['AdditionalResponse']);
 
             foreach ($pairs as $pair) {
                 $nv = \explode('=', $pair);
@@ -88,7 +88,7 @@ class PaymentPosCloudHandler implements HandlerInterface
                 $maskedPan = $paymentResponse['PaymentResult']['PaymentInstrumentData']['CardData']['MaskedPan'];
                 $expiryDate = $paymentResponse['PaymentResult']['PaymentInstrumentData']['CardData']
                 ['SensitiveCardData']['ExpiryDate']; // 1225
-                $expiryDate = \substr($expiryDate, 0, 2) . '/' . \substr($expiryDate, 2, 2);
+                $expiryDate = \substr((string) $expiryDate, 0, 2) . '/' . \substr((string) $expiryDate, 2, 2);
                 $brand = $paymentResponse['PaymentResult']['PaymentInstrumentData']['CardData']['PaymentBrand'];
 
                 // create additionalData so we can use the helper
@@ -96,7 +96,7 @@ class PaymentPosCloudHandler implements HandlerInterface
                 $additionalData['recurring.recurringDetailReference'] = $recurringDetailReference;
                 $additionalData['cardBin'] = $recurringDetailReference;
                 $additionalData['cardHolderName'] = '';
-                $additionalData['cardSummary'] = \substr($maskedPan, -4);
+                $additionalData['cardSummary'] = \substr((string) $maskedPan, -4);
                 $additionalData['expiryDate'] = $expiryDate;
                 $additionalData['paymentMethod'] = $brand;
                 $additionalData['recurring.recurringDetailReference'] = $recurringDetailReference;

--- a/Helper/Address.php
+++ b/Helper/Address.php
@@ -118,6 +118,6 @@ class Address
      */
     private function formatAddressArray($street, $houseNumber): array
     {
-        return ['name' => trim($street), 'house_number' => trim($houseNumber)];
+        return ['name' => trim((string) $street), 'house_number' => trim((string) $houseNumber)];
     }
 }

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -183,7 +183,7 @@ class Config
         if (is_null($key)) {
             return null;
         }
-        return $this->encryptor->decrypt(trim($key));
+        return $this->encryptor->decrypt(trim((string) $key));
     }
 
     /**
@@ -248,7 +248,7 @@ class Config
             return null;
         }
 
-        return $this->encryptor->decrypt(trim($key));
+        return $this->encryptor->decrypt(trim((string) $key));
     }
 
     public function isDemoMode($storeId = null): bool

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -622,14 +622,14 @@ class Data extends AbstractHelper
                 if (is_null($hmacTest)) {
                     return null;
                 }
-                $secretWord = $this->_encryptor->decrypt(trim($hmacTest));
+                $secretWord = $this->_encryptor->decrypt(trim((string) $hmacTest));
                 break;
             default:
                 $hmacLive = $this->getAdyenHppConfigData('hmac_live', $storeId);
                 if (is_null($hmacLive)) {
                     return null;
                 }
-                $secretWord = $this->_encryptor->decrypt(trim($hmacLive));
+                $secretWord = $this->_encryptor->decrypt(trim((string) $hmacLive));
                 break;
         }
         return $secretWord;
@@ -666,13 +666,13 @@ class Data extends AbstractHelper
             if (is_null($encryptedApiKeyTest)) {
                 return null;
             }
-            $apiKey = $this->_encryptor->decrypt(trim($encryptedApiKeyTest));
+            $apiKey = $this->_encryptor->decrypt(trim((string) $encryptedApiKeyTest));
         } else {
             $encryptedApiKeyLive = $this->getAdyenAbstractConfigData('api_key_live', $storeId);
             if (is_null($encryptedApiKeyLive)) {
                 return null;
             }
-            $apiKey = $this->_encryptor->decrypt(trim($encryptedApiKeyLive));
+            $apiKey = $this->_encryptor->decrypt(trim((string) $encryptedApiKeyLive));
         }
         return $apiKey;
     }
@@ -694,7 +694,7 @@ class Data extends AbstractHelper
             return null;
         }
 
-        return trim($clientKey);
+        return trim((string) $clientKey);
     }
 
     /**
@@ -710,13 +710,13 @@ class Data extends AbstractHelper
             if (is_null($wsUsernameTest)) {
                 return null;
             }
-            $wsUsername = trim($wsUsernameTest);
+            $wsUsername = trim((string) $wsUsernameTest);
         } else {
             $wsUsernameLive = $this->getAdyenAbstractConfigData('ws_username_live', $storeId);
             if (is_null($wsUsernameLive)) {
                 return null;
             }
-            $wsUsername = trim($wsUsernameLive);
+            $wsUsername = trim((string) $wsUsernameLive);
         }
         return $wsUsername;
     }
@@ -735,7 +735,7 @@ class Data extends AbstractHelper
             return null;
         }
 
-        return trim($prefix);
+        return trim((string) $prefix);
     }
 
     /**
@@ -752,7 +752,7 @@ class Data extends AbstractHelper
             return null;
         }
 
-        return trim($checkoutFrontendRegion);
+        return trim((string) $checkoutFrontendRegion);
     }
 
     /**
@@ -1032,15 +1032,15 @@ class Data extends AbstractHelper
         }
 
         // Those open invoice methods support auto capture.
-        if (strpos($paymentMethod, self::AFTERPAY) !== false ||
-            strpos($paymentMethod, self::KLARNA) !== false ||
-            strpos($paymentMethod, self::RATEPAY) !== false ||
-            strpos($paymentMethod, self::FACILYPAY) !== false ||
-            strpos($paymentMethod, self::AFFIRM) !== false ||
-            strpos($paymentMethod, self::CLEARPAY) !== false ||
-            strpos($paymentMethod, self::ZIP) !== false ||
-            strpos($paymentMethod, self::PAYBRIGHT) !== false ||
-            strpos($paymentMethod, self::ATOME) !== false
+        if (strpos((string) $paymentMethod, self::AFTERPAY) !== false ||
+            strpos((string) $paymentMethod, self::KLARNA) !== false ||
+            strpos((string) $paymentMethod, self::RATEPAY) !== false ||
+            strpos((string) $paymentMethod, self::FACILYPAY) !== false ||
+            strpos((string) $paymentMethod, self::AFFIRM) !== false ||
+            strpos((string) $paymentMethod, self::CLEARPAY) !== false ||
+            strpos((string) $paymentMethod, self::ZIP) !== false ||
+            strpos((string) $paymentMethod, self::PAYBRIGHT) !== false ||
+            strpos((string) $paymentMethod, self::ATOME) !== false
         ) {
             return true;
         }
@@ -1070,7 +1070,7 @@ class Data extends AbstractHelper
     public function isVatCategoryHigh($paymentMethod)
     {
         if ($paymentMethod == self::KLARNA ||
-            strlen($paymentMethod) >= 9 && substr($paymentMethod, 0, 9) == 'afterpay_'
+            strlen((string) $paymentMethod) >= 9 && substr((string) $paymentMethod, 0, 9) == 'afterpay_'
         ) {
             return true;
         }
@@ -1122,7 +1122,7 @@ class Data extends AbstractHelper
      */
     public function formatLocaleCode($localeCode)
     {
-        return str_replace("_", "-", $localeCode);
+        return str_replace("_", "-", (string) $localeCode);
     }
 
     public function getUnprocessedNotifications()
@@ -1159,7 +1159,7 @@ class Data extends AbstractHelper
         $payment,
         $itemId = null
     ) {
-        $description = str_replace("\n", '', trim($name));
+        $description = str_replace("\n", '', trim((string) $name));
         $itemAmount = $this->formatAmount($price, $currency);
 
         $itemVatAmount = $this->getItemVatAmount(
@@ -1362,14 +1362,14 @@ class Data extends AbstractHelper
                 return null;
             }
 
-            $apiKey = $this->_encryptor->decrypt(trim($encryptedApiKeyTest));
+            $apiKey = $this->_encryptor->decrypt(trim((string) $encryptedApiKeyTest));
         } else {
             $encryptedApiKeyLive = $this->configHelper->getAdyenPosCloudConfigData('api_key_live', $storeId);
             if (is_null($encryptedApiKeyLive)) {
                 return null;
             }
 
-            $apiKey = $this->_encryptor->decrypt(trim($encryptedApiKeyLive));
+            $apiKey = $this->_encryptor->decrypt(trim((string) $encryptedApiKeyLive));
         }
         return $apiKey;
     }
@@ -1422,7 +1422,7 @@ class Data extends AbstractHelper
         foreach ($paymentReceipt as $receipt) {
             if ($receipt['DocumentQualifier'] == "CustomerReceipt") {
                 foreach ($receipt['OutputContent']['OutputText'] as $item) {
-                    parse_str($item['Text'], $textParts);
+                    parse_str((string) $item['Text'], $textParts);
                     $formattedHtml .= "<tr class='terminal-api-receipt'>";
                     if (!empty($textParts['name'])) {
                         $formattedHtml .= "<td class='terminal-api-receipt-name'>" . $textParts['name'] . "</td>";
@@ -1537,7 +1537,7 @@ class Data extends AbstractHelper
         if ('adminhtml' === $state->getAreaCode()) {
             $baseUrl = $this->backendHelper->getHomePageUrl();
         }
-        $parsed = parse_url($baseUrl);
+        $parsed = parse_url((string) $baseUrl);
         $origin = $parsed['scheme'] . "://" . $parsed['host'];
         if (!empty($parsed['port'])) {
             $origin .= ":" . $parsed['port'];

--- a/Helper/PaymentMethods.php
+++ b/Helper/PaymentMethods.php
@@ -591,7 +591,7 @@ class PaymentMethods extends AbstractHelper
         $ccTypes = $this->adyenHelper->getAdyenCcTypes();
         $availableTypes = $this->adyenHelper->getAdyenCcConfigData('cctypes');
         if ($availableTypes) {
-            $availableTypes = explode(',', $availableTypes);
+            $availableTypes = explode(',', (string) $availableTypes);
             foreach (array_keys($ccTypes) as $code) {
                 if (in_array($code, $availableTypes)) {
                     $types[$code] = $ccTypes[$code]['name'];
@@ -613,7 +613,7 @@ class PaymentMethods extends AbstractHelper
         $ccTypes = $this->adyenHelper->getAdyenCcTypes();
         $availableTypes = $this->adyenHelper->getAdyenCcConfigData('cctypes');
         if ($availableTypes) {
-            $availableTypes = explode(',', $availableTypes);
+            $availableTypes = explode(',', (string) $availableTypes);
             foreach (array_keys($ccTypes) as $code) {
                 if (in_array($code, $availableTypes)) {
                     $types[$ccTypes[$code]['code_alt']] = $code;
@@ -636,14 +636,14 @@ class PaymentMethods extends AbstractHelper
         // validate if payment methods allows manual capture
         if ($this->manualCapture->isManualCaptureSupported($notificationPaymentMethod)) {
             $captureMode = trim(
-                $this->configHelper->getConfigData(
+                (string) $this->configHelper->getConfigData(
                     'capture_mode',
                     'adyen_abstract',
                     $order->getStoreId()
                 )
             );
             $sepaFlow = trim(
-                $this->configHelper->getConfigData(
+                (string) $this->configHelper->getConfigData(
                     'sepa_flow',
                     'adyen_abstract',
                     $order->getStoreId()
@@ -652,7 +652,7 @@ class PaymentMethods extends AbstractHelper
             $paymentCode = $order->getPayment()->getMethod();
             $autoCaptureOpenInvoice = $this->configHelper->getAutoCaptureOpenInvoice($order->getStoreId());
             $manualCapturePayPal = trim(
-                $this->configHelper->getConfigData(
+                (string) $this->configHelper->getConfigData(
                     'paypal_capture_mode',
                     'adyen_abstract',
                     $order->getStoreId()
@@ -692,7 +692,7 @@ class PaymentMethods extends AbstractHelper
                     'capture_mode_pos',
                     $order->getStoreId()
                 );
-                if (strcmp($captureModePos, 'auto') === 0) {
+                if (strcmp((string) $captureModePos, 'auto') === 0) {
                     $this->adyenLogger->addAdyenNotification(
                         'This payment method is POS Cloud and configured to be working as auto capture ',
                         array_merge(
@@ -701,7 +701,7 @@ class PaymentMethods extends AbstractHelper
                         )
                     );
                     return true;
-                } elseif (strcmp($captureModePos, 'manual') === 0) {
+                } elseif (strcmp((string) $captureModePos, 'manual') === 0) {
                     $this->adyenLogger->addAdyenNotification(
                         'This payment method is POS Cloud and configured to be working as manual capture ',
                         array_merge(
@@ -854,8 +854,8 @@ class PaymentMethods extends AbstractHelper
         $boletobancario = $additionalData['boletobancario'] ?? null;
         if ($boletobancario && is_array($boletobancario)) {
             // check if paid amount is the same as orginal amount
-            $originalAmount = isset($boletobancario['originalAmount']) ? trim($boletobancario['originalAmount']) : "";
-            $paidAmount = isset($boletobancario['paidAmount']) ? trim($boletobancario['paidAmount']) : "";
+            $originalAmount = isset($boletobancario['originalAmount']) ? trim((string) $boletobancario['originalAmount']) : "";
+            $paidAmount = isset($boletobancario['paidAmount']) ? trim((string) $boletobancario['paidAmount']) : "";
 
             if ($originalAmount != $paidAmount) {
                 // not the full amount is paid. Check if it is underpaid or overpaid

--- a/Helper/PaymentMethods.php
+++ b/Helper/PaymentMethods.php
@@ -854,7 +854,10 @@ class PaymentMethods extends AbstractHelper
         $boletobancario = $additionalData['boletobancario'] ?? null;
         if ($boletobancario && is_array($boletobancario)) {
             // check if paid amount is the same as orginal amount
-            $originalAmount = isset($boletobancario['originalAmount']) ? trim((string) $boletobancario['originalAmount']) : "";
+            $originalAmount =
+                isset($boletobancario['originalAmount']) ?
+                trim((string) $boletobancario['originalAmount']) :
+                "";
             $paidAmount = isset($boletobancario['paidAmount']) ? trim((string) $boletobancario['paidAmount']) : "";
 
             if ($originalAmount != $paidAmount) {

--- a/Helper/Requests.php
+++ b/Helper/Requests.php
@@ -143,7 +143,7 @@ class Requests extends AbstractHelper
                 $payment->getMethodInstance()->getCode() != AdyenPayByLinkConfigProvider::CODE &&
                 !is_null($billingAddress->getTelephone())
             ) {
-                $request['telephoneNumber'] = trim($billingAddress->getTelephone());
+                $request['telephoneNumber'] = trim((string) $billingAddress->getTelephone());
             }
 
             if ($firstName = $billingAddress->getFirstname()) {
@@ -236,7 +236,7 @@ class Requests extends AbstractHelper
                     $requestBilling["postalCode"] = preg_replace(
                         '/[^\d]/',
                         '',
-                        $requestBilling["postalCode"]
+                        (string) $requestBilling["postalCode"]
                     );
                 }
             }
@@ -293,7 +293,7 @@ class Requests extends AbstractHelper
                     $requestDelivery["postalCode"] = preg_replace(
                         '/[^\d]/',
                         '',
-                        $requestDelivery["postalCode"]
+                        (string) $requestDelivery["postalCode"]
                     );
                 }
             }
@@ -358,7 +358,7 @@ class Requests extends AbstractHelper
         // Initialize the request body with the current state data
         // Multishipping checkout uses the cc_number field for state data
         $stateData = $this->stateData->getStateData($payment->getOrder()->getQuoteId()) ?:
-            (json_decode($payment->getCcNumber(), true) ?: []);
+            (json_decode((string) $payment->getCcNumber(), true) ?: []);
 
         // If PayByLink
         // Else, if option to store token exists, get the value from the checkbox

--- a/Helper/ReturnUrlHelper.php
+++ b/Helper/ReturnUrlHelper.php
@@ -53,7 +53,7 @@ class ReturnUrlHelper
     public function getStoreReturnUrl($storeId)
     {
         if ($paymentReturnUrl = $this->config->getPWAReturnUrl($storeId)) {
-            return rtrim($paymentReturnUrl, '/');
+            return rtrim((string) $paymentReturnUrl, '/');
         }
         
         if ('adminhtml' === $this->state->getAreaCode()) {

--- a/Helper/Vault.php
+++ b/Helper/Vault.php
@@ -254,7 +254,7 @@ class Vault
 
         $tokenizedPaymentMethods = array_map(
             'trim',
-            explode(',', $this->config->getTokenizedPaymentMethods($storeId))
+            explode(',', (string) $this->config->getTokenizedPaymentMethods($storeId))
         );
         $shouldTokenize = in_array($adyenPaymentMethod->getTxVariant(), $tokenizedPaymentMethods);
 
@@ -408,7 +408,7 @@ class Vault
      */
     private function getExpirationDate($expirationDate)
     {
-        $expirationDate = explode('/', $expirationDate);
+        $expirationDate = explode('/', (string) $expirationDate);
 
         $expDate = new DateTime(
         //add leading zero to month

--- a/Helper/Webhook.php
+++ b/Helper/Webhook.php
@@ -308,7 +308,7 @@ class Webhook
             $additionalData2 = $additionalData['additionalData'] ?? null;
             if ($additionalData2 && is_array($additionalData2)) {
                 $this->klarnaReservationNumber = isset($additionalData2['acquirerReference']) ? trim(
-                    $additionalData2['acquirerReference']
+                    (string) $additionalData2['acquirerReference']
                 ) : "";
             }
             $ratepayDescriptor = $additionalData['openinvoicedata.descriptor'] ?? "";
@@ -526,7 +526,7 @@ class Webhook
         $result = "";
 
         if ($reason != "") {
-            $reasonArray = explode(":", $reason);
+            $reasonArray = explode(":", (string) $reason);
             if ($reasonArray != null && is_array($reasonArray) && isset($reasonArray[1])) {
                 $result = $reasonArray[1];
             }

--- a/Model/Billing/Agreement.php
+++ b/Model/Billing/Agreement.php
@@ -101,7 +101,7 @@ class Agreement extends \Magento\Paypal\Model\Billing\Agreement
             ->setReferenceId($data['recurringDetailReference'])
             ->setCreatedAt($data['creationDate']);
 
-        $creationDate = str_replace(' ', '-', $data['creationDate']);
+        $creationDate = str_replace(' ', '-', (string) $data['creationDate']);
         $this->setCreatedAt($creationDate);
 
         //Billing agreement SEPA
@@ -175,7 +175,7 @@ class Agreement extends \Magento\Paypal\Model\Billing\Agreement
      */
     public function getAgreementData()
     {
-        return json_decode($this->getData('agreement_data'), true);
+        return json_decode((string) $this->getData('agreement_data'), true);
     }
 
     /**
@@ -228,7 +228,7 @@ class Agreement extends \Magento\Paypal\Model\Billing\Agreement
 
         $this->setAgreementLabel($label);
 
-        $expiryDate = explode('/', $contractDetail['expiryDate']);
+        $expiryDate = explode('/', (string) $contractDetail['expiryDate']);
 
         $recurringType = !empty($contractDetail['pos_payment'])
             ? $this->configHelper->getAdyenPosCloudConfigData('recurring_type', $storeId)
@@ -244,7 +244,7 @@ class Agreement extends \Magento\Paypal\Model\Billing\Agreement
             'variant' => $variant,
             // contractTypes should be changed from an array to a single value in the future. It has not been done yet
             // to ensure past tokens are still operational.
-            'contractTypes' => $recurringType ? explode(',', $recurringType) : []
+            'contractTypes' => $recurringType ? explode(',', (string) $recurringType) : []
         ];
 
         if (!empty($contractDetail['pos_payment'])) {

--- a/Model/Config/Backend/Moto.php
+++ b/Model/Config/Backend/Moto.php
@@ -82,7 +82,7 @@ class Moto extends \Magento\Framework\App\Config\Value
 
             if ($data['api_key'] != AdyenMotoConfigProvider::API_KEY_PLACEHOLDER) {
                 $apiKey = $data['api_key'];
-                $apiKey = $this->encryptor->encrypt(trim($apiKey));
+                $apiKey = $this->encryptor->encrypt(trim((string) $apiKey));
             }
             else {
                 $oldRowValue = $this->getOldValue();

--- a/Model/ResourceModel/StateData/Collection.php
+++ b/Model/ResourceModel/StateData/Collection.php
@@ -37,7 +37,7 @@ class Collection extends AbstractCollection
         $stateData = $this->getStateDataRowsWithQuoteId($quoteId)
             ->getFirstItem()
             ->getData(StateDataInterface::STATE_DATA);
-        return !empty($stateData) ? json_decode($stateData, true) : [];
+        return !empty($stateData) ? json_decode((string) $stateData, true) : [];
     }
 
     /**

--- a/Model/Ui/AdyenBoletoConfigProvider.php
+++ b/Model/Ui/AdyenBoletoConfigProvider.php
@@ -90,7 +90,7 @@ class AdyenBoletoConfigProvider implements ConfigProviderInterface
         $boletoTypes = $this->_adyenHelper->getBoletoTypes();
         $availableTypes = $this->_adyenHelper->getAdyenBoletoConfigData('boletotypes');
         if ($availableTypes) {
-            $availableTypes = explode(',', $availableTypes);
+            $availableTypes = explode(',', (string) $availableTypes);
             foreach ($boletoTypes as $boletoType) {
                 if (in_array($boletoType['value'], $availableTypes)) {
                     $types[] = $boletoType;

--- a/Observer/AdyenCcDataAssignObserver.php
+++ b/Observer/AdyenCcDataAssignObserver.php
@@ -102,7 +102,7 @@ class AdyenCcDataAssignObserver extends AbstractDataAssignObserver
 
         // JSON decode state data from the frontend or fetch it from the DB entity with the quote ID
         if (!empty($additionalData[self::STATE_DATA])) {
-            $stateData = json_decode($additionalData[self::STATE_DATA], true);
+            $stateData = json_decode((string) $additionalData[self::STATE_DATA], true);
         } else {
             $stateData = $this->stateDataCollection->getStateDataArrayWithQuoteId($paymentInfo->getData('quote_id'));
         }

--- a/Observer/AdyenHppDataAssignObserver.php
+++ b/Observer/AdyenHppDataAssignObserver.php
@@ -106,7 +106,7 @@ class AdyenHppDataAssignObserver extends AbstractDataAssignObserver
 
         // JSON decode state data from the frontend or fetch it from the DB entity with the quote ID
         if (!empty($additionalData[self::STATE_DATA])) {
-            $stateData = json_decode($additionalData[self::STATE_DATA], true);
+            $stateData = json_decode((string) $additionalData[self::STATE_DATA], true);
         } else {
             $stateData = $this->stateDataCollection->getStateDataArrayWithQuoteId($paymentInfo->getData('quote_id'));
         }

--- a/Observer/AdyenMotoDataAssignObserver.php
+++ b/Observer/AdyenMotoDataAssignObserver.php
@@ -99,7 +99,7 @@ class AdyenMotoDataAssignObserver extends AbstractDataAssignObserver
 
         // JSON decode state data from the frontend or fetch it from the DB entity with the quote ID
         if (!empty($additionalData[self::STATE_DATA])) {
-            $orderStateData = json_decode($additionalData[self::STATE_DATA], true);
+            $orderStateData = json_decode((string) $additionalData[self::STATE_DATA], true);
         } else {
             $orderStateData = $this->stateDataCollection->getStateDataArrayWithQuoteId($paymentInfo->getData('quote_id'));
         }

--- a/Observer/AdyenOneclickDataAssignObserver.php
+++ b/Observer/AdyenOneclickDataAssignObserver.php
@@ -115,7 +115,7 @@ class AdyenOneclickDataAssignObserver extends AbstractDataAssignObserver
 
         // JSON decode state data from the frontend or fetch it from the DB entity with the quote ID
         if (!empty($additionalData[self::STATE_DATA])) {
-            $stateData = json_decode($additionalData[self::STATE_DATA], true);
+            $stateData = json_decode((string) $additionalData[self::STATE_DATA], true);
         } else {
             $stateData = $this->stateDataCollection->getStateDataArrayWithQuoteId($paymentInfo->getData('quote_id'));
         }

--- a/Observer/BeforeShipmentObserver.php
+++ b/Observer/BeforeShipmentObserver.php
@@ -126,6 +126,6 @@ class BeforeShipmentObserver extends AbstractDataAssignObserver
      */
     public function isPaymentMethodAdyen($order)
     {
-        return strpos($order->getPayment()->getMethod(), 'adyen') !== false;
+        return strpos((string) $order->getPayment()->getMethod(), 'adyen') !== false;
     }
 }

--- a/Plugin/CustomerFilterVaultTokens.php
+++ b/Plugin/CustomerFilterVaultTokens.php
@@ -30,8 +30,8 @@ class CustomerFilterVaultTokens
         array $customerSessionTokens
     ): array {
         foreach ($customerSessionTokens as $key => $token) {
-            if (strpos($token->getPaymentMethodCode(), 'adyen_') === 0) {
-                $tokenDetails = json_decode($token->getTokenDetails());
+            if (strpos((string) $token->getPaymentMethodCode(), 'adyen_') === 0) {
+                $tokenDetails = json_decode((string) $token->getTokenDetails());
                 if (property_exists($tokenDetails, Vault::TOKEN_TYPE) &&
                     in_array($tokenDetails->tokenType, [
                         Recurring::SUBSCRIPTION,

--- a/Test/Unit/Model/Config/Backend/DonationAmountsTest.php
+++ b/Test/Unit/Model/Config/Backend/DonationAmountsTest.php
@@ -51,7 +51,7 @@ class DonationAmountsTest extends \PHPUnit\Framework\TestCase
      */
     public function testValidateDonationAmounts($donationAmounts, $expectedResult)
     {
-        $result = $this->donationAmounts->validateDonationAmounts(explode(',', $donationAmounts));
+        $result = $this->donationAmounts->validateDonationAmounts(explode(',', (string) $donationAmounts));
         $this->assertEquals($result, $expectedResult);
     }
 

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
     }
   ],
   "require": {
+    "php": ">=8.1",
     "adyen/php-api-library": "^13.0.4",
     "adyen/php-webhook-module": "^0.6.0",
     "magento/framework": ">=101.0.8 <102 || >=102.0.1",


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Repository dependency for PHP set to 8.1 or later.

Code base was refactored with [Rector](https://github.com/rectorphp/rector) to support PHP 8.1.

**Applied Rector rules**
```
ReturnNeverTypeRector::class,
MyCLabsClassToEnumRector::class,
MyCLabsMethodCallToEnumConstRector::class,
ReadOnlyPropertyRector::class,
SpatieEnumClassToEnumRector::class,
Php81ResourceReturnToObjectRector::class,
NewInInitializerRector::class,
IntersectionTypesRector::class,
NullToStrictStringFuncCallArgRector::class
```

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- E2E
- Payment flow test (Authorise, cancel, capture, refund) for auto capture and manual capture