### PR TITLE
[PW-7531] Send email with configuration and form values

### DIFF
--- a/Block/Adminhtml/Support/ConfigurationSettingsForm.php
+++ b/Block/Adminhtml/Support/ConfigurationSettingsForm.php
@@ -3,18 +3,24 @@
 namespace Adyen\Payment\Block\Adminhtml\Support;
 
 use Adyen\Payment\Block\Adminhtml\Support\Edit\Tab\ConfigurationSettings;
+use Adyen\Payment\Helper\SupportFormHelper;
 
 class ConfigurationSettingsForm extends \Magento\Backend\Block\Widget\Form\Generic
 {
     const HEADLESS_YES = 1;
     const HEADLESS_NO = 0;
 
-    /**
-     * Internal constructor
-     */
-    protected function _construct()
+    private SupportFormHelper $supportFormHelper;
+
+    public function __construct(
+        \Magento\Backend\Block\Template\Context $context,
+        \Magento\Framework\Registry $registry,
+        \Magento\Framework\Data\FormFactory $formFactory,
+        SupportFormHelper $supportFormHelper
+    )
     {
-        parent::_construct();
+        $this->supportFormHelper = $supportFormHelper;
+        parent::__construct($context, $registry, $formFactory);
         $this->setActive(true);
     }
 
@@ -83,6 +89,7 @@ class ConfigurationSettingsForm extends \Magento\Backend\Block\Widget\Form\Gener
                 'title' => __('Email'),
                 'class' => '',
                 'required' => true,
+                'value' => $this->supportFormHelper->getGeneralContactSenderEmail()
             ]
         );
 

--- a/Block/Adminhtml/Support/ConfigurationSettingsForm.php
+++ b/Block/Adminhtml/Support/ConfigurationSettingsForm.php
@@ -30,15 +30,10 @@ class ConfigurationSettingsForm extends \Magento\Backend\Block\Widget\Form\Gener
         $form = $this->_formFactory->create([
             'data' => [
                 'id' => 'configurationsettings_form',
-                'action' => $this->getData('action'),
-                'method' => 'post',
-                'enctype' => 'multipart/form-data'
+                'action' => $this->getUrl('adyen/support/configurationsettingsform'),
+                'method' => 'post'
             ]
         ]);
-
-        $form = $this->_formFactory->create(
-            ['data' => ['id' => 'edit_form', 'action' => $this->getData('action'), 'method' => 'post', 'enctype' => 'multipart/form-data']]
-        );
 
         $fieldset = $form->addFieldset('base_fieldset', ['legend' => __('Configuration settings')]);
         $this->_addElementTypes($fieldset);
@@ -131,23 +126,20 @@ class ConfigurationSettingsForm extends \Magento\Backend\Block\Widget\Form\Gener
         );
 
         $fieldset->addField(
-            'submit_button',
+            'submit_support_configuration_settings',
             'submit',
             [
                 'name' => 'submit',
-                'title' => __('click'),
-                'class' => 'button',
-                'data_attribute' => '',
-                'value' => 'Submit',
-                'onclick' => "setLocation('{$this->getUrl('adyen/support/configurationsettingsform')}')",
+                'title' => __('Submit'),
+                'class' => 'primary',
+                'value' => 'Submit'
             ]
         );
 
-        $form->setMethod('post');
         $form->setUseContainer(true);
-        $form->setId('configurationsettings_form');
+
         $this->setForm($form);
-        return $this;
+        return parent::_prepareForm();
     }
 
 
