### PR TITLE
[PW-8047] Refactor RECURRING_CONTRACT webhook notification

### DIFF
--- a/Helper/Webhook/RecurringContractWebhookHandler.php
+++ b/Helper/Webhook/RecurringContractWebhookHandler.php
@@ -92,7 +92,7 @@ class RecurringContractWebhookHandler implements WebhookHandlerInterface
 
             $this->adyenLogger->addAdyenNotification(
                 sprintf(
-                    "Vault payment token disabled due to the failing %s webhook notification.",
+                    "Vault payment token with entity_id: %s disabled due to the failing %s webhook notification.",
                     $notification->getEventCode()
                 ),
                 [

--- a/Helper/Webhook/RecurringContractWebhookHandler.php
+++ b/Helper/Webhook/RecurringContractWebhookHandler.php
@@ -3,7 +3,7 @@
  *
  * Adyen Payment Module
  *
- * Copyright (c) 2022 Adyen N.V.
+ * Copyright (c) 2023 Adyen N.V.
  * This file is open source and available under the MIT license.
  * See the LICENSE file for more info.
  *
@@ -12,336 +12,93 @@
 
 namespace Adyen\Payment\Helper\Webhook;
 
-use Adyen\Payment\Exception\AdyenWebhookException;
-use Adyen\Payment\Helper\Config;
-use Adyen\Payment\Helper\PaymentMethods;
-use Adyen\Payment\Helper\Vault;
 use Adyen\Payment\Logger\AdyenLogger;
-use Adyen\Payment\Model\Api\PaymentRequest;
-use Adyen\Payment\Model\Billing\AgreementFactory;
 use Adyen\Payment\Model\Notification;
-use Adyen\Payment\Model\ResourceModel\Billing\Agreement;
-use Adyen\Payment\Model\ResourceModel\Billing\Agreement\CollectionFactory as AgreementCollectionFactory;
-use Adyen\Payment\Model\Ui\AdyenCcConfigProvider;
-use DateInterval;
-use DateTime;
-use DateTimeZone;
-use Magento\Framework\Encryption\EncryptorInterface;
+use Magento\Framework\Exception\LocalizedException;
 use Magento\Sales\Model\Order as MagentoOrder;
-use Magento\Vault\Api\Data\PaymentTokenFactoryInterface;
 use Magento\Vault\Api\PaymentTokenRepositoryInterface;
 use Magento\Vault\Model\PaymentTokenManagement;
 
 class RecurringContractWebhookHandler implements WebhookHandlerInterface
 {
-    /** @var Vault */
-    private $vaultHelper;
+    /**
+     * @var AdyenLogger
+     */
+    private AdyenLogger $adyenLogger;
 
-    /** @var AdyenLogger */
-    private $adyenLogger;
+    /**
+     * @var PaymentTokenManagement
+     */
+    private PaymentTokenManagement $paymentTokenManagement;
 
-    /** @var PaymentRequest */
-    private $paymentRequest;
+    /**
+     * @var PaymentTokenRepositoryInterface
+     */
+    private PaymentTokenRepositoryInterface $paymentTokenRepository;
 
-    /** @var AgreementCollectionFactory */
-    private $billingAgreementCollectionFactory;
-
-    /** @var AgreementFactory */
-    private $billingAgreementFactory;
-
-    /** @var Agreement */
-    private $billingAgreementResourceModel;
-
-    /** @var Config */
-    private $configHelper;
-
-    /** @var PaymentTokenManagement */
-    private $paymentTokenManagement;
-
-    /** @var PaymentTokenFactoryInterface */
-    private $paymentTokenFactory;
-
-    /** @var EncryptorInterface */
-    private $encryptor;
-
-    /** @var PaymentTokenRepositoryInterface */
-    private $paymentTokenRepository;
-
+    /**
+     * @param AdyenLogger $adyenLogger
+     * @param PaymentTokenManagement $paymentTokenManagement
+     * @param PaymentTokenRepositoryInterface $paymentTokenRepository
+     */
     public function __construct(
-        Vault $vaultHelper,
         AdyenLogger $adyenLogger,
-        PaymentRequest $paymentRequest,
-        AgreementCollectionFactory $billingAgreementCollectionFactory,
-        AgreementFactory $billingAgreementFactory,
-        Agreement $billingAgreementResourceModel,
-        Config $configHelper,
         PaymentTokenManagement $paymentTokenManagement,
-        PaymentTokenFactoryInterface $paymentTokenFactory,
-        EncryptorInterface $encryptor,
         PaymentTokenRepositoryInterface $paymentTokenRepository
     ) {
-        $this->vaultHelper = $vaultHelper;
         $this->adyenLogger = $adyenLogger;
-        $this->paymentRequest = $paymentRequest;
-        $this->billingAgreementCollectionFactory = $billingAgreementCollectionFactory;
-        $this->billingAgreementFactory = $billingAgreementFactory;
-        $this->billingAgreementResourceModel = $billingAgreementResourceModel;
-        $this->configHelper = $configHelper;
         $this->paymentTokenManagement = $paymentTokenManagement;
-        $this->paymentTokenFactory = $paymentTokenFactory;
-        $this->encryptor = $encryptor;
         $this->paymentTokenRepository = $paymentTokenRepository;
     }
 
-    public function handleWebhook(MagentoOrder $order, Notification $notification, string $transitionState): MagentoOrder
-    {
-        $paymentMethodCode = $order->getPayment()->getMethod();
-        // only store billing agreements if Vault is disabled
-        if ($paymentMethodCode === PaymentMethods::ADYEN_CC && !$this->vaultHelper->isCardVaultEnabled()) {
-            $order = $this->handleNonVaultCardContract($order, $notification);
-        } elseif ($paymentMethodCode === PaymentMethods::ADYEN_HPP && $this->configHelper->isStoreAlternativePaymentMethodEnabled()) {
-            $order = $this->handlePaymentMethodContract($order, $notification);
-        } else {
-            $this->adyenLogger->addAdyenNotification(
-                'Ignore recurring_contract notification because Vault feature is enabled',
-                [
-                    'pspReference' => $notification->getPspreference(),
-                    'merchantReference' => $notification->getMerchantReference()
-                ]
-            );
+    /**
+     * @param MagentoOrder $order
+     * @param Notification $notification
+     * @param string $transitionState
+     * @return MagentoOrder
+     * @throws LocalizedException
+     */
+    public function handleWebhook(
+        MagentoOrder $order,
+        Notification $notification,
+        string $transitionState
+    ): MagentoOrder {
+        if (!$notification->isSuccessful()) {
+            $this->handleFailedNotification($order, $notification);
         }
 
         return $order;
     }
 
     /**
-     * Handle RECURRING_CONTRACT webhooks that are related to card payments but NOT using vault
-     *
      * @param MagentoOrder $order
      * @param Notification $notification
-     * @return MagentoOrder
+     * @return void
+     * @throws LocalizedException
      */
-    private function handleNonVaultCardContract(MagentoOrder $order, Notification $notification): MagentoOrder
+    private function handleFailedNotification(MagentoOrder $order, Notification $notification): void
     {
-        // storedReferenceCode
-        $recurringDetailReference = $notification->getPspreference();
-
-        $storeId = $order->getStoreId();
-        $customerReference = $order->getCustomerId();
-        $this->adyenLogger->addAdyenNotification(
-            __(
-                'CustomerReference is: %1 and storeId is %2 and RecurringDetailsReference is %3',
-                $customerReference,
-                $storeId,
-                $recurringDetailReference
-            ),
-            [
-                'pspReference' => $notification->getPspreference(),
-                'merchantReference' => $notification->getMerchantReference()
-            ]
+        $vaultToken = $this->paymentTokenManagement->getByGatewayToken(
+            $notification->getPspreference(),
+            $order->getPayment()->getMethodInstance()->getCode(),
+            $order->getCustomerId()
         );
-        try {
-            $listRecurringContracts = $this->paymentRequest->getRecurringContractsForShopper(
-                $customerReference,
-                $storeId
-            );
-            $contractDetail = null;
-            // get current Contract details and get list of all current ones
-            $recurringReferencesList = [];
 
-            if (!$listRecurringContracts) {
-                throw new AdyenWebhookException(__("Empty list recurring contracts"));
-            }
-            // Find the reference on the list
-            foreach ($listRecurringContracts as $rc) {
-                $recurringReferencesList[] = $rc['recurringDetailReference'];
-                if (isset($rc['recurringDetailReference']) &&
-                    $rc['recurringDetailReference'] == $recurringDetailReference
-                ) {
-                    $contractDetail = $rc;
-                }
-            }
+        if (isset($vaultToken)) {
+            $vaultToken->setIsActive(false);
+            $vaultToken->setIsVisible(false);
 
-            if ($contractDetail == null) {
-                $this->adyenLogger->addAdyenNotification(
-                    json_encode($listRecurringContracts),
-                    [
-                        'pspReference' => $notification->getPspreference(),
-                        'merchantReference' => $notification->getMerchantReference()
-                    ]
-                );
-                $message = __(
-                    'Failed to create billing agreement for this order ' .
-                    '(listRecurringCall did not contain contract)'
-                );
-                throw new AdyenWebhookException($message);
-            }
+            $this->paymentTokenRepository->save($vaultToken);
 
-            $billingAgreements = $this->billingAgreementCollectionFactory->create();
-            $billingAgreements->addFieldToFilter('customer_id', $customerReference);
-
-            // Get collection and update existing agreements
-
-            foreach ($billingAgreements as $updateBillingAgreement) {
-                if (!in_array($updateBillingAgreement->getReferenceId(), $recurringReferencesList)) {
-                    $updateBillingAgreement->setStatus(
-                        \Adyen\Payment\Model\Billing\Agreement::STATUS_CANCELED
-                    );
-                } else {
-                    $updateBillingAgreement->setStatus(
-                        \Adyen\Payment\Model\Billing\Agreement::STATUS_ACTIVE
-                    );
-                }
-                $updateBillingAgreement->save();
-            }
-
-            // Get or create billing agreement
-            $billingAgreement = $this->billingAgreementFactory->create();
-            $billingAgreement->load($recurringDetailReference, 'reference_id');
-            // check if BA exists
-            if (!($billingAgreement && $billingAgreement->getAgreementId() > 0
-                && $billingAgreement->isValid())) {
-                // create new
-                $this->adyenLogger->addAdyenNotification(
-                    "Creating new Billing Agreement",
-                    [
-                        'pspReference' => $notification->getPspreference(),
-                        'merchantReference' => $notification->getMerchantReference()
-                    ]
-                );
-                $order->getPayment()->setBillingAgreementData(
-                    [
-                        'billing_agreement_id' => $recurringDetailReference,
-                        'method_code' => $order->getPayment()->getMethodCode(),
-                    ]
-                );
-
-                $billingAgreement = $this->billingAgreementFactory->create();
-                $billingAgreement->setStoreId($order->getStoreId());
-                $billingAgreement->importOrderPaymentWithRecurringDetailReference($order->getPayment(), $recurringDetailReference);
-                $message = __('Created billing agreement #%1.', $recurringDetailReference);
-            } else {
-                $this->adyenLogger->addAdyenNotification(
-                    "Using existing Billing Agreement",
-                    [
-                        'pspReference' => $notification->getPspreference(),
-                        'merchantReference' => $notification->getMerchantReference()
-                    ]
-                );
-                $billingAgreement->setIsObjectChanged(true);
-                $message = __('Updated billing agreement #%1.', $recurringDetailReference);
-            }
-
-            // Populate billing agreement data
-            $billingAgreement->parseRecurringContractData($contractDetail);
-            if ($billingAgreement->isValid()) {
-                if (!$this->billingAgreementResourceModel->getOrderRelation(
-                    $billingAgreement->getAgreementId(),
-                    $order->getId()
-                )) {
-                    // save into sales_billing_agreement_order
-                    $billingAgreement->addOrderRelation($order);
-
-                    // add to order to save agreement
-                    $order->addRelatedObject($billingAgreement);
-                }
-            } else {
-                $message = __('Failed to create billing agreement for this order.');
-                throw new AdyenWebhookException($message);
-            }
-        } catch (AdyenWebhookException $exception) {
-            $message = $exception->getMessage();
-        }
-
-        $this->adyenLogger->addAdyenNotification(
-            $message,
-            [
-                'pspReference' => $notification->getPspreference(),
-                'merchantReference' => $notification->getMerchantReference()
-            ]
-        );
-        $comment = $order->addStatusHistoryComment($message, $order->getStatus());
-        $order->addRelatedObject($comment);
-
-        return $order;
-    }
-
-    /**
-     * Handle RECURRING_CONTRACT webhooks that are related to payment methods (non-card)
-     *
-     * @param MagentoOrder $order
-     * @param Notification $notification
-     * @return MagentoOrder
-     */
-    private function handlePaymentMethodContract(MagentoOrder $order, Notification $notification): MagentoOrder
-    {
-        //get the payment
-        $payment = $order->getPayment();
-        $customerId = $order->getCustomerId();
-
-        $this->adyenLogger->addAdyenNotification(
-            '$paymentMethodCode ' . $notification->getPaymentMethod(),
-            [
-                'pspReference' => $notification->getPspreference(),
-                'merchantReference' => $notification->getMerchantReference()
-            ]
-        );
-        if (!empty($notification->getPspreference())) {
-            // Check if $paymentTokenAlternativePaymentMethod exists already
-            $paymentTokenAlternativePaymentMethod = $this->paymentTokenManagement->getByGatewayToken(
-                $notification->getPspreference(),
-                $payment->getMethodInstance()->getCode(),
-                $payment->getOrder()->getCustomerId()
-            );
-
-
-            // In case the payment token for this payment method does not exist, create it based on the additionalData
-            if ($paymentTokenAlternativePaymentMethod === null) {
-                $this->adyenLogger->addAdyenNotification(
-                    'Creating new gateway token',
-                    [
-                        'pspReference' => $notification->getPspreference(),
-                        'merchantReference' => $notification->getMerchantReference()
-                    ]
-                );
-                $paymentTokenAlternativePaymentMethod = $this->paymentTokenFactory->create(
-                    PaymentTokenFactoryInterface::TOKEN_TYPE_ACCOUNT
-                );
-
-                $details = [
-                    'type' => $notification->getPaymentMethod(),
-                ];
-
-                $paymentTokenAlternativePaymentMethod->setCustomerId($customerId)
-                    ->setGatewayToken($notification->getPspreference())
-                    ->setPaymentMethodCode(AdyenCcConfigProvider::CODE)
-                    ->setPublicHash($this->encryptor->getHash($customerId . $notification->getPspreference()))
-                    ->setTokenDetails(json_encode($details));
-            } else {
-                $this->adyenLogger->addAdyenNotification(
-                    'Gateway token already exists',
-                    [
-                        'pspReference' => $notification->getPspreference(),
-                        'merchantReference' => $notification->getMerchantReference()
-                    ]
-                );
-            }
-
-            //SEPA tokens don't expire. The expiration date is set 10 years from now
-            $expDate = new DateTime('now', new DateTimeZone('UTC'));
-            $expDate->add(new DateInterval('P10Y'));
-            $paymentTokenAlternativePaymentMethod->setExpiresAt($expDate->format('Y-m-d H:i:s'));
-
-            $this->paymentTokenRepository->save($paymentTokenAlternativePaymentMethod);
             $this->adyenLogger->addAdyenNotification(
-                'New gateway token saved',
+                sprintf(
+                    "Vault payment token disabled due to the failing %s webhook notification.",
+                    $notification->getEventCode()
+                ),
                 [
-                    'pspReference' => $notification->getPspreference(),
                     'merchantReference' => $notification->getMerchantReference()
                 ]
             );
         }
-
-        return $order;
     }
 }

--- a/Helper/Webhook/WebhookHandlerFactory.php
+++ b/Helper/Webhook/WebhookHandlerFactory.php
@@ -3,7 +3,7 @@
  *
  * Adyen Payment Module
  *
- * Copyright (c) 2022 Adyen N.V.
+ * Copyright (c) 2023 Adyen N.V.
  * This file is open source and available under the MIT license.
  * See the LICENSE file for more info.
  *
@@ -19,92 +19,81 @@ use Adyen\Payment\Helper\Config;
 use Adyen\Payment\Helper\Invoice;
 use Adyen\Payment\Helper\Order;
 use Adyen\Payment\Helper\PaymentMethods;
-use Adyen\Payment\Helper\Vault;
 use Adyen\Payment\Logger\AdyenLogger;
-use Adyen\Payment\Model\Api\PaymentRequest;
-use Adyen\Payment\Model\Billing\AgreementFactory;
 use Adyen\Payment\Model\Notification;
-use Adyen\Payment\Model\ResourceModel\Billing\Agreement;
-use Adyen\Payment\Model\ResourceModel\Billing\Agreement\CollectionFactory as AgreementCollectionFactory;
 use Adyen\Payment\Model\ResourceModel\Order\Payment\CollectionFactory as OrderPaymentCollectionFactory;
 use Adyen\Payment\Model\Order\PaymentFactory;
 use Adyen\Payment\Model\ResourceModel\Order\Payment as OrderPaymentResourceModel;
 use Adyen\Webhook\Exception\InvalidDataException;
-use Magento\Framework\Encryption\EncryptorInterface;
 use Magento\Framework\Serialize\SerializerInterface;
 use Magento\Sales\Model\Order\InvoiceFactory as MagentoInvoiceFactory;
-use Magento\Vault\Api\Data\PaymentTokenFactoryInterface;
 use Magento\Vault\Api\PaymentTokenManagementInterface;
 use Magento\Vault\Api\PaymentTokenRepositoryInterface;
 
 class WebhookHandlerFactory
 {
     /** @var AdyenOrderPayment */
-    private static $adyenOrderPayment;
+    private static AdyenOrderPayment $adyenOrderPayment;
 
     /** @var Order */
-    private static $orderHelper;
+    private static Order $orderHelper;
 
     /** @var CaseManagement */
-    private static $caseManagementHelper;
+    private static CaseManagement $caseManagementHelper;
 
     /** @var SerializerInterface */
-    private static $serializer;
+    private static SerializerInterface $serializer;
 
     /** @var AdyenLogger $adyenLogger */
-    private static $adyenLogger;
+    private static AdyenLogger $adyenLogger;
 
     /** @var ChargedCurrency */
-    private static $chargedCurrency;
+    private static ChargedCurrency $chargedCurrency;
 
     /** @var Config */
-    private static $configHelper;
+    private static Config $configHelper;
 
     /** @var Invoice */
-    private static $invoiceHelper;
+    private static Invoice $invoiceHelper;
 
     /** @var PaymentFactory */
-    private static $adyenOrderPaymentFactory;
+    private static PaymentFactory $adyenOrderPaymentFactory;
 
     /** @var MagentoInvoiceFactory */
-    private static $magentoInvoiceFactory;
+    private static MagentoInvoiceFactory $magentoInvoiceFactory;
 
     /** @var PaymentMethods */
-    private static $paymentMethodsHelper;
+    private static PaymentMethods $paymentMethodsHelper;
 
     /** @var OrderPaymentCollectionFactory */
-    private static $adyenOrderPaymentCollectionFactory;
-
-    /** @var Vault */
-    private static $vaultHelper;
-
-    /** @var PaymentRequest */
-    private static $paymentRequest;
-
-    /** @var AgreementCollectionFactory */
-    private static $agreementCollectionFactory;
-
-    /** @var AgreementFactory */
-    private static $agreementFactory;
-
-    /** @var Agreement */
-    private static $billingAgreementResourceModel;
+    private static OrderPaymentCollectionFactory $adyenOrderPaymentCollectionFactory;
 
     /** @var PaymentTokenManagementInterface */
-    private static $tokenManagement;
-
-    /** @var PaymentTokenFactoryInterface */
-    private static $paymentTokenFactory;
-
-    /** @var EncryptorInterface */
-    private static $encryptor;
+    private static PaymentTokenManagementInterface $tokenManagement;
 
     /** @var PaymentTokenRepositoryInterface */
-    private static $paymentTokenRepository;
+    private static PaymentTokenRepositoryInterface $paymentTokenRepository;
 
     /** @var OrderPaymentResourceModel */
-    private static $orderPaymentResourceModel;
+    private static OrderPaymentResourceModel $orderPaymentResourceModel;
 
+    /**
+     * @param AdyenOrderPayment $adyenOrderPayment
+     * @param Order $orderHelper
+     * @param CaseManagement $caseManagementHelper
+     * @param SerializerInterface $serializer
+     * @param AdyenLogger $adyenLogger
+     * @param ChargedCurrency $chargedCurrency
+     * @param Config $configHelper
+     * @param Invoice $invoiceHelper
+     * @param PaymentFactory $adyenOrderPaymentFactory
+     * @param MagentoInvoiceFactory $magentoInvoiceFactory
+     * @param PaymentMethods $paymentMethodsHelper
+     * @param OrderPaymentCollectionFactory $adyenOrderPaymentCollectionFactory
+     * @param PaymentTokenManagementInterface $paymentTokenManagement
+     * @param PaymentTokenRepositoryInterface $paymentTokenRepository
+     * @param OrderPaymentResourceModel $orderPaymentResourceModel
+     */
     public function __construct(
         AdyenOrderPayment $adyenOrderPayment,
         Order $orderHelper,
@@ -118,14 +107,7 @@ class WebhookHandlerFactory
         MagentoInvoiceFactory $magentoInvoiceFactory,
         PaymentMethods $paymentMethodsHelper,
         OrderPaymentCollectionFactory $adyenOrderPaymentCollectionFactory,
-        Vault $vaultHelper,
-        PaymentRequest $paymentRequest,
-        AgreementCollectionFactory $agreementCollectionFactory,
-        AgreementFactory $agreementFactory,
-        Agreement $billingAgreementResourceModel,
         PaymentTokenManagementInterface $paymentTokenManagement,
-        PaymentTokenFactoryInterface $paymentTokenFactory,
-        EncryptorInterface $encryptor,
         PaymentTokenRepositoryInterface $paymentTokenRepository,
         OrderPaymentResourceModel $orderPaymentResourceModel
     ) {
@@ -141,14 +123,7 @@ class WebhookHandlerFactory
         self::$magentoInvoiceFactory = $magentoInvoiceFactory;
         self::$paymentMethodsHelper = $paymentMethodsHelper;
         self::$adyenOrderPaymentCollectionFactory = $adyenOrderPaymentCollectionFactory;
-        self::$vaultHelper = $vaultHelper;
-        self::$paymentRequest = $paymentRequest;
-        self::$agreementCollectionFactory = $agreementCollectionFactory;
-        self::$agreementFactory = $agreementFactory;
-        self::$billingAgreementResourceModel = $billingAgreementResourceModel;
         self::$tokenManagement = $paymentTokenManagement;
-        self::$paymentTokenFactory = $paymentTokenFactory;
-        self::$encryptor = $encryptor;
         self::$paymentTokenRepository = $paymentTokenRepository;
         self::$orderPaymentResourceModel = $orderPaymentResourceModel;
     }
@@ -215,16 +190,8 @@ class WebhookHandlerFactory
                 );
             case Notification::RECURRING_CONTRACT:
                 return new RecurringContractWebhookHandler(
-                    self::$vaultHelper,
                     self::$adyenLogger,
-                    self::$paymentRequest,
-                    self::$agreementCollectionFactory,
-                    self::$agreementFactory,
-                    self::$billingAgreementResourceModel,
-                    self::$configHelper,
                     self::$tokenManagement,
-                    self::$paymentTokenFactory,
-                    self::$encryptor,
                     self::$paymentTokenRepository
                 );
             case Notification::PENDING:


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
After moving all of the tokenization functionality to Magento Vault, `RECURRING_CONTRACT` webhook handler needs to be refactored.

Removed all of the billing agreement functionality from the webhook handler. After obtaining the recurring payment reference from the synchronous `/payments` call, the plugin assumes everything works as expected unless it gets a failed (success=false) `RECURRING_CONTRACT` webhook notification. If a failing webhook arrives, the handler disables the payment token in `vault_payment_tokens` table.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- Successful / failed RECURRING_CONTRACT webhook processing