### PR TITLE
[PW-8304] -  Remove vault token filtering from frontend js

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/adyen-vault-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-vault-method.js
@@ -20,13 +20,6 @@ define([
             template: 'Adyen_Payment/payment/payment-method-vault'
         },
         /**
-         * Check if token should be displayed
-         * @returns {boolean}
-         */
-        displayToken: function() {
-            return this.details.displayToken;
-        },
-        /**
          * Get tx_variant
          * @returns {String}
          */

--- a/view/frontend/web/js/view/payment/method-renderer/payment_method_vault.js
+++ b/view/frontend/web/js/view/payment/method-renderer/payment_method_vault.js
@@ -20,13 +20,6 @@ define([
             template: 'Adyen_Payment/payment/payment-method-vault-form'
         },
         /**
-         * Check if token should be displayed
-         * @returns {boolean}
-         */
-        displayToken: function() {
-            return this.details.displayToken;
-        },
-        /**
          * Get tx_variant
          * @returns {String}
          */

--- a/view/frontend/web/template/payment/payment-method-vault-form.html
+++ b/view/frontend/web/template/payment/payment-method-vault-form.html
@@ -4,7 +4,7 @@
  * See COPYING.txt for license details.
  */
 -->
-<div data-bind="visible: displayToken()" class="payment-method" css="'_active': (getId() === isChecked())">
+<div class="payment-method" css="'_active': (getId() === isChecked())">
     <div class="payment-method-title field choice">
         <input type="radio"
                name="payment[method]"

--- a/view/frontend/web/template/payment/payment-method-vault.html
+++ b/view/frontend/web/template/payment/payment-method-vault.html
@@ -1,4 +1,4 @@
-<div data-bind="visible: displayToken()" class="payment-method" css="'_active': (getId() === isChecked())">
+<div class="payment-method" css="'_active': (getId() === isChecked())">
     <div class="payment-method-title field choice">
         <input type="radio"
                name="payment[method]"


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
This PR will remove the filtering to show vault tokens from the frontend and instead filter on the backend (`CustomerFilterVaultTokens.php`).

**Tested scenarios**
* Card vault token w/subscription
* Card vault token w/card on file
* Klarna token w/subscription