@@ -169,7 +161,7 @@ class ConfigurationSettingsForm extends \Magento\Backend\Block\Widget\Form\Gener
     {
         return [
             'invalid_origin' => 'Invalid Origin',
-            'headles_state_data_actions' => 'Headless state data actions',
+            'headless_state_data_actions' => 'Headless state data actions',
             'refund' => 'Refund',
             'other' => 'Other'
         ];

--- a/Block/Adminhtml/Support/ConfigurationSettingsForm.php
+++ b/Block/Adminhtml/Support/ConfigurationSettingsForm.php
@@ -8,6 +8,16 @@ class ConfigurationSettingsForm extends \Magento\Backend\Block\Widget\Form\Gener
 {
     const HEADLESS_YES = 1;
     const HEADLESS_NO = 0;
+
+    /**
+     * Internal constructor
+     */
+    protected function _construct()
+    {
+        parent::_construct();
+        $this->setActive(true);
+    }
+
     /**
      * Prepare form before rendering HTML
      *
@@ -21,9 +31,14 @@ class ConfigurationSettingsForm extends \Magento\Backend\Block\Widget\Form\Gener
             'data' => [
                 'id' => 'configurationsettings_form',
                 'action' => $this->getData('action'),
-                'method' => 'post'
+                'method' => 'post',
+                'enctype' => 'multipart/form-data'
             ]
         ]);
+
+        $form = $this->_formFactory->create(
+            ['data' => ['id' => 'edit_form', 'action' => $this->getData('action'), 'method' => 'post', 'enctype' => 'multipart/form-data']]
+        );
 
         $fieldset = $form->addFieldset('base_fieldset', ['legend' => __('Configuration settings')]);
         $this->_addElementTypes($fieldset);
@@ -72,6 +87,18 @@ class ConfigurationSettingsForm extends \Magento\Backend\Block\Widget\Form\Gener
                 'label' => __('Email'),
                 'title' => __('Email'),
                 'class' => '',
+                'required' => true,
+            ]
+        );
+
+        $fieldset->addField(
+            'logs',
+            'file',
+            [
+                'name' => 'logs',
+                'label' => __('Attach Logs'),
+                'title' => __('Attach Logs'),
+                'class' => '',
                 'required' => false,
             ]
         );
@@ -102,25 +129,25 @@ class ConfigurationSettingsForm extends \Magento\Backend\Block\Widget\Form\Gener
                 'required' => false,
             ]
         );
+
         $fieldset->addField(
-            'upload_button',
-            'button',
+            'submit_button',
+            'submit',
             [
                 'name' => 'submit',
-
                 'title' => __('click'),
-                'class' => 'primary',
+                'class' => 'button',
                 'data_attribute' => '',
                 'value' => 'Submit',
-                'data_attribute' => [
-                    'mage-init' => ['button' => ['event' => 'send', 'target' => '#support_form']],
-                ]
+                'onclick' => "setLocation('{$this->getUrl('adyen/support/configurationsettingsform')}')",
             ]
         );
 
-
+        $form->setMethod('post');
+        $form->setUseContainer(true);
+        $form->setId('configurationsettings_form');
         $this->setForm($form);
-        return parent::_prepareForm();
+        return $this;
     }
 
 

--- a/Block/Adminhtml/Support/ConfigurationSettingsForm.php
+++ b/Block/Adminhtml/Support/ConfigurationSettingsForm.php
@@ -2,7 +2,6 @@
 
 namespace Adyen\Payment\Block\Adminhtml\Support;
 
-use Adyen\Payment\Block\Adminhtml\Support\Edit\Tab\ConfigurationSettings;
 use Adyen\Payment\Helper\SupportFormHelper;
 
 class ConfigurationSettingsForm extends \Magento\Backend\Block\Widget\Form\Generic
@@ -10,7 +9,7 @@ class ConfigurationSettingsForm extends \Magento\Backend\Block\Widget\Form\Gener
     const HEADLESS_YES = 1;
     const HEADLESS_NO = 0;
 
-    private SupportFormHelper $supportFormHelper;
+    private $supportFormHelper;
 
     public function __construct(
         \Magento\Backend\Block\Template\Context $context,

--- a/Block/Adminhtml/Support/OrderProcessingForm.php
+++ b/Block/Adminhtml/Support/OrderProcessingForm.php
@@ -2,10 +2,25 @@
 
 namespace Adyen\Payment\Block\Adminhtml\Support;
 
+use Adyen\Payment\Helper\SupportFormHelper;
+
 class OrderProcessingForm extends \Magento\Backend\Block\Widget\Form\Generic
 {
     const HEADLESS_YES = 1;
     const HEADLESS_NO = 0;
+
+    private SupportFormHelper $supportFormHelper;
+
+    public function __construct(
+        \Magento\Backend\Block\Template\Context $context,
+        \Magento\Framework\Registry $registry,
+        \Magento\Framework\Data\FormFactory $formFactory,
+        SupportFormHelper $supportFormHelper
+    )
+    {
+        $this->supportFormHelper = $supportFormHelper;
+        parent::__construct($context, $registry, $formFactory);
+    }
 
     /**
      * Prepare form before rendering HTML
@@ -64,6 +79,7 @@ class OrderProcessingForm extends \Magento\Backend\Block\Widget\Form\Generic
                 'title' => __('Email'),
                 'class' => '',
                 'required' => true,
+                'value'=>$this->supportFormHelper->getGeneralContactSenderEmail()
             ]
         );
 

--- a/Block/Adminhtml/Support/OrderProcessingForm.php
+++ b/Block/Adminhtml/Support/OrderProcessingForm.php
@@ -19,7 +19,7 @@ class OrderProcessingForm extends \Magento\Backend\Block\Widget\Form\Generic
         $form = $this->_formFactory->create([
             'data' => [
                 'id' => 'support_form',
-                'action' => $this->getData('action'),
+                'action' => $this->getUrl('adyen/support/orderprocessingform'),
                 'method' => 'post',
             ]
         ]);
@@ -162,23 +162,18 @@ class OrderProcessingForm extends \Magento\Backend\Block\Widget\Form\Generic
         );
 
         $fieldset->addField(
-            'submit_button',
+            'submit_support_order_processing',
             'submit',
             [
                 'name' => 'submit',
-                'title' => __('click'),
-                'class' => 'button',
-                'data_attribute' => '',
-                'value' => 'Submit',
-                'onclick' => "setLocation('{$this->getUrl('adyen/support/orderprocessingform')}')",
+                'title' => __('Submit'),
+                'class' => 'primary',
+                'value' => 'Submit'
             ]
         );
 
-
-        $form->setMethod('post');
         $form->setUseContainer(true);
-        $form->setId('orderprocessing_form');
         $this->setForm($form);
-        return $this;
+        return parent::_prepareForm();
     }
 }

--- a/Block/Adminhtml/Support/OrderProcessingForm.php
+++ b/Block/Adminhtml/Support/OrderProcessingForm.php
@@ -63,7 +63,7 @@ class OrderProcessingForm extends \Magento\Backend\Block\Widget\Form\Generic
                 'label' => __('Email'),
                 'title' => __('Email'),
                 'class' => '',
-                'required' => false,
+                'required' => true,
             ]
         );
 

--- a/Block/Adminhtml/Support/OrderProcessingForm.php
+++ b/Block/Adminhtml/Support/OrderProcessingForm.php
@@ -126,7 +126,17 @@ class OrderProcessingForm extends \Magento\Backend\Block\Widget\Form\Generic
                 'required' => false,
             ]
         );
-
+        $fieldset->addField(
+            'logs',
+            'file',
+            [
+                'name' => 'logs',
+                'label' => __('Attach Logs'),
+                'title' => __('Attach Logs'),
+                'class' => '',
+                'required' => false,
+            ]
+        );
         $fieldset->addField(
             'orderHistoryComments',
             'textarea',
@@ -152,19 +162,23 @@ class OrderProcessingForm extends \Magento\Backend\Block\Widget\Form\Generic
         );
 
         $fieldset->addField(
-            'upload_button',
-            'button',
+            'submit_button',
+            'submit',
             [
                 'name' => 'submit',
-
                 'title' => __('click'),
-                'class' => 'upload_button',
+                'class' => 'button',
                 'data_attribute' => '',
-                'value' => 'Submit'
+                'value' => 'Submit',
+                'onclick' => "setLocation('{$this->getUrl('adyen/support/orderprocessingform')}')",
             ]
         );
 
+
+        $form->setMethod('post');
+        $form->setUseContainer(true);
+        $form->setId('orderprocessing_form');
         $this->setForm($form);
-        return parent::_prepareForm();
+        return $this;
     }
 }

--- a/Block/Adminhtml/Support/OrderProcessingForm.php
+++ b/Block/Adminhtml/Support/OrderProcessingForm.php
@@ -9,7 +9,7 @@ class OrderProcessingForm extends \Magento\Backend\Block\Widget\Form\Generic
     const HEADLESS_YES = 1;
     const HEADLESS_NO = 0;
 
-    private SupportFormHelper $supportFormHelper;
+    private $supportFormHelper;
 
     public function __construct(
         \Magento\Backend\Block\Template\Context $context,

--- a/Controller/Adminhtml/Support/ConfigurationData.php
+++ b/Controller/Adminhtml/Support/ConfigurationData.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Adyen\Payment\Controller\Adminhtml\Support;
+
+use Adyen\Payment\Helper\Config;
+use Adyen\Payment\Helper\Data;
+use Magento\Store\Model\StoreManagerInterface;
+
+class ConfigurationData
+{
+    /**
+     * @var Config
+     */
+    protected Config $config;
+    /**
+     * @var Data
+     */
+    private Data $adyenHelper;
+    /**
+     * @var StoreManagerInterface
+     */
+    private StoreManagerInterface $storeManager;
+
+    public function __construct(Config $config, Data $adyenHelper, StoreManagerInterface $storeManager)
+    {
+        $this->storeManager = $storeManager;
+        $this->config = $config;
+        $this->adyenHelper = $adyenHelper;
+    }
+
+    public function getConfigData(): array
+    {
+        $storeId = $this->storeManager->getStore()->getId();
+        $notificationUsername = $this->config->getNotificationsUsername($storeId) ? 'Username set' : 'No Username';
+        $notificationPassword = $this->config->getNotificationsPassword($storeId) ? 'Password set' : 'No Password';
+        $merchantAccount = $this->config->getMerchantAccount($storeId);
+        $environmentMode = $this->config->isDemoMode($storeId) ? 'Test' : 'Live';
+        $moduleVersion = $this->adyenHelper->getModuleVersion();
+        $alternativePaymentMethods = $this->config->getConfigData('active', Config::XML_ADYEN_HPP, $storeId);
+        $moto = $this->config->getConfigData('active', Config::XML_ADYEN_MOTO, $storeId);
+
+        return [
+            'pluginVersion' => $moduleVersion,
+            'notificationUsername' => $notificationUsername,
+            'notificationPassword' => $notificationPassword,
+            'merchantAccount' => $merchantAccount,
+            'environmentMode' => $environmentMode,
+            'paymentMethodsEnabled' => $alternativePaymentMethods,
+            'motoEnabled' => $moto
+        ];
+    }
+}

--- a/Controller/Adminhtml/Support/ConfigurationData.php
+++ b/Controller/Adminhtml/Support/ConfigurationData.php
@@ -4,6 +4,7 @@ namespace Adyen\Payment\Controller\Adminhtml\Support;
 
 use Adyen\Payment\Helper\Config;
 use Adyen\Payment\Helper\Data;
+use Magento\Framework\App\ProductMetadataInterface;
 use Magento\Store\Model\StoreManagerInterface;
 
 class ConfigurationData
@@ -21,16 +22,29 @@ class ConfigurationData
      */
     private StoreManagerInterface $storeManager;
 
-    public function __construct(Config $config, Data $adyenHelper, StoreManagerInterface $storeManager)
+
+    protected ProductMetadataInterface $productMetadata;
+
+    public function __construct(Config                   $config,
+                                Data                     $adyenHelper,
+                                StoreManagerInterface    $storeManager,
+                                ProductMetadataInterface $productMetadata)
     {
         $this->storeManager = $storeManager;
         $this->config = $config;
         $this->adyenHelper = $adyenHelper;
+        $this->productMetadata = $productMetadata;
     }
 
+    /**
+     * @return array
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     */
     public function getConfigData(): array
     {
-        $storeId = $this->storeManager->getStore()->getId();
+        $storeId = $this->getStoreId();
+        $magentoEdition = $this->productMetadata->getEdition();
+        $magentoVersion = $this->productMetadata->getVersion();
         $notificationUsername = $this->config->getNotificationsUsername($storeId) ? 'Username set' : 'No Username';
         $notificationPassword = $this->config->getNotificationsPassword($storeId) ? 'Password set' : 'No Password';
         $merchantAccount = $this->config->getMerchantAccount($storeId);
@@ -40,13 +54,26 @@ class ConfigurationData
         $moto = $this->config->getConfigData('active', Config::XML_ADYEN_MOTO, $storeId);
 
         return [
+            'magentoEdition' => $magentoEdition,
+            'magentoVersion' => $magentoVersion,
+            'storeId' => $storeId,
             'pluginVersion' => $moduleVersion,
-            'notificationUsername' => $notificationUsername,
-            'notificationPassword' => $notificationPassword,
             'merchantAccount' => $merchantAccount,
             'environmentMode' => $environmentMode,
             'paymentMethodsEnabled' => $alternativePaymentMethods,
+            'notificationUsername' => $notificationUsername,
+            'notificationPassword' => $notificationPassword,
+
             'motoEnabled' => $moto
         ];
+    }
+
+    /**
+     * @return int
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     */
+    public function getStoreId() : int
+    {
+        return $this->storeManager->getStore()->getId();
     }
 }

