### PR TITLE
Support form fix

### DIFF
--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -532,6 +532,19 @@ class Config
     }
 
     /**
+     * @param int $storeId
+     * @return string
+     */
+    public function getConfigurationMode(int $storeId): string
+    {
+        return $this->getConfigData(
+            self::XML_CONFIGURATION_MODE,
+            self::XML_ADYEN_ABSTRACT_PREFIX,
+            $storeId
+        );
+    }
+
+    /**
      * Retrieve information from payment configuration
      *
      * @param string $field

--- a/Helper/SupportFormHelper.php
+++ b/Helper/SupportFormHelper.php
@@ -15,6 +15,7 @@ use Adyen\Payment\Exception\FileUploadException;
 use Adyen\Payment\Model\TransportBuilder;
 use Magento\Backend\Model\Auth\Session;
 use Magento\Framework\App\Area;
+use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\App\ProductMetadataInterface;
 use Magento\Framework\Exception\FileSystemException;
@@ -24,6 +25,7 @@ use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\Exception\ValidatorException;
 use Magento\Framework\Filesystem;
 use Magento\Framework\Message\ManagerInterface as MessageManagerInterface;
+use Magento\Store\Model\ScopeInterface;
 use Magento\Store\Model\StoreManagerInterface;
 
 class SupportFormHelper
@@ -82,6 +84,11 @@ class SupportFormHelper
     private $authSession;
 
     /**
+     * @var ScopeConfigInterface
+     */
+    private $scopeConfig;
+
+    /**
      * @param TransportBuilder $transportBuilder
      * @param MessageManagerInterface $messageManager
      * @param Config $config
@@ -92,6 +99,7 @@ class SupportFormHelper
      * @param Filesystem\Directory\WriteFactory $writeFactory
      * @param ProductMetadataInterface $productMetadata
      * @param Session $authSession
+     * @param ScopeConfigInterface $scopeConfig
      */
     public function __construct(
         TransportBuilder $transportBuilder,
@@ -103,7 +111,8 @@ class SupportFormHelper
         Filesystem $filesystem,
         Filesystem\Directory\WriteFactory $writeFactory,
         ProductMetadataInterface $productMetadata,
-        Session $authSession
+        Session $authSession,
+        ScopeConfigInterface $scopeConfig
     ) {
         $this->transportBuilder = $transportBuilder;
         $this->messageManager = $messageManager;
@@ -115,6 +124,7 @@ class SupportFormHelper
         $this->writeFactory = $writeFactory;
         $this->fileUtil = $fileUtil;
         $this->authSession = $authSession;
+        $this->scopeConfig = $scopeConfig;
     }
 
     /**
@@ -143,21 +153,24 @@ class SupportFormHelper
         ];
 
         $to = $this->config->getSupportMailAddress($storeId);
-        $from = ['email' => $templateVars['email'], 'name' => $this->getAdminName()];
 
-        if (!isset($from['email'])) {
-            $from['email'] = $this->getAdminEmail();
-        }
+        /*
+         * fromEmail address is different from the adminEmail,
+         * since that value should be configured in mail sender.
+         */
+        $fromEmail = $this->getStoreGeneralEmail();
+        $from = ['email' => $fromEmail, 'name' => $this->getAdminName()];
 
         $templateVars['emailSubject'] = sprintf(
-            "Magento 2 support form - %s",
-            $this->config->getMerchantAccount($storeId)
+            "Support Form Adobe Commerce - %s",
+            $templateVars['subject']
         );
 
         $transportBuilder = $this->transportBuilder->setTemplateIdentifier($template)
             ->setTemplateOptions($templateOptions)
             ->setTemplateVars($templateVars)
             ->setFromByScope($from)
+            ->setReplyTo($templateVars['email'])
             ->addTo($to);
 
         if (isset($formData['attachments']) && is_array($formData['attachments'])) {
@@ -219,7 +232,6 @@ class SupportFormHelper
             $storeId,
             true
         );
-        $motoMerchantAccounts = json_encode($this->config->getMotoMerchantAccounts($storeId));
         $useManualCaptureForPaypal = $this->config->getConfigData(
             'paypal_capture_mode',
             'adyen_abstract',
@@ -373,7 +385,6 @@ class SupportFormHelper
             'isBoletoEnabled' => $isBoletoEnabled ? 'Yes' : 'No',
             'boletoDeliveryDays' => $boletoDeliveryDays,
             'isPayByLinkEnabled' => $isPayByLinkEnabled ? 'Yes' : 'No',
-            'motoMerchantAccounts' => $motoMerchantAccounts,
             'useManualCaptureForPaypal' => $useManualCaptureForPaypal ? 'Yes' : 'No',
             'captureOnShipmentForOpenInvoice' => $captureOnShipmentForOpenInvoice ? 'Yes' : 'No',
             'autoCaptureOpenInvoice' => $autoCaptureOpenInvoice ? 'Yes' : 'No',
@@ -417,6 +428,16 @@ class SupportFormHelper
     }
 
     /**
+     * Get the stores general contact email address
+     *
+     * @return string
+     */
+    public function getStoreGeneralEmail(): string
+    {
+        return $this->scopeConfig->getValue('trans_email/ident_general/email', ScopeInterface::SCOPE_STORE);
+    }
+
+    /**
      * Get the email from the current admin user
      *
      * @return string
@@ -426,6 +447,9 @@ class SupportFormHelper
         return $this->authSession->getUser()->getEmail();
     }
 
+    /**
+     * @return string
+     */
     public function getAdminName(): string
     {
         return $this->authSession->getUser()->getName();

--- a/Helper/SupportFormHelper.php
+++ b/Helper/SupportFormHelper.php
@@ -472,7 +472,7 @@ class SupportFormHelper
         }
 
         $fileInfo = $this->fileUtil->getPathInfo($file['name']);
