### PR TITLE
Remove the  additional comma

### DIFF
--- a/Observer/VaultConfigObserver.php
+++ b/Observer/VaultConfigObserver.php
@@ -77,7 +77,7 @@ class VaultConfigObserver implements ObserverInterface
         if ($vaultEnabledConfig !== $vaultActiveConfig) {
             $this->configWriter->save(
                 'payment/' . Config::XML_ADYEN_CC_VAULT . '/active',
-                intval($vaultEnabledConfig),
+                intval($vaultEnabledConfig)
             );
         }
     }


### PR DESCRIPTION
Remove the  additional comma on configWriter save function, it cause a compilation error

<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

Fixes  <!-- #-prefixed github issue number -->
