### PR TITLE
[PW-7759] - Only parse Level2 and 3 data for Credit cards.

### DIFF
--- a/Gateway/Request/AdditionalDataLevel23DataBuilder.php
+++ b/Gateway/Request/AdditionalDataLevel23DataBuilder.php
@@ -16,7 +16,6 @@ use Adyen\Payment\Helper\ChargedCurrency;
 use Adyen\Payment\Helper\Config;
 use Adyen\Payment\Helper\Data;
 use Adyen\Payment\Helper\Requests;
-use Adyen\Util\Uuid;
 use Magento\Payment\Gateway\Helper\SubjectReader;
 use Magento\Payment\Gateway\Request\BuilderInterface;
 use Magento\Sales\Model\Order;

--- a/etc/adminhtml/system/adyen_additional_payment_settings.xml
+++ b/etc/adminhtml/system/adyen_additional_payment_settings.xml
@@ -31,7 +31,7 @@
             <config_path>payment/adyen_abstract/send_level23_data</config_path>
             <comment>
                 <![CDATA[
-                If enabled level 2/level 3 data will be sent with every payment request. Refer to
+                If enabled level 2/level 3 data will be sent for credit card payments. Refer to
                 <a target="_blank" href="https://docs.adyen.com/online-payments/classic-integrations/hosted-payment-pages/hpp-payments-with-l2l3-data">Adyen documentation</a>
                 for more information.
                 ]]>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -666,7 +666,6 @@
                 <item name="address" xsi:type="string">Adyen\Payment\Gateway\Request\AddressDataBuilder</item>
                 <item name="payment" xsi:type="string">Adyen\Payment\Gateway\Request\PaymentDataBuilder</item>
                 <item name="risk" xsi:type="string">Adyen\Payment\Gateway\Request\RiskDataBuilder</item>
-                <item name="level23" xsi:type="string">Adyen\Payment\Gateway\Request\AdditionalDataLevel23DataBuilder</item>
                 <item name="returnurl" xsi:type="string">Adyen\Payment\Gateway\Request\ReturnUrlDataBuilder</item>
                 <item name="channel" xsi:type="string">Adyen\Payment\Gateway\Request\ChannelDataBuilder</item>
                 <item name="origin" xsi:type="string">Adyen\Payment\Gateway\Request\OriginDataBuilder</item>
@@ -722,7 +721,6 @@
                 <item name="address" xsi:type="string">Adyen\Payment\Gateway\Request\AddressDataBuilder</item>
                 <item name="payment" xsi:type="string">Adyen\Payment\Gateway\Request\PaymentDataBuilder</item>
                 <item name="risk" xsi:type="string">Adyen\Payment\Gateway\Request\RiskDataBuilder</item>
-                <item name="level23" xsi:type="string">Adyen\Payment\Gateway\Request\AdditionalDataLevel23DataBuilder</item>
                 <item name="browserinfo" xsi:type="string">Adyen\Payment\Gateway\Request\BrowserInfoDataBuilder</item>
                 <item name="recurring" xsi:type="string">Adyen\Payment\Gateway\Request\RecurringDataBuilder</item>
                 <item name="shopperinteraction" xsi:type="string">Adyen\Payment\Gateway\Request\ShopperInteractionDataBuilder</item>


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->

Modify the Di.xml in order to only add the L2 and L3 data. Also updated the comment. 

**Tested scenarios**
<!-- Description of tested scenarios -->

Tested with L2 enabled, CC and Oneclick payment. 
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

Fixes  <!-- #-prefixed github issue number -->
