### PR TITLE
Implement option to use queue or cron (default) for webhook notification processing

### DIFF
--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -12,6 +12,7 @@
 namespace Adyen\Payment\Helper;
 
 use Adyen\AdyenException;
+use Adyen\Payment\Model\Config\Source\NotificationProcessor;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\App\Config\Storage\WriterInterface;
 use Magento\Framework\Encryption\EncryptorInterface;
@@ -46,6 +47,7 @@ class Config
     const XML_STATUS_FRAUD_MANUAL_REVIEW_ACCEPT = 'fraud_manual_review_accept_status';
     const XML_MOTO_MERCHANT_ACCOUNTS = 'moto_merchant_accounts';
     const XML_ADYEN_POS_CLOUD = 'adyen_pos_cloud';
+    const XML_WEBHOOK_NOTIFICATION_PROCESSOR = 'webhook_notification_processor';
 
     /**
      * @var ScopeConfigInterface
@@ -495,6 +497,14 @@ class Config
         return $this->getConfigData('apple_pay_certificate_url', self::XML_ADYEN_HPP, $storeId);
     }
 
+    public function useQueueProcessor($storeId = null): bool
+    {
+        return $this->getConfigData(
+            self::XML_WEBHOOK_NOTIFICATION_PROCESSOR,
+            self::XML_ADYEN_ABSTRACT_PREFIX,
+            $storeId
+        ) === NotificationProcessor::QUEUE;
+    }
 
     /**
      * Retrieve information from payment configuration

--- a/Model/Config/Source/NotificationProcessor.php
+++ b/Model/Config/Source/NotificationProcessor.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Adyen\Payment\Model\Config\Source;
+
+use Magento\Framework\Data\OptionSourceInterface;
+
+class NotificationProcessor implements OptionSourceInterface
+{
+    public const CRON = 'cron';
+    public const QUEUE = 'queue';
+
+    /**
+     * @return array[]
+     */
+    public function toOptionArray(): array
+    {
+        return [
+            ['value' => self::CRON, 'label' => __('Cron')],
+            ['value' => self::QUEUE, 'label' => __('Queue')],
+        ];
+    }
+}

--- a/Model/Queue/Notification/Consumer.php
+++ b/Model/Queue/Notification/Consumer.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Adyen\Payment\Model\Queue\Notification;
+
+use Adyen\Payment\Api\Data\NotificationInterface;
+use Adyen\Payment\Helper\Webhook;
+use Adyen\Payment\Logger\AdyenLogger;
+use Exception;
+
+class Consumer
+{
+    public const TOPIC_NAME = "adyen.notification";
+
+    /** @var Webhook $webhookHelper */
+    private $webhookHelper;
+
+    /** @var AdyenLogger $adyenLogger */
+    private $adyenLogger;
+
+    /**
+     * @param Webhook $webhookHelper
+     * @param AdyenLogger $adyenLogger
+     */
+    public function __construct(
+        Webhook $webhookHelper,
+        AdyenLogger $adyenLogger,
+    ) {
+        $this->webhookHelper = $webhookHelper;
+        $this->adyenLogger = $adyenLogger;
+    }
+
+    /**
+     * @param NotificationInterface $notification
+     * @return bool
+     * @throws Exception
+     */
+    public function execute(NotificationInterface $notification): bool
+    {
+        try {
+            return $this->webhookHelper->processNotification($notification);
+        } catch (Exception $e) {
+            $this->adyenLogger->addAdyenWarning($e->getMessage() . "\n" . $e->getTraceAsString());
+            throw $e;
+        }
+    }
+}

