### PR TITLE
[PW-8243] - Add max_order_total and min_order_total

### DIFF
--- a/etc/adminhtml/system/adyen_cc.xml
+++ b/etc/adminhtml/system/adyen_cc.xml
@@ -34,6 +34,14 @@
             <frontend_class>validate-number</frontend_class>
             <config_path>payment/adyen_cc/sort_order</config_path>
         </field>
+        <field id="min_order_total" translate="label" type="text" sortOrder="40" showInDefault="1" showInWebsite="1">
+            <label>Minimum order total</label>
+            <config_path>payment/adyen_cc/min_order_total</config_path>
+        </field>
+        <field id="max_order_total" translate="label" type="text" sortOrder="50" showInDefault="1" showInWebsite="1">
+            <label>Maximum order total</label>
+            <config_path>payment/adyen_cc/max_order_total</config_path>
+        </field>
         <group id="adyen_cc_advanced_settings" translate="label" showInDefault="1" showInWebsite="1" showInStore="1"
                sortOrder="60">
             <label>Installments Setup</label>

--- a/etc/adminhtml/system/adyen_hpp.xml
+++ b/etc/adminhtml/system/adyen_hpp.xml
@@ -30,6 +30,20 @@
                 <field id="active">1</field>
             </depends>
         </field>
+        <field id="min_order_total" translate="label" type="text" sortOrder="21" showInDefault="1" showInWebsite="1">
+            <label>Minimum order total</label>
+            <config_path>payment/adyen_hpp/min_order_total</config_path>
+            <depends>
+                <field id="active">1</field>
+            </depends>
+        </field>
+        <field id="max_order_total" translate="label" type="text" sortOrder="22" showInDefault="1" showInWebsite="1">
+            <label>Maximum order total</label>
+            <config_path>payment/adyen_hpp/max_order_total</config_path>
+            <depends>
+                <field id="active">1</field>
+            </depends>
+        </field>
         <field id="adyen_hpp_vault_active" translate="label" type="select" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
             <label>Store alternative payment methods</label>
             <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
This PR will add `max_order_total` and `min_order_total` config values to the adyen_cc and adyen_hpp payment methods.

**Tested scenarios**
* Amount falls between these constraints
* Amount exceeds constraints

Fixes  #1981
