### PR TITLE
[PW-8155] -  getDefaultBillingAddress() is not reachable when the user is logged in

### DIFF
--- a/Api/AdyenPaymentMethodManagementInterface.php
+++ b/Api/AdyenPaymentMethodManagementInterface.php
@@ -11,8 +11,6 @@
 
 namespace Adyen\Payment\Api;
 
-use Magento\Quote\Api\Data\AddressInterface;
-
 /**
  * Interface for fetching payment methods from Adyen for logged in customers
  */
@@ -22,13 +20,8 @@ interface AdyenPaymentMethodManagementInterface
      * Fetches Adyen payment methods for logged in customers
      *
      * @param string $cartId
-     * @param AddressInterface|null $shippingAddress
      * @param string|null $shopperLocale
      * @return string
      */
-    public function getPaymentMethods(
-        string $cartId,
-        AddressInterface $billingAddress = null,
-        ?string $shopperLocale = null
-    ) :string;
+    public function getPaymentMethods(string $cartId, ?string $shopperLocale = null) :string;
 }

--- a/Api/GuestAdyenPaymentMethodManagementInterface.php
+++ b/Api/GuestAdyenPaymentMethodManagementInterface.php
@@ -22,13 +22,8 @@ interface GuestAdyenPaymentMethodManagementInterface
      * Fetches Adyen payment methods for guest customers
      *
      * @param string $cartId
-     * @param AddressInterface|null $billingAddress
      * @param string|null $shopperLocale
      * @return string
      */
-    public function getPaymentMethods(
-        string $cartId,
-        AddressInterface $billingAddress = null,
-        ?string $shopperLocale = null
-    ): string;
+    public function getPaymentMethods(string $cartId, ?string $shopperLocale = null): string;
 }

--- a/Api/Internal/InternalAdyenPaymentMethodManagementInterface.php
+++ b/Api/Internal/InternalAdyenPaymentMethodManagementInterface.php
@@ -11,8 +11,6 @@
 
 namespace Adyen\Payment\Api\Internal;
 
-use Magento\Quote\Api\Data\AddressInterface;
-
 /**
  * Interface for fetching payment methods from Adyen for logged in customers
  */
@@ -23,12 +21,7 @@ interface InternalAdyenPaymentMethodManagementInterface
      *
      * @param string $cartId
      * @param string $formKey
-     * @param AddressInterface|null $shippingAddress
      * @return string
      */
-    public function handleInternalRequest(
-        string $cartId,
-        string $formKey,
-        AddressInterface $billingAddress = null
-    ): string;
+    public function handleInternalRequest(string $cartId, string $formKey): string;
 }