--- a/Controller/Adminhtml/Support/ConfigurationSettingsForm.php
+++ b/Controller/Adminhtml/Support/ConfigurationSettingsForm.php
@@ -40,9 +40,9 @@ class ConfigurationSettingsForm extends Action
         $resultPage = $this->resultFactory->create(ResultFactory::TYPE_PAGE);
         $resultPage->setActiveMenu('Adyen_Payment::support')
             ->getConfig()->getTitle()->prepend(__('Configuration settings'));
-        if ($_SERVER["REQUEST_METHOD"] == "POST") {
+        if ('POST' === $this->getRequest()->getMethod()) {
             try {
-                $this->save();
+                $this->handleSubmit();
                 return $this->_redirect('*/*/success');
             } catch (\Exception $exception) {
                 $this->messageManager->addErrorMessage(__('Form unsuccessfully submitted'));
@@ -50,7 +50,7 @@ class ConfigurationSettingsForm extends Action
         }
         return $resultPage;
     }
-    private function save()
+    private function handleSubmit()
     {
         $request = $this->getRequest()->getParams();
         $configurationData = $this->configurationData->getConfigData();

--- a/Controller/Adminhtml/Support/ConfigurationSettingsForm.php
+++ b/Controller/Adminhtml/Support/ConfigurationSettingsForm.php
@@ -77,8 +77,8 @@ class ConfigurationSettingsForm extends Action
             'store' => $configurationData['storeId']
         ];
 
-        $from = ['email' => 'alexandros.moraitis@adyen.com', 'name' => 'Adyen test'];
-        $to = ['email' => 'alexandros.moraitis@adyen.com', 'name' => 'Adyen test'];
+        $from = ['email' => 'support@example.com', 'name' => 'Adyen test'];
+        $to = 'amoraitis@outlook.com';
 
         $transport = $this->transportBuilder->setTemplateIdentifier(self::CONFIGURATION_SETTINGS_EMAIL_TEMPLATE,)
             ->setTemplateOptions($templateOptions)

--- a/Controller/Adminhtml/Support/ConfigurationSettingsForm.php
+++ b/Controller/Adminhtml/Support/ConfigurationSettingsForm.php
@@ -1,38 +1,28 @@
 <?php declare(strict_types=1);
 
 namespace Adyen\Payment\Controller\Adminhtml\Support;
+
 use Magento\Backend\App\Action;
 use Magento\Backend\App\Action\Context;
 use Magento\Framework\Controller\ResultFactory;
-use Magento\Framework\Mail\Template\TransportBuilder;
-use Magento\Framework\Message\ManagerInterface as MessageManagerInterface;
+use Adyen\Payment\Helper\SupportFormHelper;
 
 class ConfigurationSettingsForm extends Action
 {
     const CONFIGURATION_SETTINGS_EMAIL_TEMPLATE = 'configuration_settings_email_template';
-    /**
-     * @var TransportBuilder
-     */
-    private $transportBuilder;
-    /**
-     * @var MessageManagerInterface
-     */
-    protected $messageManager;
 
     /**
-     * @var ConfigurationData
+     * @var SupportFormHelper
      */
-    protected $configurationData;
+    protected SupportFormHelper $supportFormHelper;
 
     public function __construct(
-        Context          $context,
-        TransportBuilder $transportBuilder,
-        ConfigurationData $configurationData
+        Context           $context,
+        SupportFormHelper $supportFormHelper
     )
     {
+        $this->supportFormHelper = $supportFormHelper;
         parent::__construct($context);
-        $this->transportBuilder = $transportBuilder;
-        $this->configurationData = $configurationData;
     }
 
     public function execute()
@@ -51,42 +41,12 @@ class ConfigurationSettingsForm extends Action
                     'headless' => $request['headless'],
                     'descriptionComments' => $request['descriptionComments']
                 ];
-                $this->handleSubmit($formData, self::CONFIGURATION_SETTINGS_EMAIL_TEMPLATE);
+                $this->supportFormHelper->handleSubmit($formData, self::CONFIGURATION_SETTINGS_EMAIL_TEMPLATE);
                 return $this->_redirect('*/*/success');
             } catch (\Exception $exception) {
                 $this->messageManager->addErrorMessage(__('Form unsuccessfully submitted'));
             }
         }
         return $resultPage;
-    }
-
-    /**
-     * @param array $formData
-     * @param string $template
-     *
-     * @return void
-     * @throws \Magento\Framework\Exception\LocalizedException
-     * @throws \Magento\Framework\Exception\MailException
-     */
-    private function  handleSubmit(array $formData, string $template) : void
-    {
-        $configurationData = $this->configurationData->getConfigData();
-        $templateVars = array_merge($configurationData, $formData);
-        $templateOptions = [
-            'area' => \Magento\Framework\App\Area::AREA_ADMINHTML,
-            'store' => $configurationData['storeId']
-        ];
-
-        $from = ['email' => 'support@example.com', 'name' => 'Adyen test'];
-        $to = 'amoraitis@outlook.com';
-
-        $transport = $this->transportBuilder->setTemplateIdentifier(self::CONFIGURATION_SETTINGS_EMAIL_TEMPLATE,)
-            ->setTemplateOptions($templateOptions)
-            ->setTemplateVars($templateVars)
-            ->setFromByScope($from)
-            ->addTo($to)
-            ->getTransport();
-        $transport->sendMessage();
-        $this->messageManager->addSuccess(__('Form successfully submitted'));
     }
 }

--- a/Controller/Adminhtml/Support/ConfigurationSettingsForm.php
+++ b/Controller/Adminhtml/Support/ConfigurationSettingsForm.php
@@ -6,6 +6,7 @@ use Magento\Backend\App\Action\Context;
 use Magento\Framework\Controller\ResultFactory;
 use Magento\Framework\Mail\Template\TransportBuilder;
 use Magento\Framework\Message\ManagerInterface as MessageManagerInterface;
