### PR TITLE
[PW-7711] Remove brand_code unsetter for alternative payment methods

### DIFF
--- a/Observer/AdyenHppDataAssignObserver.php
+++ b/Observer/AdyenHppDataAssignObserver.php
@@ -89,9 +89,6 @@ class AdyenHppDataAssignObserver extends AbstractDataAssignObserver
         $data = $this->readDataArgument($observer);
         $paymentInfo = $this->readPaymentModelArgument($observer);
 
-        // Remove remaining brand_code information from the previous payment
-        $paymentInfo->unsAdditionalInformation('brand_code');
-
         // Get additional data array
         $additionalData = $data->getData(PaymentInterface::KEY_ADDITIONAL_DATA);
         if (!is_array($additionalData)) {


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
This part of the code was introduced on the early versions to prevent leftover parameter `brand_code` in the additional information field from the alternative payment methods if the second payment attempt was completed with adyen_cc or adyen_onclick. However, it created another issue on the headless payments, since the observer is hit twice. On the second hit, it always removes the `brand_code` field, which causes failing Klarna payments due to lack of line items.

This part was removed from `AdyenHppDataAssignObserver` class.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- Klarna

Fixes #1904 