--- a/Model/Queue/Notification/Consumer.php
+++ b/Model/Queue/Notification/Consumer.php
@@ -9,8 +9,6 @@ use Exception;
 
 class Consumer
 {
-    public const TOPIC_NAME = "adyen.notification";
-
     /** @var Webhook $webhookHelper */
     private $webhookHelper;
 
@@ -23,7 +21,7 @@ class Consumer
      */
     public function __construct(
         Webhook $webhookHelper,
-        AdyenLogger $adyenLogger,
+        AdyenLogger $adyenLogger
     ) {
         $this->webhookHelper = $webhookHelper;
         $this->adyenLogger = $adyenLogger;

--- a/Model/Queue/Notification/Publisher.php
+++ b/Model/Queue/Notification/Publisher.php
@@ -10,7 +10,7 @@ class Publisher
     private const TOPIC_NAME = "adyen.notification";
 
     /** @var PublisherInterface $publisher */
-    private PublisherInterface $publisher;
+    private $publisher;
 
     /**
      * @param PublisherInterface $publisher

--- a/Model/Queue/Notification/Publisher.php
+++ b/Model/Queue/Notification/Publisher.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Adyen\Payment\Model\Queue\Notification;
+
+use Adyen\Payment\Api\Data\NotificationInterface;
+use Magento\Framework\MessageQueue\PublisherInterface;
+
+class Publisher
+{
+    private const TOPIC_NAME = "adyen.notification";
+
+    /** @var PublisherInterface $publisher */
+    private PublisherInterface $publisher;
+
+    /**
+     * @param PublisherInterface $publisher
+     */
+    public function __construct(PublisherInterface $publisher)
+    {
+        $this->publisher = $publisher;
+    }
+
+    /**
+     * @param NotificationInterface $notification
+     * @return void
+     */
+    public function execute(NotificationInterface $notification): void
+    {
+        $this->publisher->publish(self::TOPIC_NAME, $notification);
+    }
+}

--- a/etc/adminhtml/system/adyen_required_settings.xml
+++ b/etc/adminhtml/system/adyen_required_settings.xml
@@ -218,5 +218,11 @@
             </depends>
             <frontend_model>Adyen\Payment\Model\Config\Adminhtml\ConfigurationWizard</frontend_model>
         </field>
+        <field id="webhook_notification_processor" translate="label" type="select" sortOrder="140" showInDefault="1" showInWebsite="0" showInStore="0">
+            <label>Webhook Notification Processor</label>
+            <source_model>Adyen\Payment\Model\Config\Source\NotificationProcessor</source_model>
+            <config_path>payment/adyen_abstract/webhook_notification_processor</config_path>
+            <comment>Use cron or queue (async) to process webhook notifications</comment>
+        </field>
     </group>
 </include>

--- a/etc/communication.xml
+++ b/etc/communication.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:Communication/etc/communication.xsd">
+    <topic name="adyen.notification"
+           is_synchronous="false"
+           response="boolean"
+           request="Adyen\Payment\Api\Data\NotificationInterface">
+        <handler name="AdyenNotificationHandler"
+                 type="Adyen\Payment\Model\Queue\Notification\Consumer"
+                 method="execute"/>
+    </topic>
+</config>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -27,6 +27,7 @@
                 <notifications_can_cancel>1</notifications_can_cancel>
                 <charged_currency>display</charged_currency>
                 <house_number_street_line>0</house_number_street_line>
+                <webhook_notification_processor>cron</webhook_notification_processor>
             </adyen_abstract>
             <adyen_cc>
                 <active>0</active>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1152,6 +1152,8 @@
                 type="Adyen\Payment\Model\Api\Internal\InternalAdyenDonations"/>
     <preference for="Adyen\Payment\Api\AdyenDonationsInterface"
                 type="Adyen\Payment\Model\Api\AdyenDonations"/>
+    <preference for="Adyen\Payment\Api\Data\NotificationInterface"
+                type="Adyen\Payment\Model\Notification"/>
     <type name="Magento\Vault\Api\PaymentTokenRepositoryInterface">
         <plugin name="AdyenPaymentVaultDeleteToken" type="Adyen\Payment\Plugin\PaymentVaultDeleteToken" sortOrder="10"/>
     </type>

--- a/etc/queue_consumer.xml
+++ b/etc/queue_consumer.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework-message-queue:etc/consumer.xsd">
+    <consumer name="adyen.notification"
+              queue="adyen.notification"
+              connection="amqp"
+              handler="Adyen\Payment\Model\Queue\Notification\Consumer::execute"/>
+</config>

--- a/etc/queue_publisher.xml
+++ b/etc/queue_publisher.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework-message-queue:etc/publisher.xsd">
+    <publisher topic="adyen.notification">
+        <connection name="amqp" exchange="magento"/>
+    </publisher>
+</config>

--- a/etc/queue_topology.xml
+++ b/etc/queue_topology.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework-message-queue:etc/topology.xsd">
+    <exchange name="magento" type="topic" connection="amqp">
+        <binding id="NotificationBinding"
+                 topic="adyen.notification"
+                 destinationType="queue"
+                 destination="adyen.notification"/>
+    </exchange>
+</config>


### PR DESCRIPTION
**Description**
Add configuration to use queue for async processing for webhook notifications or use default cron process.

**Tested scenarios**

Fixes  https://github.com/Adyen/adyen-magento2/issues/1847
