### PR TITLE
[PW-7948] REPORT_AVAILABLE notification fails and throws exception

### DIFF
--- a/Helper/Webhook.php
+++ b/Helper/Webhook.php
@@ -131,13 +131,26 @@ class Webhook
                 ],
             );
 
-        if (!is_null($notification->getMerchantReference()) &&
-            $order = $this->orderHelper->getOrderByIncrementId($notification->getMerchantReference())) {
-        } else {
+        // log the executed notification
+        if(is_null($notification->getMerchantReference())) {
             $errorMessage = sprintf(
-                'Order w/merchant reference %s and notification event code %s not found',
-                $notification->getMerchantReference(),
+                'Invalid merchant reference for notification with the event code %s',
                 $notification->getEventCode()
+            );
+
+            $this->logger->addAdyenNotification($errorMessage);
+
+            $this->updateNotification($notification, false, true);
+            $this->setNotificationError($notification, $errorMessage);
+
+            return false;
+        }
+
+        $order = $this->orderHelper->getOrderByIncrementId($notification->getMerchantReference());
+        if(!$order) {
+            $errorMessage = sprintf(
+                'Order w/merchant reference %s not found',
+                $notification->getMerchantReference()
             );
 
             $this->logger->addAdyenNotification($errorMessage);

--- a/Helper/Webhook.php
+++ b/Helper/Webhook.php
@@ -131,7 +131,6 @@ class Webhook
                 ],
             );
 
-        // log the executed notification
         if (is_null($notification->getMerchantReference())) {
             $errorMessage = sprintf(
                 'Invalid merchant reference for notification with the event code %s',

--- a/Helper/Webhook.php
+++ b/Helper/Webhook.php
@@ -131,12 +131,13 @@ class Webhook
                 ],
             );
 
-        // log the executed notification
-        $order = $this->orderHelper->getOrderByIncrementId($notification->getMerchantReference());
-        if (!$order) {
+        if (!is_null($notification->getMerchantReference()) &&
+            $order = $this->orderHelper->getOrderByIncrementId($notification->getMerchantReference())) {
+        } else {
             $errorMessage = sprintf(
-                'Order w/merchant reference %s not found',
-                $notification->getMerchantReference()
+                'Order w/merchant reference %s and notification event code %s not found',
+                $notification->getMerchantReference(),
+                $notification->getEventCode()
             );
 
             $this->logger->addAdyenNotification($errorMessage);

--- a/Helper/Webhook.php
+++ b/Helper/Webhook.php
@@ -132,7 +132,7 @@ class Webhook
             );
 
         // log the executed notification
-        if(is_null($notification->getMerchantReference())) {
+        if (is_null($notification->getMerchantReference())) {
             $errorMessage = sprintf(
                 'Invalid merchant reference for notification with the event code %s',
                 $notification->getEventCode()
@@ -147,7 +147,7 @@ class Webhook
         }
 
         $order = $this->orderHelper->getOrderByIncrementId($notification->getMerchantReference());
-        if(!$order) {
+        if (!$order) {
             $errorMessage = sprintf(
                 'Order w/merchant reference %s not found',
                 $notification->getMerchantReference()


### PR DESCRIPTION
**Description**
Currently, processing of the REPORT_AVAILABLE webhook notification fails due to the missing `merchant_reference` field. This fix changes this behavior so that we are logging an error message for the unsupported webhook notification.

**Tested scenarios**
- process REPORT_AVAILABLE notification without the merchant_reference
- process REPORT_AVAILABLE notification containing the merchant_reference
- process AUTHORISATION notification with an incorrect merchant_reference
- process AUTHORISATION notification with correct merchant_reference

Fixes  #1920 