### PR TITLE
[PW-7796] Magento 2 Headless is not returning back donation token

### DIFF
--- a/Helper/PaymentResponseHandler.php
+++ b/Helper/PaymentResponseHandler.php
@@ -112,7 +112,7 @@ class PaymentResponseHandler
         $this->paymentMethodFactory = $paymentMethodFactory;
     }
 
-    public function formatPaymentResponse($resultCode, $action = null, $additionalData = null)
+    public function formatPaymentResponse($resultCode, $action = null, $additionalData = null, $donationToken = null)
     {
         switch ($resultCode) {
             case self::AUTHORISED:
@@ -121,6 +121,7 @@ class PaymentResponseHandler
                 return [
                     "isFinal" => true,
                     "resultCode" => $resultCode,
+                    "donationToken" => $donationToken
                 ];
             case self::REDIRECT_SHOPPER:
             case self::IDENTIFY_SHOPPER:

--- a/Model/Api/AdyenOrderPaymentStatus.php
+++ b/Model/Api/AdyenOrderPaymentStatus.php
@@ -89,7 +89,8 @@ class AdyenOrderPaymentStatus implements AdyenOrderPaymentStatusInterface
         return json_encode($this->paymentResponseHandler->formatPaymentResponse(
             $additionalInformation['resultCode'],
             !empty($additionalInformation['action']) ? $additionalInformation['action'] : null,
-            !empty($additionalInformation['additionalData']) ? $additionalInformation['additionalData'] : null
+            !empty($additionalInformation['additionalData']) ? $additionalInformation['additionalData'] : null,
+            !empty($additionalInformation['donationToken']) ? $additionalInformation['donationToken'] : null
         ));
     }
 }


### PR DESCRIPTION
**Description**
Adyen is returning the response back including the donation token but it appears we are not parsing this response correctly, resulting in blocking Adyen Giving. This PR fixes the issue by adding the token in the PaymentResponseHandler and passing it in AdyenOrderPaymentStatus API model.

**Tested scenarios**
- make a /payment-status call and make sure the donationToken is returned and passed down the line correctly