--- a/Api/Internal/InternalGuestAdyenPaymentMethodManagementInterface.php
+++ b/Api/Internal/InternalGuestAdyenPaymentMethodManagementInterface.php
@@ -3,15 +3,13 @@
  *
  * Adyen Payment module (https://www.adyen.com/)
  *
- * Copyright (c) 2021 Adyen BV (https://www.adyen.com/)
+ * Copyright (c) 2023 Adyen BV (https://www.adyen.com/)
  * See LICENSE.txt for license details.
  *
  * Author: Adyen <magento@adyen.com>
  */
 
 namespace Adyen\Payment\Api\Internal;
-
-use Magento\Quote\Api\Data\AddressInterface;
 
 /**
  * Interface for fetching payment methods from Adyen for guest customers
@@ -25,12 +23,7 @@ interface InternalGuestAdyenPaymentMethodManagementInterface
      *
      * @param string $cartId
      * @param string $formKey
-     * @param AddressInterface|null $billingAddress
      * @return string
      */
-    public function handleInternalRequest(
-        string $cartId,
-        string $formKey,
-        AddressInterface $billingAddress = null
-    ): string;
+    public function handleInternalRequest(string $cartId, string $formKey): string;
 }

--- a/Helper/PaymentMethods.php
+++ b/Helper/PaymentMethods.php
@@ -298,7 +298,7 @@ class PaymentMethods extends AbstractHelper
      */
     protected function getCurrentCountryCode($store): string
     {
-        // if fixed countryCode is setup in config use this
+        // If fixed countryCode is set up in config use it
         $countryCode = $this->adyenHelper->getAdyenHppConfigData('country_code', $store->getId());
 
         if ($countryCode != "") {
@@ -386,7 +386,6 @@ class PaymentMethods extends AbstractHelper
      * @param $merchantAccount
      * @param \Magento\Store\Model\Store $store
      * @param \Magento\Quote\Model\Quote $quote
-     * @param string|null $country
      * @param string|null $shopperLocale
      * @return array
      * @throws \Exception
@@ -395,9 +394,8 @@ class PaymentMethods extends AbstractHelper
         $merchantAccount,
         \Magento\Store\Model\Store $store,
         \Magento\Quote\Model\Quote $quote,
-        ?string $country = null,
         ?string $shopperLocale = null
-    ) {
+    ): array {
         $currencyCode = $this->chargedCurrency->getQuoteAmountCurrency($quote)->getCurrencyCode();
 
         $paymentMethodRequest = [

--- a/Helper/PaymentMethods.php
+++ b/Helper/PaymentMethods.php
@@ -289,12 +289,7 @@ class PaymentMethods extends AbstractHelper
         );
     }
 
-    /**
-     * @param $store
-     * @param $country
-     * @return int|mixed|string
-     */
-    protected function getCurrentCountryCode($store, $country = null)
+    protected function getCurrentCountryCode($store, $country = null): string
     {
         // if fixed countryCode is setup in config use this
         $countryCode = $this->adyenHelper->getAdyenHppConfigData('country_code', $store->getId());
@@ -303,13 +298,10 @@ class PaymentMethods extends AbstractHelper
             return $countryCode;
         }
 
-        if ($country != null) {
-            return $country;
-        }
-
         $quote = $this->getQuote();
-        if (!is_null($quote->getCustomer()) && !is_null($quote->getCustomer()->getDefaultBillingAddress())) {
-            return $quote->getCustomer()->getDefaultBillingAddress()->getCountryId();
+        $billingAddress = $quote->getBillingAddress();
+        if (isset($billingAddress)) {
+            return $billingAddress->getCountryId();
         }
 
         $defaultCountry = $this->config->getValue(

--- a/Model/Api/AdyenPaymentMethodManagement.php
+++ b/Model/Api/AdyenPaymentMethodManagement.php
@@ -30,21 +30,11 @@ class AdyenPaymentMethodManagement implements AdyenPaymentMethodManagementInterf
 
     /**
      * @param string $cartId
-     * @param AddressInterface|null $shippingAddress
      * @param string|null $shopperLocale
      * @return string
      */
-    public function getPaymentMethods(
-        string $cartId,
-        AddressInterface $billingAddress = null,
-        ?string $shopperLocale = null
-    ) :string {
-        // if billingAddress is provided use this country
-        $country = null;
-        if ($billingAddress) {
-            $country = $billingAddress->getCountryId();
-        }
+    public function getPaymentMethods(string $cartId, ?string $shopperLocale = null) : string {
 
-        return $this->paymentMethodsHelper->getPaymentMethods($cartId, $country, $shopperLocale);
+        return $this->paymentMethodsHelper->getPaymentMethods($cartId, $shopperLocale);
     }
 }

--- a/Model/Api/GuestAdyenPaymentMethodManagement.php
+++ b/Model/Api/GuestAdyenPaymentMethodManagement.php
@@ -36,24 +36,13 @@ class GuestAdyenPaymentMethodManagement implements GuestAdyenPaymentMethodManage
 
     /**
      * @param string $cartId
-     * @param AddressInterface|null $shippingAddress
      * @param string|null $shopperLocale
      * @return string
      */
-    public function getPaymentMethods(
-        string $cartId,
-        AddressInterface $billingAddress = null,
-        ?string $shopperLocale = null
-    ): string {
+    public function getPaymentMethods(string $cartId, ?string $shopperLocale = null): string {
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
         $quoteId = $quoteIdMask->getQuoteId();
 
-        // if shippingAddress is provided use this country
-        $country = null;
-        if ($billingAddress) {
-            $country = $billingAddress->getCountryId();
-        }
-
-        return $this->paymentMethodsHelper->getPaymentMethods($quoteId, $country, $shopperLocale);
+        return $this->paymentMethodsHelper->getPaymentMethods($quoteId, $shopperLocale);
     }
 }

--- a/Model/Api/Internal/InternalAdyenPaymentMethodManagement.php
+++ b/Model/Api/Internal/InternalAdyenPaymentMethodManagement.php
@@ -42,17 +42,12 @@ class InternalAdyenPaymentMethodManagement extends AbstractInternalApiController
     /**
      * @param string $cartId
      * @param string $formKey
-     * @param AddressInterface|null $shippingAddress
      * @return string
      * @throws \Adyen\AdyenException
      */
-    public function handleInternalRequest(
-        string $cartId,
-        string $formKey,
-        AddressInterface $billingAddress = null
-    ): string {
+    public function handleInternalRequest(string $cartId, string $formKey): string {
         $this->validateInternalRequest($formKey);
 
-        return $this->adyenPaymentMethodManagement->getPaymentMethods($cartId, $billingAddress);
+        return $this->adyenPaymentMethodManagement->getPaymentMethods($cartId);
     }
 }

--- a/Model/Api/Internal/InternalGuestAdyenPaymentMethodManagement.php
+++ b/Model/Api/Internal/InternalGuestAdyenPaymentMethodManagement.php
@@ -42,17 +42,12 @@ class InternalGuestAdyenPaymentMethodManagement extends AbstractInternalApiContr
     /**
      * @param string $cartId
      * @param string $formKey
-     * @param AddressInterface|null $billingAddress
      * @return string
      * @throws \Adyen\AdyenException
      */
-    public function handleInternalRequest(
-        string $cartId,
-        string $formKey,
-        AddressInterface $billingAddress = null
-    ): string {
+    public function handleInternalRequest(string $cartId, string $formKey,): string {
         $this->validateInternalRequest($formKey);
 
-        return $this->guestAdyenPaymentMethodManagement->getPaymentMethods($cartId, $billingAddress);
+        return $this->guestAdyenPaymentMethodManagement->getPaymentMethods($cartId);
     }
 }

--- a/Model/Resolver/GetAdyenPaymentMethods.php
+++ b/Model/Resolver/GetAdyenPaymentMethods.php
@@ -105,14 +105,8 @@ class GetAdyenPaymentMethods implements ResolverInterface
         try {
             $cart = $this->getCartForUser->execute($maskedCartId, $currentUserId, $storeId);
 
-            $country = null;
-            $shippingAddress = $cart->getShippingAddress();
-            if ($shippingAddress) {
-                $country = $shippingAddress->getCountryId();
-            }
             $adyenPaymentMethodsResponse = $this->paymentMethodsHelper->getPaymentMethods(
                 intval($cart->getId()),
-                $country,
                 $shopperLocale
             );
 

--- a/view/frontend/web/js/model/adyen-payment-service.js
+++ b/view/frontend/web/js/model/adyen-payment-service.js
@@ -47,7 +47,6 @@ define(
                 // Construct payload for the retrieve payment methods request
                 var payload = {
                     cartId: quote.getQuoteId(),
-                    billingAddress: quote.billingAddress(),
                     form_key: $.mage.cookies.get('form_key')
                 };
 


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
Currently we have an issue where the `getDefaultBillingAddress()` is called on the incorrect class, since magento returns a different customer object depending on if the customer is logged in. This PR will fix this issue and update different locations where the countryCode was being sent. This value is now redundant when getting the payment methods.

**Tested scenarios**
* Guest checkout
* Logged-in checkout
* Logged-in checkout w/different shipping address
