### PR TITLE
[PW-7435] - Migrate all the 'Adyen Billing' tokens to Magento Vault

### DIFF
--- a/Model/Methods/Vault/CardVault.php
+++ b/Model/Methods/Vault/CardVault.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Adyen\Payment\Model\Methods\Vault;
+
+use Magento\Vault\Model\Method\Vault;
+
+class CardVault extends Vault
+{
+    const CODE = 'adyen_cc_vault';
+
+    /**
+     * @inheritdoc
+     * @since 100.1.0
+     */
+    public function isInitializeNeeded()
+    {
+        return false;
+    }
+}

--- a/Setup/Patch/Data/VaultMigration.php
+++ b/Setup/Patch/Data/VaultMigration.php
@@ -1,0 +1,239 @@
+<?php
+/**
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2023 Adyen BV (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+declare(strict_types=1);
+
+namespace Adyen\Payment\Setup\Patch\Data;
+
+use Adyen\Payment\Helper\Recurring;
+use Adyen\Payment\Logger\AdyenLogger;
+use Adyen\Payment\Model\Ui\AdyenCcConfigProvider;
+use DateInterval;
+use DateTime;
+use Magento\Framework\App\Config\ReinitableConfigInterface;
+use Magento\Framework\App\Config\Storage\WriterInterface;
+use Magento\Framework\Encryption\EncryptorInterface;
+use Magento\Framework\Setup\ModuleDataSetupInterface;
+use Magento\Framework\Setup\Patch\DataPatchInterface;
+use Magento\Vault\Api\Data\PaymentTokenFactoryInterface;
+use Magento\Vault\Api\Data\PaymentTokenInterface;
+use Magento\Vault\Api\PaymentTokenManagementInterface;
+use Magento\Vault\Api\PaymentTokenRepositoryInterface;
+
+class VaultMigration implements DataPatchInterface
+{
+    private ModuleDataSetupInterface $moduleDataSetup;
+    private WriterInterface $configWriter;
+    private ReinitableConfigInterface $reinitableConfig;
+    private PaymentTokenManagementInterface $tokenManagement;
+    private PaymentTokenFactoryInterface $tokenFactory;
+    private PaymentTokenRepositoryInterface $tokenRepository;
+    private EncryptorInterface $encryptor;
+
+    public function __construct(
+        ModuleDataSetupInterface $moduleDataSetup,
+        WriterInterface $configWriter,
+        ReinitableConfigInterface $reinitableConfig,
+        PaymentTokenManagementInterface $tokenManagement,
+        PaymentTokenFactoryInterface $tokenFactory,
+        PaymentTokenRepositoryInterface $tokenRepository,
+        EncryptorInterface $encryptor
+    ) {
+        $this->moduleDataSetup = $moduleDataSetup;
+        $this->configWriter = $configWriter;
+        $this->reinitableConfig = $reinitableConfig;
+        $this->tokenManagement = $tokenManagement;
+        $this->tokenFactory = $tokenFactory;
+        $this->tokenRepository = $tokenRepository;
+        $this->encryptor = $encryptor;
+    }
+
+    /**
+     * Do Upgrade
+     *
+     * @return void
+     */
+    public function apply()
+    {
+        $this->moduleDataSetup->getConnection()->startSetup();
+        $this->migrateBillingAgreementsToVault($this->moduleDataSetup);
+        $this->moduleDataSetup->getConnection()->endSetup();
+    }
+
+    private function migrateBillingAgreementsToVault(ModuleDataSetupInterface $setup)
+    {
+        $paypalTable = $setup->getTable('paypal_billing_agreement');
+        $connection = $setup->getConnection();
+
+        $select = $connection->select()
+            ->from($paypalTable)
+            ->where(
+                'method_code = ?',
+                'adyen_oneclick'
+            )
+            ->where(
+                'status = ?',
+                'active'
+            );
+
+        $adyenBillingAgreements = $connection->fetchAll($select);
+
+        $today = new DateTime();
+        $today->add(new DateInterval('P1Y'));
+
+        foreach ($adyenBillingAgreements as $adyenBillingAgreement) {
+            $this->saveVaultToken(
+                intval($adyenBillingAgreement['customer_id']),
+                $adyenBillingAgreement['reference_id'],
+                $today,
+                $adyenBillingAgreement['created_at'],
+                $adyenBillingAgreement['agreement_data']
+            );
+        }
+    }
+
+    /**
+     * TODO: Transform token details, add functionality to create public hash, update sql to only get active BA
+     *
+     *
+     *
+     * @param int $customerId
+     * @param string $gatewayToken
+     * @param DateTime $expirationDate
+     * @param string $createdAt
+     * @param string $tokenDetails
+     * @return PaymentTokenInterface
+     */
+    private function saveVaultToken(
+        int $customerId,
+        string $gatewayToken,
+        DateTime $expirationDate,
+        string $createdAt,
+        string $tokenDetails
+    ): PaymentTokenInterface
+    {
+        $paymentToken = $this->tokenFactory->create(
+            PaymentTokenFactoryInterface::TOKEN_TYPE_CREDIT_CARD
+        );
+        $paymentToken->setCustomerId($customerId);
+        $paymentToken->setPaymentMethodCode(AdyenCcConfigProvider::CODE);
+        $paymentToken->setGatewayToken($gatewayToken);
+        $paymentToken->setIsActive(true);
+        $paymentToken->setIsVisible(true);
+        $paymentToken->setCreatedAt($createdAt);
+        $paymentToken->setTokenDetails($tokenDetails);
+        $paymentToken->setExpiresAt($expirationDate);
+        $paymentToken->setPublicHash($this->generatePublicHash($customerId, $tokenDetails));
+
+        $this->tokenRepository->save($paymentToken);
+
+        return $paymentToken;
+    }
+
+    /**
+     * Generate vault payment public hash
+     *
+     * @param PaymentTokenInterface $paymentToken
+     * @return string
+     */
+    private function generatePublicHash(int $customerId, string $tokenDetails): string
+    {
+        $hashKey = $customerId;
+
+        $hashKey .= AdyenCcConfigProvider::CODE
+            . PaymentTokenFactoryInterface::TOKEN_TYPE_CREDIT_CARD
+            . $tokenDetails;
+
+        return $this->encryptor->getHash($hashKey);
+    }
+
+    private function transformTokenDetails(string $baAgreementData): string
+    {
+        return '';
+    }
+
+    /**
+     * Update a config which has a specific path and a specific value
+     *
+     * @param ModuleDataSetupInterface $setup
+     * @param string $path
+     * @param string $valueToUpdate
+     * @param string $updatedValue
+     */
+    private function updateConfigValue(
+        ModuleDataSetupInterface $setup,
+        string $path,
+        string $valueToUpdate,
+        string $updatedValue
+    ): void {
+        $config = $this->findConfig($setup, $path, $valueToUpdate);
+        if (isset($config)) {
+            $this->configWriter->save(
+                $path,
+                $updatedValue,
+                $config['scope'],
+                $config['scope_id']
+            );
+        }
+        // re-initialize otherwise it will cause errors
+        $this->reinitableConfig->reinit();
+    }
+
+    /**
+     * Return the config based on the passed path and value. If value is null, return the first item in array
+     *
+     * @param ModuleDataSetupInterface $setup
+     * @param string $path
+     * @param string|null $value
+     * @return array|null
+     */
+    private function findConfig(ModuleDataSetupInterface $setup, string $path, ?string $value): ?array
+    {
+        $config = null;
+        $configDataTable = $setup->getTable('core_config_data');
+        $connection = $setup->getConnection();
+
+        $select = $connection->select()
+            ->from($configDataTable)
+            ->where(
+                'path = ?',
+                $path
+            );
+
+        $matchingConfigs = $connection->fetchAll($select);
+
+        if (!empty($matchingConfigs) && is_null($value)) {
+            $config = reset($matchingConfigs);
+        } else {
+            foreach ($matchingConfigs as $matchingConfig) {
+                if ($matchingConfig['value'] === $value) {
+                    $config = $matchingConfig;
+                }
+            }
+        }
+
+        return $config;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getAliases()
+    {
+        return [];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public static function getDependencies()
+    {
+        return [];
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,6 @@
     "adyen/php-webhook-module": "^0.6.0",
     "magento/framework": ">=101.0.8 <102 || >=102.0.1",
     "magento/module-vault": "101.*",
-    "magento/module-paypal": ">=100.2.6",
     "magento/module-multishipping": ">=100.3.7",
     "ext-json": "*"
   },

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -56,8 +56,8 @@
                 <group>adyen</group>
             </adyen_cc>
             <adyen_cc_vault>
-                <model>AdyenPaymentCcVaultFacade</model>
                 <title>Stored Cards (Adyen)</title>
+                <model>Adyen\Payment\Model\Methods\Vault\CardVault</model>
             </adyen_cc_vault>
             <adyen_oneclick>
                 <active>0</active>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -42,15 +42,6 @@
             <argument name="commandPool" xsi:type="object">AdyenPaymentMotoCommandPool</argument>
         </arguments>
     </virtualType>
-    <virtualType name="AdyenPaymentCcVaultFacade" type="Magento\Vault\Model\Method\Vault">
-        <arguments>
-            <argument name="code" xsi:type="const">Adyen\Payment\Model\Ui\AdyenCcConfigProvider::CC_VAULT_CODE
-            </argument>
-            <argument name="config" xsi:type="object">AdyenPaymentCcVaultConfig</argument>
-            <argument name="valueHandlerPool" xsi:type="object">AdyenPaymentCcVaultPaymentValueHandlerPool</argument>
-            <argument name="vaultProvider" xsi:type="object">AdyenPaymentCcFacade</argument>
-        </arguments>
-    </virtualType>
 
     <virtualType name="AdyenPaymentHppVaultFacade" type="Adyen\Payment\Model\Method\PaymentMethodVault">
         <arguments>
@@ -62,6 +53,15 @@
     </virtualType>
 
     <!-- Vault methods start -->
+    <type name="Adyen\Payment\Model\Methods\Vault\CardVault">
+        <arguments>
+            <argument name="config" xsi:type="object">AdyenPaymentCcVaultConfig</argument>
+            <argument name="valueHandlerPool" xsi:type="object">AdyenPaymentCcVaultPaymentValueHandlerPool</argument>
+            <argument name="vaultProvider" xsi:type="object">AdyenPaymentCcFacade</argument>
+            <argument name="code" xsi:type="const">Adyen\Payment\Model\Methods\Vault\CardVault::CODE</argument>
+        </arguments>
+    </type>
+
     <type name="Adyen\Payment\Model\Methods\Vault\PaypalVault">
         <arguments>
             <argument name="config" xsi:type="object">AdyenPaymentHppVaultConfig</argument>


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
This PR will create a data patch that will migrate the data from `paypal_billing_agreement` table to the `vault_payment_token` table.

**Tested scenarios**
* Token created on v7 successfully migrated, payment successful
* Token created on v8 successfully migrated, payment succesful
* Token already exists in `vault_payment_token` table
* Exception thrown during migration