-        $allowedTypes = ['zip', 'txt', 'log', 'rar', 'jpeg', 'jpg', 'pdf' ];
+        $allowedTypes = ['zip', 'txt', 'log', 'rar', 'jpeg', 'jpg', 'pdf', 'png'];
         if (!in_array($fileInfo['extension'], $allowedTypes)) {
             throw new FileUploadException(__('Invalid file type. Allowed types: ' . join(', ', $allowedTypes)));
         }

--- a/view/adminhtml/email/configuration_settings_email_template.html
+++ b/view/adminhtml/email/configuration_settings_email_template.html
@@ -1,6 +1,6 @@
 <!--@subject {{var emailSubject}} @-->
 
-<h4>Magento 2 plugin support request about {{var topic}}</h4>
+<h4>Support Form Adobe Commerce</h4>
 <table class="message-details" border="1" cellpadding="5" cellspacing="0" aria-label="Support Form Fields">
     <tr>
         <th>Form Fields</th>
@@ -94,10 +94,6 @@
     <tr>
         <td><strong>{{trans "Is PBL enabled?"}}</strong></td>
         <td>{{var isPayByLinkEnabled}}</td>
-    </tr>
-    <tr>
-        <td><strong>{{trans "Merchant accounts for MOTO"}}</strong></td>
-        <td>{{var motoMerchantAccounts}}</td>
     </tr>
     <tr>
         <td><strong>{{trans "Use manual capture for PayPal"}}</strong></td>

--- a/view/adminhtml/email/order_processing_email_template.html
+++ b/view/adminhtml/email/order_processing_email_template.html
@@ -1,6 +1,6 @@
 <!--@subject {{var emailSubject}} @-->
 
-<h4>Magento 2 plugin support request about {{var topic}}</h4>
+<h4>Support Form Adobe Commerce</h4>
 <table class="message-details" border="1" cellpadding="5" cellspacing="0" aria-label="Support Form Fields">
     <tr>
         <th>Form Fields</th>
@@ -110,10 +110,6 @@
     <tr>
         <td><strong>{{trans "Is PBL enabled?"}}</strong></td>
         <td>{{var isPayByLinkEnabled}}</td>
-    </tr>
-    <tr>
-        <td><strong>{{trans "Merchant accounts for MOTO"}}</strong></td>
-        <td>{{var motoMerchantAccounts}}</td>
     </tr>
     <tr>
         <td><strong>{{trans "Use manual capture for PayPal"}}</strong></td>

--- a/view/adminhtml/email/other_topics_email_template.html
+++ b/view/adminhtml/email/other_topics_email_template.html
@@ -1,6 +1,6 @@
 <!--@subject {{var emailSubject}} @-->
 
-<h4>Magento 2 plugin support request about {{var topic}}</h4>
+<h4>Support Form Adobe Commerce</h4>
 <table class="message-details" border="1" cellpadding="5" cellspacing="0" aria-label="Support Form Fields">
     <tr>
         <th>Form Fields</th>
@@ -102,10 +102,6 @@
     <tr>
         <td><strong>{{trans "Is PBL enabled?"}}</strong></td>
         <td>{{var isPayByLinkEnabled}}</td>
-    </tr>
-    <tr>
-        <td><strong>{{trans "Merchant accounts for MOTO"}}</strong></td>
-        <td>{{var motoMerchantAccounts}}</td>
     </tr>
     <tr>
         <td><strong>{{trans "Use manual capture for PayPal"}}</strong></td>


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
- Created missing configuration getter
- Included `Support Form Adobe Commerce` keyword in the body and the subject for Zendesk classification
- Added `reply-to` parameter to email header
- MOTO configuration values removed from the configuration snapshot.
- Added PNG file format attachment support

PS: Store general contact email address will be used for the `from` address. However, Zendesk will reply to the email address on the form which is added as `reply-to`.

PS2: If the store general contact email address is different from the SMTP sender email, Zendesk may refuse the support form email due to DMARK authentication failure. In this case, it is merchant's responsibility to add correct SPF records to their DNS zone.

PS3: MOTO configuration field contains encrypted API keys. This feature can be added in more logical way in the next iterations. Removed from the initial release.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- Sending mail to Zendesk