### PR TITLE
[PW-6520] Override HolderName configurations for ACH component

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/adyen-hpp-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-hpp-method.js
@@ -699,6 +699,12 @@ define(
                     configuration = Object.assign(configuration, paymentMethodsExtraInfo[paymentMethod.methodIdentifier].configuration);
                 }
 
+                // Show HolderName for ACH component, as it's always required
+                if (paymentMethod.methodIdentifier.includes('ach')) {
+                    configuration.hasHolderName = true;
+                    configuration.holderNameRequired = true;
+                }
+
                 // Extra apple pay configuration
                 if (paymentMethod.methodIdentifier.includes('applepay')) {
                     if ('configuration' in configuration &&


### PR DESCRIPTION

**Description**
Overriding the Checkout Experience settings of Magento admin for ACH component, as this payment method requires account holder name to be populated and sent. Previous code would use the configuration set in the admin, which is supposed to be used only for Card Payment methods

**Tested scenarios**
Tested ACH with all combinations of Checkout Experience settings, new code consistently shows the holder name in the component regardless of the config.
