### PR TITLE
[PW-7803] Save resources on e2e pipelines

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -5,6 +5,7 @@ on: [pull_request]
 
 jobs:
   build:
+    if: ${{ github.actor != 'renovate[bot]' || github.actor != 'lgtm-com[bot]' }}
     runs-on:
       group: larger-runners
       labels: ubuntu-latest-8-cores

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on:
       group: larger-runners
       labels: ubuntu-latest-8-cores
+    timeout-minutes: 20
     env:
       PHP_VERSION: "8.1"
       MAGENTO_VERSION: "2.4.5"


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
- PRs from bot accounts (renovate, lgtm-com) won't be able to trigger E2E pipelines, therefore our paid runner minutes won't be wasted
- An upper limit of 20 minutes has been defined to prevent wasting minutes in the rare event of pipeline getting stuck

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

Fixes  <!-- #-prefixed github issue number -->