+use Adyen\Payment\Controller\Adminhtml\Support\ConfigurationData;
 
 class ConfigurationSettingsForm extends Action
 {
@@ -18,13 +19,20 @@ class ConfigurationSettingsForm extends Action
      */
     protected $messageManager;
 
+    /**
+     * @var ConfigurationData
+     */
+    protected $configurationData;
+
     public function __construct(
         Context          $context,
-        TransportBuilder $transportBuilder
+        TransportBuilder $transportBuilder,
+        ConfigurationData $configurationData
     )
     {
         parent::__construct($context);
         $this->transportBuilder = $transportBuilder;
+        $this->configurationData = $configurationData;
     }
 
     public function execute()
@@ -45,6 +53,7 @@ class ConfigurationSettingsForm extends Action
     private function save()
     {
         $request = $this->getRequest()->getParams();
+        $configurationData = $this->configurationData->getConfigData();
         $templateVars = [
             'topic' => $request['topic'],
             'issue' => $request['issue'],

--- a/Controller/Adminhtml/Support/ConfigurationSettingsForm.php
+++ b/Controller/Adminhtml/Support/ConfigurationSettingsForm.php
@@ -48,6 +48,7 @@ class ConfigurationSettingsForm extends Action
         $templateVars = [
             'topic' => $request['topic'],
             'issue' => $request['issue'],
+            'subject' => $request['subject'],
             'email' => $request['email'],
             'headless' => $request['headless'],
             'descriptionComments' => $request['descriptionComments']
@@ -60,7 +61,7 @@ class ConfigurationSettingsForm extends Action
         $from = ['email' => 'test@test.com', 'name' => 'Adyen test'];
         $to = ['email' => 'test@test.com', 'name' => 'Adyen test'];
         //the template identifier is set in the etc/email_templates.xml
-        $transport = $this->transportBuilder->setTemplateIdentifier('contact_email_template')
+        $transport = $this->transportBuilder->setTemplateIdentifier('configuration_settings_email_template')
             ->setTemplateOptions($templateOptions)
             ->setTemplateVars($templateVars)
             ->setFromByScope($from)

--- a/Controller/Adminhtml/Support/ConfigurationSettingsForm.php
+++ b/Controller/Adminhtml/Support/ConfigurationSettingsForm.php
@@ -14,7 +14,7 @@ class ConfigurationSettingsForm extends Action
     /**
      * @var SupportFormHelper
      */
-    protected SupportFormHelper $supportFormHelper;
+    protected $supportFormHelper;
 
     public function __construct(
         Context           $context,

--- a/Controller/Adminhtml/Support/OrderProcessingForm.php
+++ b/Controller/Adminhtml/Support/OrderProcessingForm.php
@@ -4,12 +4,27 @@ namespace Adyen\Payment\Controller\Adminhtml\Support;
 use Magento\Backend\App\Action;
 use Magento\Backend\App\Action\Context;
 use Magento\Framework\Controller\ResultFactory;
+use Magento\Framework\Mail\Template\TransportBuilder;
+use Magento\Framework\Message\ManagerInterface as MessageManagerInterface;
 
 class OrderProcessingForm extends Action
 {
-    public function __construct(Context $context)
+    /**
+     * @var TransportBuilder
+     */
+    private $transportBuilder;
+    /**
+     * @var MessageManagerInterface
+     */
+    protected $messageManager;
+
+    public function __construct(
+        Context          $context,
+        TransportBuilder $transportBuilder
+    )
     {
         parent::__construct($context);
+        $this->transportBuilder = $transportBuilder;
     }
 
     public function execute()
@@ -17,7 +32,48 @@ class OrderProcessingForm extends Action
         $resultPage = $this->resultFactory->create(ResultFactory::TYPE_PAGE);
         $resultPage->setActiveMenu('Adyen_Payment::support')
             ->getConfig()->getTitle()->prepend(__('Order processing'));
+        if ($_SERVER["REQUEST_METHOD"] == "POST") {
+            try {
+                $this->save();
+                return $this->_redirect('*/*/success');
+            } catch (\Exception $exception) {
+                $this->messageManager->addErrorMessage(__('Form unsuccessfully submitted'));
+            }
+        }
 
         return $resultPage;
+    }
+
+    private function save()
+    {
+        $request = $this->getRequest()->getParams();
+        $templateVars = [
+            'topic' => $request['topic'],
+            'subject' => $request['subject'],
+            'email' => $request['email'],
+            'pspReference' => $request['pspReference'],
+            'merchantReference' => $request['merchantReference'],
+            'headless' => $request['headless'],
+            'paymentMethod' => $request['paymentMethod'],
+            'terminalId' => $request['terminalId'],
+            'orderHistoryComments' => $request['orderHistoryComments'],
+            'orderDescription' => $request['orderDescription']
+        ];
+
+        $templateOptions = [
+            'area' => \Magento\Framework\App\Area::AREA_ADMINHTML,
+            'store' => 1
+        ];
+        $from = ['email' => 'test@test.com', 'name' => 'Adyen test'];
+        $to = ['email' => 'test@test.com', 'name' => 'Adyen test'];
+        //the template identifier is set in the etc/email_templates.xml
+        $transport = $this->transportBuilder->setTemplateIdentifier('contact_email_template')
+            ->setTemplateOptions($templateOptions)
+            ->setTemplateVars($templateVars)
+            ->setFromByScope($from)
+            ->addTo($to)
+            ->getTransport();
+        //$transport->sendMessage();
+        $this->messageManager->addSuccess(__('Form successfully submitted'));
     }
 }

--- a/Controller/Adminhtml/Support/OrderProcessingForm.php
+++ b/Controller/Adminhtml/Support/OrderProcessingForm.php
@@ -12,7 +12,7 @@ class OrderProcessingForm extends Action
     /**
      * @var SupportFormHelper
      */
-    private SupportFormHelper $supportFormHelper;
+    private $supportFormHelper;
     /**
      * @var MessageManagerInterface
      */

--- a/Controller/Adminhtml/Support/OrderProcessingForm.php
+++ b/Controller/Adminhtml/Support/OrderProcessingForm.php
@@ -67,7 +67,7 @@ class OrderProcessingForm extends Action
         $from = ['email' => 'test@test.com', 'name' => 'Adyen test'];
         $to = ['email' => 'test@test.com', 'name' => 'Adyen test'];
         //the template identifier is set in the etc/email_templates.xml
-        $transport = $this->transportBuilder->setTemplateIdentifier('contact_email_template')
+        $transport = $this->transportBuilder->setTemplateIdentifier('order_processing_email_template')
             ->setTemplateOptions($templateOptions)
             ->setTemplateVars($templateVars)
             ->setFromByScope($from)

--- a/Controller/Adminhtml/Support/OrderProcessingForm.php
+++ b/Controller/Adminhtml/Support/OrderProcessingForm.php
@@ -32,9 +32,9 @@ class OrderProcessingForm extends Action
         $resultPage = $this->resultFactory->create(ResultFactory::TYPE_PAGE);
         $resultPage->setActiveMenu('Adyen_Payment::support')
             ->getConfig()->getTitle()->prepend(__('Order processing'));
-        if ($_SERVER["REQUEST_METHOD"] == "POST") {
+        if ('POST' === $this->getRequest()->getMethod()){
             try {
-                $this->save();
+                $this->handleSubmit();
                 return $this->_redirect('*/*/success');
             } catch (\Exception $exception) {
                 $this->messageManager->addErrorMessage(__('Form unsuccessfully submitted'));
@@ -44,7 +44,7 @@ class OrderProcessingForm extends Action
         return $resultPage;
     }
 
-    private function save()
+    private function handleSubmit()
     {
         $request = $this->getRequest()->getParams();
         $templateVars = [

--- a/Controller/Adminhtml/Support/Success.php
+++ b/Controller/Adminhtml/Support/Success.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Adyen\Payment\Controller\Adminhtml\Configuration;
+namespace Adyen\Payment\Controller\Adminhtml\Support;
 
 use Magento\Backend\App\Action;
 

--- a/Gateway/Validator/CancelResponseValidator.php
+++ b/Gateway/Validator/CancelResponseValidator.php
@@ -45,7 +45,7 @@ class CancelResponseValidator extends AbstractValidator
         $isValid = true;
         $errorMessages = [];
 
-        // The available response codes that the API can return in case of successfully cancellation
+        // The available response codes that the API can return in case of a successful cancellation
         $expectedResponses = ['[cancelOrRefund-received]', '[cancel-received]'];
 
         if (empty($response['response']) || !in_array($response['response'], $expectedResponses)) {

--- a/Gateway/Validator/CancelResponseValidator.php
+++ b/Gateway/Validator/CancelResponseValidator.php
@@ -45,7 +45,7 @@ class CancelResponseValidator extends AbstractValidator
         $isValid = true;
         $errorMessages = [];
 
-        // The available response codes that the API can return in case of successfull cancellation
+        // The available response codes that the API can return in case of successfully cancellation
         $expectedResponses = ['[cancelOrRefund-received]', '[cancel-received]'];
 
         if (empty($response['response']) || !in_array($response['response'], $expectedResponses)) {

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -44,6 +44,7 @@ class Config
     const XML_STATUS_FRAUD_MANUAL_REVIEW = 'fraud_manual_review_status';
     const XML_STATUS_FRAUD_MANUAL_REVIEW_ACCEPT = 'fraud_manual_review_accept_status';
     const XML_MOTO_MERCHANT_ACCOUNTS = 'moto_merchant_accounts';
+    const XML_ADYEN_SUPPORT_PREFIX = "adyen_support";
 
     /**
      * @var ScopeConfigInterface
@@ -467,6 +468,22 @@ class Config
         return $this->getConfigData('auto_capture_openinvoice', self::XML_ADYEN_ABSTRACT_PREFIX, $storeId, true);
     }
 
+    public function getSupportMailAddress(int $storeId): ?string
+    {
+        return $this->getConfigData('adyen_support_email_address', self::XML_ADYEN_SUPPORT_PREFIX, $storeId);
+    }
+
+    /**
+     * When enabled includes a snapshot from admin configuration in the support form email
+     *
+     * @param int $storeId
+     * @return bool
+     */
+    public function isSendAdminConfigurationEnabled(int $storeId): bool
+    {
+        return $this->getConfigData('adyen_support_send_admin_config', self::XML_ADYEN_SUPPORT_PREFIX, $storeId,true);
+    }
+
     /**
      * Retrieve information from payment configuration
      *
@@ -492,5 +509,4 @@ class Config
         $path = implode("/", [self::XML_PAYMENT_PREFIX, $xmlPrefix, $field]);
         $this->configWriter->save($path, $value, $scope);
     }
-
 }

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -493,20 +493,4 @@ class Config
         $this->configWriter->save($path, $value, $scope);
     }
 
-  //Example function below which gets specific details which we can then later call, currently assumes form will be per store.
-    public function getSupportFormDetails(int $storeId): array
-    {
-        $checkNotificationUsername = $this->getNotificationsUsername($storeId) ?'Username set':'No Username';
-        $checkNotificationPassword = $this->getNotificationsPassword($storeId) ?'Password set':'No Password';
-        $checkMerchantAccount = $this -> getMerchantAccount($storeId);
-        $checkMode = $this -> isDemoMode($storeId);
-        $storedMethod = $this -> isStoreAlternativePaymentMethodEnabled($storeId);
-        return [
-            'Notif' => $checkNotificationUsername,
-            'Pass' => $checkNotificationPassword,
-            'Merchant' => $checkMerchantAccount,
-            'Mode' => $checkMode,
-            'Stored' => $storedMethod,
-        ];
-    }
 }

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -44,7 +44,7 @@ class Config
     const XML_STATUS_FRAUD_MANUAL_REVIEW = 'fraud_manual_review_status';
     const XML_STATUS_FRAUD_MANUAL_REVIEW_ACCEPT = 'fraud_manual_review_accept_status';
     const XML_MOTO_MERCHANT_ACCOUNTS = 'moto_merchant_accounts';
-    const XML_ADYEN_SUPPORT_PREFIX = "adyen_support";
+    const XML_ADYEN_SUPPORT_PREFIX = 'adyen_support';
 
     /**
      * @var ScopeConfigInterface
@@ -481,7 +481,10 @@ class Config
      */
     public function isSendAdminConfigurationEnabled(int $storeId): bool
     {
-        return $this->getConfigData('adyen_support_send_admin_config', self::XML_ADYEN_SUPPORT_PREFIX, $storeId,true);
+        return $this->getConfigData('adyen_support_send_admin_config',
+            self::XML_ADYEN_SUPPORT_PREFIX,
+            $storeId,
+            true);
     }
 
     /**

--- a/Helper/SupportFormHelper.php
+++ b/Helper/SupportFormHelper.php
@@ -36,9 +36,8 @@ class SupportFormHelper
     protected $messageManager;
 
     public function __construct(
-
-        TransportBuilder  $transportBuilder,
-              MessageManagerInterface    $messageManager,
+        TransportBuilder         $transportBuilder,
+        MessageManagerInterface  $messageManager,
         Config                   $config,
         Data                     $adyenHelper,
         StoreManagerInterface    $storeManager,

--- a/Helper/SupportFormHelper.php
+++ b/Helper/SupportFormHelper.php
@@ -76,8 +76,11 @@ class SupportFormHelper
             'store' => $storeId
         ];
 
-        $from = ['email' => $templateVars['email'], 'name' => $this->config->getMerchantAccount($storeId)];
         $to = $this->config->getSupportMailAddress($storeId);
+        $from = ['email' => $templateVars['email'], 'name' => $this->config->getMerchantAccount($storeId)];
+        if(!isset($from['email'])){
+            $from['email'] = $this->getGeneralContactSenderEmail();
+        }
 
         $transport = $this->transportBuilder->setTemplateIdentifier($template)
             ->setTemplateOptions($templateOptions)
@@ -127,5 +130,17 @@ class SupportFormHelper
     public function getStoreId(): int
     {
         return $this->storeManager->getStore()->getId();
+    }
+
+    /**
+     * Get the email from the general contact
+     *
+     * @return string
+     */
+    public function getGeneralContactSenderEmail():string
+    {
+        $objectManager = \Magento\Framework\App\ObjectManager::getInstance();
+        $scopeConfig = $objectManager->create('\Magento\Framework\App\Config\ScopeConfigInterface');
+        return $scopeConfig->getValue('trans_email/ident_general/email',\Magento\Store\Model\ScopeInterface::SCOPE_STORE);
     }
 }

--- a/Helper/SupportFormHelper.php
+++ b/Helper/SupportFormHelper.php
@@ -13,27 +13,27 @@ class SupportFormHelper
     /**
      * @var Config
      */
-    protected Config $config;
+    protected $config;
     /**
      * @var Data
      */
-    private Data $adyenHelper;
+    private $adyenHelper;
     /**
      * @var StoreManagerInterface
      */
-    private StoreManagerInterface $storeManager;
+    private $storeManager;
     /**
      * @var ProductMetadataInterface
      */
-    protected ProductMetadataInterface $productMetadata;
+    protected $productMetadata;
     /**
      * @var TransportBuilder
      */
-    private TransportBuilder $transportBuilder;
+    private $transportBuilder;
     /**
      * @var MessageManagerInterface
      */
-    protected MessageManagerInterface $messageManager;
+    protected $messageManager;
 
     public function __construct(
 
@@ -64,10 +64,10 @@ class SupportFormHelper
     public function handleSubmit(array $formData, string $template): void
     {
         $storeId = $this->getStoreId();
-        if($this->config->isSendAdminConfigurationEnabled($storeId)){
+        if ($this->config->isSendAdminConfigurationEnabled($storeId)) {
             $configurationData = $this->getConfigData();
             $templateVars = array_merge($configurationData, $formData);
-        }else{
+        } else {
             $templateVars = $formData;
         }
 
@@ -78,7 +78,7 @@ class SupportFormHelper
 
         $to = $this->config->getSupportMailAddress($storeId);
         $from = ['email' => $templateVars['email'], 'name' => $this->config->getMerchantAccount($storeId)];
-        if(!isset($from['email'])){
+        if (!isset($from['email'])) {
             $from['email'] = $this->getGeneralContactSenderEmail();
         }
 
@@ -137,10 +137,10 @@ class SupportFormHelper
      *
      * @return string
      */
-    public function getGeneralContactSenderEmail():string
+    public function getGeneralContactSenderEmail(): string
     {
         $objectManager = \Magento\Framework\App\ObjectManager::getInstance();
         $scopeConfig = $objectManager->create('\Magento\Framework\App\Config\ScopeConfigInterface');
-        return $scopeConfig->getValue('trans_email/ident_general/email',\Magento\Store\Model\ScopeInterface::SCOPE_STORE);
+        return $scopeConfig->getValue('trans_email/ident_general/email', \Magento\Store\Model\ScopeInterface::SCOPE_STORE);
     }
 }

--- a/Helper/SupportFormHelper.php
+++ b/Helper/SupportFormHelper.php
@@ -63,15 +63,21 @@ class SupportFormHelper
      */
     public function handleSubmit(array $formData, string $template): void
     {
-        $configurationData = $this->getConfigData();
-        $templateVars = array_merge($configurationData, $formData);
+        $storeId = $this->getStoreId();
+        if($this->config->isSendAdminConfigurationEnabled($storeId)){
+            $configurationData = $this->getConfigData();
+            $templateVars = array_merge($configurationData, $formData);
+        }else{
+            $templateVars = $formData;
+        }
+
         $templateOptions = [
             'area' => \Magento\Framework\App\Area::AREA_ADMINHTML,
-            'store' => $configurationData['storeId']
+            'store' => $storeId
         ];
 
-        $from = ['email' => 'support@example.com', 'name' => 'Adyen test'];
-        $to = 'amoraitis@outlook.com';
+        $from = ['email' => $templateVars['email'], 'name' => $this->config->getMerchantAccount($storeId)];
+        $to = $this->config->getSupportMailAddress($storeId);
 
         $transport = $this->transportBuilder->setTemplateIdentifier($template)
             ->setTemplateOptions($templateOptions)

--- a/Model/TransportBuilder.php
+++ b/Model/TransportBuilder.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Adyen\Payment\Model;
+
+class TransportBuilder extends \Magento\Framework\Mail\Template\TransportBuilder
+{
+    public function addAttachment(
+        $body,
+        $mimeType    = \Zend_Mime::TYPE_OCTETSTREAM,
+        $disposition = \Zend_Mime::DISPOSITION_ATTACHMENT,
+        $encoding    = \Zend_Mime::ENCODING_BASE64,
+        $filename    = null
+    ) {
+        $this->message->createAttachment($body, $mimeType, $disposition, $encoding, $filename);
+        return $this;
+    }
+}

--- a/etc/adminhtml/system/adyen_advanced_settings.xml
+++ b/etc/adminhtml/system/adyen_advanced_settings.xml
@@ -23,5 +23,6 @@
         <include path="Adyen_Payment::system/adyen_refunds.xml"/>
         <include path="Adyen_Payment::system/adyen_pwa.xml"/>
         <include path="Adyen_Payment::system/adyen_additional_payment_settings.xml"/>
+        <include path="Adyen_Payment::system/adyen_support.xml"/>
     </group>
 </include>

--- a/etc/adminhtml/system/adyen_support.xml
+++ b/etc/adminhtml/system/adyen_support.xml
@@ -23,7 +23,7 @@
         </comment>
         <field id="adyen_support_send_admin_configuration" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
             <label>Send config values</label>
-            <tooltip>Enabling this, each support form includes the admin configuration values in the support email</tooltip>
+            <tooltip>When enabled, admin configuration values will be included in the support email</tooltip>
             <config_path>payment/adyen_support/adyen_support_send_admin_config</config_path>
             <source_model>Magento\Config\Model\Config\Source\Enabledisable</source_model>
         </field>

--- a/etc/adminhtml/system/adyen_support.xml
+++ b/etc/adminhtml/system/adyen_support.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<!--
+/**
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2022 Adyen NV (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+-->
+<include xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_include.xsd">
+    <group id="adyen_support" translate="label" type="text" sortOrder="95" showInDefault="1" showInWebsite="1" showInStore="1">
+        <label><![CDATA[Adyen Support]]></label>
+        <frontend_model>Magento\Config\Block\System\Config\Form\Fieldset</frontend_model>
+        <comment>
+            <![CDATA[
+                <p>
+                Support form settings.
+                </p>
+            ]]>
+        </comment>
+        <field id="adyen_support_send_admin_configuration" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
+            <label>Send config values</label>
+            <tooltip>Enabling this, each support form includes the admin configuration values in the support email</tooltip>
+            <config_path>payment/adyen_support/adyen_support_send_admin_config</config_path>
+            <source_model>Magento\Config\Model\Config\Source\Enabledisable</source_model>
+        </field>
+    </group>
+</include>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -206,7 +206,7 @@
                 <group>adyen</group>
             </adyen_moto>
             <adyen_support>
-                <adyen_support_email_address>amoraitis@outlook.com</adyen_support_email_address>
+                <adyen_support_email_address></adyen_support_email_address>
                 <adyen_support_send_admin_config>1</adyen_support_send_admin_config>
             </adyen_support>
         </payment>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -205,6 +205,10 @@
                 <can_capture_vault>1</can_capture_vault>
                 <group>adyen</group>
             </adyen_moto>
+            <adyen_support>
+                <adyen_support_email_address>amoraitis@outlook.com</adyen_support_email_address>
+                <adyen_support_send_admin_config>1</adyen_support_send_admin_config>
+            </adyen_support>
         </payment>
     </default>
 </config>

--- a/etc/email_templates.xml
+++ b/etc/email_templates.xml
@@ -2,6 +2,6 @@
 
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Email:etc/email_templates.xsd">
-    <template id="contact_email_template" label="Contact Form" file="email_template.html" type="html"
+    <template id="configuration_settings_email_template" label="Contact Form" file="configuration_settings_email_template.html" type="html"
               module="Adyen_Payment" area="adminhtml"/>
 </config>

--- a/etc/email_templates.xml
+++ b/etc/email_templates.xml
@@ -4,4 +4,6 @@
         xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Email:etc/email_templates.xsd">
     <template id="configuration_settings_email_template" label="Contact Form" file="configuration_settings_email_template.html" type="html"
               module="Adyen_Payment" area="adminhtml"/>
+    <template id="order_processing_email_template" label="Contact Form" file="order_processing_email_template.html" type="html"
+              module="Adyen_Payment" area="adminhtml"/>
 </config>

--- a/view/adminhtml/email/configuration_settings_email_template.html
+++ b/view/adminhtml/email/configuration_settings_email_template.html
@@ -1,34 +1,63 @@
-<table class="message-details" >
+<table class="message-details">
     <caption>Mail message from magento</caption>
-    <th>Topic {{var topic}} Magento<th>
-    <tr>
-        <td><strong>{{trans "Issue"}}</strong></td>
-        <td>{{var issue}}</td>
-    </tr>
-    <tr>
-        <td><strong>{{trans "Subject"}}</strong></td>
-        <td>{{var subject}}</td>
-    </tr>
-    <tr>
-        <td><strong>{{trans "Merchant email"}}</strong></td>
-        <td>{{var email}}</td>
-    </tr>
-    <tr>
-        <td><strong>{{trans "Are you using headless integration?"}}</strong></td>
-        <td>{{var headless}}</td>
-    </tr>
-    <tr>
-        <td><strong>{{trans "What is the description of the problem?"}}</strong></td>
-        <td>{{var descriptionComments}}</td>
-    </tr>
-    <!--Configuration settings-->
-    <tr>
-        <td><strong>{{trans "Magento version"}}</strong></td>
-        <td>{{var magentoVersion}}</td>
-    </tr>
-    <tr>
-        <td><strong>{{trans "Plugin version"}}</strong></td>
-        <td>{{var pluginVersion}}</td>
-    </tr>
+    <th>Topic {{var topic}} Magento
+    <th>
+        <tr>
+            <td><strong>{{trans "Issue"}}</strong></td>
+            <td>{{var issue}}</td>
+        </tr>
+        <tr>
+            <td><strong>{{trans "Subject"}}</strong></td>
+            <td>{{var subject}}</td>
+        </tr>
+        <tr>
+            <td><strong>{{trans "Merchant email"}}</strong></td>
+            <td>{{var email}}</td>
+        </tr>
+        <tr>
+            <td><strong>{{trans "Are you using headless integration?"}}</strong></td>
+            <td>{{var headless}}</td>
+        </tr>
+        <tr>
+            <td><strong>{{trans "What is the description of the problem?"}}</strong></td>
+            <td>{{var descriptionComments}}</td>
+        </tr>
+        <!--Configuration settings-->
+        <tr>
+            <td><strong>{{trans "Magento version"}}</strong></td>
+            <td>{{var magentoVersion}}</td>
+        </tr>
+        <tr>
+            <td><strong>{{trans "Plugin version"}}</strong></td>
+            <td>{{var pluginVersion}}</td>
+        </tr>
+        <tr>
+            <td><strong>{{trans "Merchant account"}}</strong></td>
+            <td>{{var merchantAccount}}</td>
+        </tr>
+        <tr>
+            <td><strong>{{trans "Environment live or test"}}</strong></td>
+            <td>{{var isDemoMode}}</td>
+        </tr>
+        <tr>
+            <td><strong>{{trans "Are payment methods enabled"}}</strong></td>
+            <td>{{var paymentMethodsEnabled}}</td>
+        </tr>
+        <tr>
+            <td><strong>{{trans "PBL enabled or not?"}}</strong></td>
+            <td>{{var pblEnabled}}</td>
+        </tr>
+        <tr>
+            <td><strong>{{trans "Moto enabled"}}</strong></td>
+            <td>{{var motoEnabled}}</td>
+        </tr>
+        <tr>
+            <td><strong>{{trans "Notification username set"}}</strong></td>
+            <td>{{var notificationUsername}}</td>
+        </tr>
+        <tr>
+            <td><strong>{{trans "Notification password set"}}</strong></td>
+            <td>{{var notificationPassword}}</td>
+        </tr>
 
 </table>

--- a/view/adminhtml/email/configuration_settings_email_template.html
+++ b/view/adminhtml/email/configuration_settings_email_template.html
@@ -24,6 +24,10 @@
         </tr>
         <!--Configuration settings-->
         <tr>
+            <td><strong>{{trans "Magento edition"}}</strong></td>
+            <td>{{var magentoEdition}}</td>
+        </tr>
+        <tr>
             <td><strong>{{trans "Magento version"}}</strong></td>
             <td>{{var magentoVersion}}</td>
         </tr>
@@ -37,19 +41,11 @@
         </tr>
         <tr>
             <td><strong>{{trans "Environment live or test"}}</strong></td>
-            <td>{{var isDemoMode}}</td>
+            <td>{{var environmentMode}}</td>
         </tr>
         <tr>
             <td><strong>{{trans "Are payment methods enabled"}}</strong></td>
             <td>{{var paymentMethodsEnabled}}</td>
-        </tr>
-        <tr>
-            <td><strong>{{trans "PBL enabled or not?"}}</strong></td>
-            <td>{{var pblEnabled}}</td>
-        </tr>
-        <tr>
-            <td><strong>{{trans "Moto enabled"}}</strong></td>
-            <td>{{var motoEnabled}}</td>
         </tr>
         <tr>
             <td><strong>{{trans "Notification username set"}}</strong></td>
@@ -59,5 +55,14 @@
             <td><strong>{{trans "Notification password set"}}</strong></td>
             <td>{{var notificationPassword}}</td>
         </tr>
+        <tr>
+            <td><strong>{{trans "Moto enabled"}}</strong></td>
+            <td>{{var motoEnabled}}</td>
+        </tr>
+        <tr>
+            <td><strong>{{trans "PBL enabled or not?"}}</strong></td>
+            <td>{{var pblEnabled}}</td>
+        </tr>
+
 
 </table>

--- a/view/adminhtml/email/configuration_settings_email_template.html
+++ b/view/adminhtml/email/configuration_settings_email_template.html
@@ -21,5 +21,14 @@
         <td><strong>{{trans "What is the description of the problem?"}}</strong></td>
         <td>{{var descriptionComments}}</td>
     </tr>
+    <!--Configuration settings-->
+    <tr>
+        <td><strong>{{trans "Magento version"}}</strong></td>
+        <td>{{var magentoVersion}}</td>
+    </tr>
+    <tr>
+        <td><strong>{{trans "Plugin version"}}</strong></td>
+        <td>{{var pluginVersion}}</td>
+    </tr>
 
 </table>

--- a/view/adminhtml/email/configuration_settings_email_template.html
+++ b/view/adminhtml/email/configuration_settings_email_template.html
@@ -1,0 +1,25 @@
+<table class="message-details" >
+    <caption>Mail message from magento</caption>
+    <th>Topic {{var topic}} Magento<th>
+    <tr>
+        <td><strong>{{trans "Issue"}}</strong></td>
+        <td>{{var issue}}</td>
+    </tr>
+    <tr>
+        <td><strong>{{trans "Subject"}}</strong></td>
+        <td>{{var subject}}</td>
+    </tr>
+    <tr>
+        <td><strong>{{trans "Merchant email"}}</strong></td>
+        <td>{{var email}}</td>
+    </tr>
+    <tr>
+        <td><strong>{{trans "Are you using headless integration?"}}</strong></td>
+        <td>{{var headless}}</td>
+    </tr>
+    <tr>
+        <td><strong>{{trans "What is the description of the problem?"}}</strong></td>
+        <td>{{var descriptionComments}}</td>
+    </tr>
+
+</table>

--- a/view/adminhtml/email/configuration_settings_email_template.html
+++ b/view/adminhtml/email/configuration_settings_email_template.html
@@ -1,7 +1,10 @@
+<!--@subject {{var subject}} @-->
 <table class="message-details">
     <caption>Mail message from magento</caption>
-    <th>Topic {{var topic}} Magento
-    <th>
+    <tr>
+        <td><strong>{{trans "Topic"}}</strong></td>
+        <td>{{var topic}}</td>
+    </tr>
         <tr>
             <td><strong>{{trans "Issue"}}</strong></td>
             <td>{{var issue}}</td>
@@ -63,6 +66,5 @@
             <td><strong>{{trans "PBL enabled or not?"}}</strong></td>
             <td>{{var pblEnabled}}</td>
         </tr>
-
 
 </table>

--- a/view/adminhtml/email/configuration_settings_email_template.html
+++ b/view/adminhtml/email/configuration_settings_email_template.html
@@ -2,6 +2,9 @@
 <table class="message-details">
     <caption>Mail message from magento</caption>
     <tr>
+        <th scope="col">Contact form</th>
+    </tr>
+    <tr>
         <td><strong>{{trans "Topic"}}</strong></td>
         <td>{{var topic}}</td>
     </tr>

--- a/view/adminhtml/email/order_processing_email_template.html
+++ b/view/adminhtml/email/order_processing_email_template.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+
+</body>
+</html>

--- a/view/adminhtml/email/order_processing_email_template.html
+++ b/view/adminhtml/email/order_processing_email_template.html
@@ -1,10 +1,46 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <title>Title</title>
-</head>
-<body>
+<table class="message-details" >
+    <caption>Mail message from magento</caption>
+    <th>Topic {{var topic}} Magento<th>
+      <tr>
+        <td><strong>{{trans "Subject"}}</strong></td>
+        <td>{{var subject}}</td>
+    </tr>
+    <tr>
+        <td><strong>{{trans "Merchant email"}}</strong></td>
+        <td>{{var email}}</td>
+    </tr>
+    <tr>
+        <td><strong>{{trans "Psp reference"}}</strong></td>
+        <td>{{var pspReference}}</td>
+    </tr>
+    <tr>
+        <td><strong>{{trans " Merchant reference"}}</strong></td>
+        <td>{{var merchantReference}}</td>
+    </tr>
+    <tr>
+        <td><strong>{{trans "Are you using headless integration?"}}</strong></td>
+        <td>{{var headless}}</td>
+    </tr>
+    <tr>
+        <td><strong>{{trans "TerminalId"}}</strong></td>
+        <td>{{var terminalId}}</td>
+    </tr>
+    <tr>
+        <td><strong>{{trans "Order History comments"}}</strong></td>
+        <td>{{var orderHistoryComments}}</td>
+    </tr>
+    <tr>
+        <td><strong>{{trans "What is the description of the problem?"}}</strong></td>
+        <td>{{var orderDescription}}</td>
+    </tr>
+    <!--Configuration settings-->
+    <tr>
+        <td><strong>{{trans "Magento version"}}</strong></td>
+        <td>{{var magentoVersion}}</td>
+    </tr>
+    <tr>
+        <td><strong>{{trans "Plugin version"}}</strong></td>
+        <td>{{var pluginVersion}}</td>
+    </tr>
 
-</body>
-</html>
+</table>

--- a/view/adminhtml/email/order_processing_email_template.html
+++ b/view/adminhtml/email/order_processing_email_template.html
@@ -1,3 +1,4 @@
+<!--@subject {{var subject}} @-->
 <table class="message-details" >
     <caption>Mail message from magento</caption>
     <th>Topic {{var topic}} Magento<th>
@@ -22,6 +23,10 @@
         <td>{{var headless}}</td>
     </tr>
     <tr>
+        <td><strong>{{trans "What payment method is causing the problem? "}}</strong></td>
+        <td>{{var paymentMethod}}</td>
+    </tr>
+    <tr>
         <td><strong>{{trans "TerminalId"}}</strong></td>
         <td>{{var terminalId}}</td>
     </tr>
@@ -30,10 +35,14 @@
         <td>{{var orderHistoryComments}}</td>
     </tr>
     <tr>
-        <td><strong>{{trans "What is the description of the problem?"}}</strong></td>
+        <td><strong>{{trans "Description"}}</strong></td>
         <td>{{var orderDescription}}</td>
     </tr>
     <!--Configuration settings-->
+    <tr>
+        <td><strong>{{trans "Magento edition"}}</strong></td>
+        <td>{{var magentoEdition}}</td>
+    </tr>
     <tr>
         <td><strong>{{trans "Magento version"}}</strong></td>
         <td>{{var magentoVersion}}</td>
@@ -47,28 +56,12 @@
         <td>{{var merchantAccount}}</td>
     </tr>
     <tr>
-        <td><strong>{{trans "Environment test mode"}}</strong></td>
-        <td>{{var isDemoMode}}</td>
+        <td><strong>{{trans "Environment live or test"}}</strong></td>
+        <td>{{var environmentMode}}</td>
     </tr>
     <tr>
-        <td><strong>{{trans "Is test Mode"}}</strong></td>
-        <td>{{var configurationMode}}</td>
-    </tr>
-    <tr>
-        <td><strong>{{trans "Is payment methods enabled"}}</strong></td>
+        <td><strong>{{trans "Are payment methods enabled"}}</strong></td>
         <td>{{var paymentMethodsEnabled}}</td>
-    </tr>
-    <tr>
-        <td><strong>{{trans "Is POS enabled ?"}}</strong></td>
-        <td>{{var posEnabled}}</td>
-    </tr>
-    <tr>
-        <td><strong>{{trans "PBL enabled or not?"}}</strong></td>
-        <td>{{var pblEnabled}}</td>
-    </tr>
-    <tr>
-        <td><strong>{{trans "Moto enabled"}}</strong></td>
-        <td>{{var motoEnabled}}</td>
     </tr>
     <tr>
         <td><strong>{{trans "Notification username set"}}</strong></td>
@@ -77,6 +70,14 @@
     <tr>
         <td><strong>{{trans "Notification password set"}}</strong></td>
         <td>{{var notificationPassword}}</td>
+    </tr>
+    <tr>
+        <td><strong>{{trans "Moto enabled"}}</strong></td>
+        <td>{{var motoEnabled}}</td>
+    </tr>
+    <tr>
+        <td><strong>{{trans "PBL enabled or not?"}}</strong></td>
+        <td>{{var pblEnabled}}</td>
     </tr>
 
 </table>

--- a/view/adminhtml/email/order_processing_email_template.html
+++ b/view/adminhtml/email/order_processing_email_template.html
@@ -42,5 +42,41 @@
         <td><strong>{{trans "Plugin version"}}</strong></td>
         <td>{{var pluginVersion}}</td>
     </tr>
+    <tr>
+        <td><strong>{{trans "Merchant account"}}</strong></td>
+        <td>{{var merchantAccount}}</td>
+    </tr>
+    <tr>
+        <td><strong>{{trans "Environment test mode"}}</strong></td>
+        <td>{{var isDemoMode}}</td>
+    </tr>
+    <tr>
+        <td><strong>{{trans "Is test Mode"}}</strong></td>
+        <td>{{var configurationMode}}</td>
+    </tr>
+    <tr>
+        <td><strong>{{trans "Is payment methods enabled"}}</strong></td>
+        <td>{{var paymentMethodsEnabled}}</td>
+    </tr>
+    <tr>
+        <td><strong>{{trans "Is POS enabled ?"}}</strong></td>
+        <td>{{var posEnabled}}</td>
+    </tr>
+    <tr>
+        <td><strong>{{trans "PBL enabled or not?"}}</strong></td>
+        <td>{{var pblEnabled}}</td>
+    </tr>
+    <tr>
+        <td><strong>{{trans "Moto enabled"}}</strong></td>
+        <td>{{var motoEnabled}}</td>
+    </tr>
+    <tr>
+        <td><strong>{{trans "Notification username set"}}</strong></td>
+        <td>{{var notificationUsername}}</td>
+    </tr>
+    <tr>
+        <td><strong>{{trans "Notification password set"}}</strong></td>
+        <td>{{var notificationPassword}}</td>
+    </tr>
 
 </table>

--- a/view/adminhtml/templates/support/js.phtml
+++ b/view/adminhtml/templates/support/js.phtml
@@ -8,7 +8,7 @@ require([
 ], function($) {
     $('#support_topic_value').change(function() {
         // enable/disable the submit button
-        let topic = $( "#support_topic_value" ).val();
+        let topic = $("#support_topic_value").val();
 
         if (0 !== topic.length) {
             $('#adyen_support-need-help').prop('disabled', false);

--- a/view/adminhtml/templates/support/js.phtml
+++ b/view/adminhtml/templates/support/js.phtml
@@ -6,21 +6,15 @@ require([
     'jquery',
     'mage/mage'
 ], function($) {
-    $('#support_form').mage('form').mage('validation', {
-        highlight: function(element) {
-            var detailsElement = $(element).closest('details');
-            if (detailsElement.length && detailsElement.is('.details')) {
-                var summaryElement = detailsElement.find('summary');
-                if (summaryElement.length && summaryElement.attr('aria-expanded') === "false") {
-                    summaryElement.trigger('click');
-                }
-            }
-            $(element).trigger('highlight.validate');
-        }
-    });
+    $('#support_topic_value').change(function() {
+        // enable/disable the submit button
+        let topic = $( "#support_topic_value" ).val();
 
-    $('#send').click(() => {
-        $('#support_form').submit();
+        if (0 !== topic.length) {
+            $('#adyen_support-need-help').prop('disabled', false);
+        } else {
+            $('#adyen_support-need-help').prop('disabled', true);
+        }
     });
 
     const linksMapping = {

--- a/view/adminhtml/templates/support/support_links.phtml
+++ b/view/adminhtml/templates/support/support_links.phtml
@@ -1,39 +1,39 @@
 <?php /** @var SupportTabInterface $block */
 use Adyen\Payment\Block\Adminhtml\Support\SupportTabInterface; ?>
 <div class="adyen_support-main">
-    <table class="adyen_support-content">
-        <caption>Table containing support topics</caption>
-        <tr>
-            <th class="adyen_support-label">Topic</th>
-            <td>
-                <div class="adyen_support-value">
-                    <select id="support_topic_value">
-                        <option value="">Please select a topic</option>
-                        <?php foreach ($block->getSupportTopics() as $key => $topic): ?>
-                            <option value="<?=$key;?>"><?=$topic;?></option>
-                        <?php endforeach; ?>
-                    </select>
-                </div>
-            </td>
-        </tr>
-        <tr>
-            <td>&nbsp;</td>
-            <td>
-                <div class="adyen_support-links--container adyen_support-value">
-                    <h3><strong>Related articles</strong></h3>
-                    <div class="adyen_support-links"></div>
-                </div>
-            </td>
-        </tr>
-        <tr>
-            <td>&nbsp;</td>
-            <td>
-                <div class="adyen_support-value">
-                    <a href="<?= $block->supportFormUrl();?>">
-                        <button class="adyen_support-form_link btn btn-large btn-prime">I still need help</button>
-                    </a>
-                </div>
-            </td>
-        </tr>
-    </table>
+    <form action="<?= $block->supportFormUrl();?>" method="GET">
+        <table class="adyen_support-content">
+            <caption>Table containing support topics</caption>
+            <tr>
+                <th class="adyen_support-label">Topic</th>
+                <td>
+                    <div class="adyen_support-value">
+                        <select name="topic" id="support_topic_value">
+                            <option value="">Please select a topic</option>
+                            <?php foreach ($block->getSupportTopics() as $key => $topic): ?>
+                                <option value="<?=$key;?>"><?=$topic;?></option>
+                            <?php endforeach; ?>
+                        </select>
+                    </div>
+                </td>
+            </tr>
+            <tr>
+                <td>&nbsp;</td>
+                <td>
+                    <div class="adyen_support-links--container adyen_support-value">
+                        <h3><strong>Related articles</strong></h3>
+                        <div class="adyen_support-links"></div>
+                    </div>
+                </td>
+            </tr>
+            <tr>
+                <td>&nbsp;</td>
+                <td>
+                    <div class="adyen_support-value">
+                        <button type="submit" disabled="disabled" id="adyen_support-need-help" class="adyen_support-form_link btn btn-large btn-prime">I still need help</button>
+                    </div>
+                </td>
+            </tr>
+        </table>
+    </form>
 </div>

--- a/view/adminhtml/templates/support/support_links.phtml
+++ b/view/adminhtml/templates/support/support_links.phtml
@@ -1,7 +1,8 @@
 <?php /** @var SupportTabInterface $block */
+
 use Adyen\Payment\Block\Adminhtml\Support\SupportTabInterface; ?>
 <div class="adyen_support-main">
-    <form action="<?= $block->supportFormUrl();?>" method="GET">
+    <form action="<?= $block->supportFormUrl(); ?>" method="GET">
         <table class="adyen_support-content">
             <caption>Table containing support topics</caption>
             <tr>
@@ -11,7 +12,7 @@ use Adyen\Payment\Block\Adminhtml\Support\SupportTabInterface; ?>
                         <select name="topic" id="support_topic_value">
                             <option value="">Please select a topic</option>
                             <?php foreach ($block->getSupportTopics() as $key => $topic): ?>
-                                <option value="<?=$key;?>"><?=$topic;?></option>
+                                <option value="<?= $key; ?>"><?= $topic; ?></option>
                             <?php endforeach; ?>
                         </select>
                     </div>
@@ -30,7 +31,9 @@ use Adyen\Payment\Block\Adminhtml\Support\SupportTabInterface; ?>
                 <td>&nbsp;</td>
                 <td>
                     <div class="adyen_support-value">
-                        <button type="submit" disabled="disabled" id="adyen_support-need-help" class="adyen_support-form_link btn btn-large btn-prime">I still need help</button>
+                        <button type="submit" disabled="disabled" id="adyen_support-need-help"
+                                class="adyen_support-form_link btn btn-large btn-prime">I still need help
+                        </button>
                     </div>
                 </td>
             </tr>


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
- Send email from the forms using the email address from the config `adyen_support_send_admin_config`
- Creates a snapshot with the admin configuration data, magento instance details and includes them in the email
- Update the support form templates

**Tested scenarios**
- Send test emails to real address using [mageplaza plugin](https://github.com/mageplaza/magento-2-smtp#2-how-to-install-smtp-extension)
