### PR TITLE
[PW-7767] Fix redirect issue from the success page

### DIFF
--- a/Controller/Process/Result.php
+++ b/Controller/Process/Result.php
@@ -226,11 +226,11 @@ class Result extends Action
             $session = $this->_session;
             $session->getQuote()->setIsActive($setQuoteAsActive)->save();
 
-            // Prevent action component to redirect page with the payment method Dotpay Bank transfer / postal
-            if (
-                $this->_order->getPayment()->getAdditionalInformation('brand_code') == self::BRAND_CODE_DOTPAY &&
-                $this->_order->getPayment()->getAdditionalInformation('resultCode') == self::RESULT_CODE_RECEIVED
-            ) {
+            /**
+             * Prevent action component to redirect page again after returning to the shop.
+             */
+            $paymentAction = $this->_order->getPayment()->getAdditionalInformation('action');
+            if (isset($paymentAction) && $paymentAction['type'] === 'redirect') {
                 $this->payment->unsAdditionalInformation('action');
                 $this->_order->save();
             }


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Action component loads the required after payment actions on the success page. However, it was also redirecting already redirected payments to the payment method page for (Oney, DotPay etc.).

Action component with the type `redirect` is removed after being redirected to the Magento shop.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- Oney (Received eventCode)
- DotPay (Received eventCode)