### PR TITLE
[PW-8307] Refactor payments-details endpoint

### DIFF
--- a/Api/AdyenPaymentsDetailsInterface.php
+++ b/Api/AdyenPaymentsDetailsInterface.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ *
+ * Adyen Payment Module
+ *
+ * Copyright (c) 2023 Adyen B.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\Payment\Api;
+
+/**
+ * Interface for performing an Adyen payment details call
+ */
+interface AdyenPaymentsDetailsInterface
+{
+    /**
+     * @param string $payload
+     * @param string $orderId
+     * @return string
+     */
+    public function initiate(string $payload, string $orderId): string;
+}

--- a/Api/GuestAdyenPaymentsDetailsInterface.php
+++ b/Api/GuestAdyenPaymentsDetailsInterface.php
@@ -15,11 +15,13 @@ namespace Adyen\Payment\Api;
 /**
  * Interface for performing an Adyen payment details call
  */
-interface AdyenPaymentDetailsInterface
+interface GuestAdyenPaymentsDetailsInterface
 {
     /**
      * @param string $payload
+     * @param string $orderId
+     * @param string $cartId
      * @return string
      */
-    public function initiate(string $payload): string;
+    public function initiate(string $payload, string $orderId, string $cartId): string;
 }

--- a/Helper/PaymentsDetails.php
+++ b/Helper/PaymentsDetails.php
@@ -109,7 +109,13 @@ class PaymentsDetails
             $additionalData = $paymentDetails['additionalData'];
         }
 
-        return json_encode($this->paymentResponseHandler->formatPaymentResponse($paymentDetails['resultCode'], $action, $additionalData));
+        return json_encode(
+            $this->paymentResponseHandler->formatPaymentResponse(
+                $paymentDetails['resultCode'],
+                $action,
+                $additionalData
+            )
+        );
     }
 
     /**

--- a/Model/Api/AdyenPaymentsDetails.php
+++ b/Model/Api/AdyenPaymentsDetails.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2023 Adyen N.V. (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\Payment\Model\Api;
+
+use Adyen\Payment\Api\AdyenPaymentsDetailsInterface;
+use Adyen\Payment\Helper\PaymentsDetails;
+use Magento\Framework\Exception\AlreadyExistsException;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Sales\Api\OrderRepositoryInterface;
+
+class AdyenPaymentsDetails implements AdyenPaymentsDetailsInterface
+{
+    private OrderRepositoryInterface $orderRepository;
+
+    private PaymentsDetails $paymentsDetails;
+
+    public function __construct(
+        OrderRepositoryInterface $orderRepository,
+        PaymentsDetails $paymentsDetails
+    ) {
+        $this->orderRepository = $orderRepository;
+        $this->paymentsDetails = $paymentsDetails;
+    }
+
+    /**
+     * @param string $payload
+     * @param string $orderId
+     * @return string
+     * @throws LocalizedException
+     * @throws NoSuchEntityException
+     * @throws AlreadyExistsException
+     * @api
+     */
+    public function initiate(string $payload, string $orderId): string
+    {
+        $order = $this->orderRepository->get(intval($orderId));
+
+        return $this->paymentsDetails->initiatePaymentDetails($order, $payload);
+    }
+}

--- a/Model/Api/GuestAdyenPaymentsDetails.php
+++ b/Model/Api/GuestAdyenPaymentsDetails.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2023 Adyen N.V. (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\Payment\Model\Api;
+
+use Adyen\Payment\Api\GuestAdyenPaymentsDetailsInterface;
+use Adyen\Payment\Helper\PaymentsDetails;
+use Magento\Framework\Exception\AlreadyExistsException;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\Exception\NotFoundException;
+use Magento\Quote\Model\QuoteIdMaskFactory;
+use Magento\Sales\Api\OrderRepositoryInterface;
+
+class GuestAdyenPaymentsDetails implements GuestAdyenPaymentsDetailsInterface
+{
+    private OrderRepositoryInterface $orderRepository;
+
+    private QuoteIdMaskFactory $quoteIdMaskFactory;
+
+    private PaymentsDetails $paymentsDetails;
+
+    public function __construct(
+        OrderRepositoryInterface $orderRepository,
+        QuoteIdMaskFactory $quoteIdMaskFactory,
+        PaymentsDetails $paymentsDetails
+    ) {
+        $this->orderRepository = $orderRepository;
+        $this->quoteIdMaskFactory = $quoteIdMaskFactory;
+        $this->paymentsDetails = $paymentsDetails;
+    }
+
+    /**
+     * @param string $payload
+     * @param string $orderId
+     * @param string $cartId
+     * @return string
+     * @throws AlreadyExistsException
+     * @throws LocalizedException
+     * @throws NoSuchEntityException
+     * @api
+     */
+    public function initiate(string $payload, string $orderId, string $cartId): string
+    {
+        $order = $this->orderRepository->get(intval($orderId));
+
+        $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
+        $quoteId = $quoteIdMask->getQuoteId();
+
+        if ($order->getQuoteId() != $quoteId) {
+            throw new NotFoundException(
+                __("The entity that was requested doesn't exist. Verify the entity and try again.")
+            );
+        }
+
+        return $this->paymentsDetails->initiatePaymentDetails($order, $payload);
+    }
+}

--- a/Model/Resolver/DataProvider/GetAdyenPaymentStatus.php
+++ b/Model/Resolver/DataProvider/GetAdyenPaymentStatus.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Adyen\Payment\Model\Resolver\DataProvider;
 
 use Adyen\Payment\Model\Api\AdyenOrderPaymentStatus;
-use Adyen\Payment\Model\Api\AdyenPaymentDetails;
+use Adyen\Payment\Model\Api\AdyenPaymentsDetails;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Serialize\Serializer\Json;
 
@@ -25,7 +25,7 @@ class GetAdyenPaymentStatus
      */
     protected $adyenOrderPaymentStatusModel;
     /**
-     * @var AdyenPaymentDetails
+     * @var AdyenPaymentsDetails
      */
     protected $adyenPaymentDetails;
     /**
@@ -36,13 +36,13 @@ class GetAdyenPaymentStatus
     /**
      * GetAdyenPaymentStatus constructor.
      * @param AdyenOrderPaymentStatus $adyenOrderPaymentStatusModel
-     * @param AdyenPaymentDetails $adyenPaymentDetails
+     * @param AdyenPaymentsDetails $adyenPaymentDetails
      * @param Json $jsonSerializer
      */
     public function __construct(
         AdyenOrderPaymentStatus $adyenOrderPaymentStatusModel,
-        AdyenPaymentDetails $adyenPaymentDetails,
-        Json $jsonSerializer
+        AdyenPaymentsDetails    $adyenPaymentDetails,
+        Json                    $jsonSerializer
     ) {
         $this->adyenOrderPaymentStatusModel = $adyenOrderPaymentStatusModel;
         $this->adyenPaymentDetails = $adyenPaymentDetails;

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1169,8 +1169,10 @@
                 type="Adyen\Payment\Model\Api\AdyenPaymentMethodManagement"/>
     <preference for="Adyen\Payment\Api\AdyenInitiateTerminalApiInterface"
                 type="Adyen\Payment\Model\AdyenInitiateTerminalApi"/>
-    <preference for="Adyen\Payment\Api\AdyenPaymentDetailsInterface"
-                type="Adyen\Payment\Model\Api\AdyenPaymentDetails"/>
+    <preference for="Adyen\Payment\Api\AdyenPaymentsDetailsInterface"
+                type="Adyen\Payment\Model\Api\AdyenPaymentsDetails"/>
+    <preference for="Adyen\Payment\Api\GuestAdyenPaymentsDetailsInterface"
+                type="Adyen\Payment\Model\Api\GuestAdyenPaymentsDetails"/>
     <preference for="Adyen\Payment\Api\AdyenOrderPaymentStatusInterface"
                 type="Adyen\Payment\Model\Api\AdyenOrderPaymentStatus"/>
     <preference for="Adyen\Payment\Api\Internal\InternalAdyenOrderPaymentStatusInterface"
@@ -1294,7 +1296,7 @@
             <argument name="checkoutSession" xsi:type="object">Magento\Checkout\Model\Session\Proxy</argument>
         </arguments>
     </type>
-    <type name="Adyen\Payment\Model\Api\AdyenPaymentDetails">
+    <type name="Adyen\Payment\Model\Api\AdyenPaymentsDetails">
         <arguments>
             <argument name="checkoutSession" xsi:type="object">Magento\Checkout\Model\Session\Proxy</argument>
         </arguments>

--- a/etc/webapi.xml
+++ b/etc/webapi.xml
@@ -22,7 +22,6 @@
         </resources>
     </route>
 
-
     <route url="/V1/carts/mine/retrieve-adyen-payment-methods" method="POST">
         <service class="Adyen\Payment\Api\AdyenPaymentMethodManagementInterface" method="getPaymentMethods"/>
         <resources>
@@ -40,16 +39,15 @@
         </resources>
     </route>
 
-
-    <route url="/V1/adyen/guest-carts/:cartId/payment-details" method="POST">
-        <service class="Adyen\Payment\Api\AdyenPaymentDetailsInterface" method="initiate"/>
+    <route url="/V1/adyen/guest-carts/:cartId/payments-details" method="POST">
+        <service class="Adyen\Payment\Api\GuestAdyenPaymentsDetailsInterface" method="initiate"/>
         <resources>
             <resource ref="anonymous"/>
         </resources>
     </route>
 
-    <route url="/V1/adyen/carts/mine/payment-details" method="POST">
-        <service class="Adyen\Payment\Api\AdyenPaymentDetailsInterface" method="initiate"/>
+    <route url="/V1/adyen/carts/mine/payments-details" method="POST">
+        <service class="Adyen\Payment\Api\AdyenPaymentsDetailsInterface" method="initiate"/>
         <resources>
             <resource ref="self"/>
         </resources>

--- a/view/frontend/templates/checkout/multishipping/success.phtml
+++ b/view/frontend/templates/checkout/multishipping/success.phtml
@@ -144,10 +144,10 @@ $paymentResponseEntities = $block->getPaymentResponseEntities();
             function handleOnAdditionalDetails(result) {
                 let self = this;
                 let request = result.data;
-                request.orderId = $(paymentSelected).data('order-id');
+                let orderId = $(paymentSelected).data('order-id');
                 fullScreenLoader.stopLoader();
                 let popupModal = showModal();
-                adyenPaymentService.paymentDetails(request).done(function (responseJSON) {
+                adyenPaymentService.paymentDetails(request, orderId).done(function (responseJSON) {
                     handleAdyenResult(responseJSON, $(paymentSelected).data('order-id'));
                 }).fail(function (response) {
                     errorProcessor.process(response, self.messageContainer);

--- a/view/frontend/web/js/model/adyen-payment-modal.js
+++ b/view/frontend/web/js/model/adyen-payment-modal.js
@@ -29,19 +29,7 @@ define(
                     innerScroll: false,
                     // empty buttons, we don't need that
                     buttons: [],
-                    modalClass: modalLabel,
-                    closed: function() {
-                        // call endpoint with state.data if available
-                        let request = {};
-                        request.orderId = orderId;
-                        request.cancelled = true;
-
-                        adyenPaymentService.paymentDetails(request).fail(function(response) {
-                            errorProcessor.process(response, messageContainer);
-                            callback(true);
-                            fullScreenLoader.stopLoader();
-                        });
-                    },
+                    modalClass: modalLabel
                 });
 
                 popupModal.modal('openModal');

--- a/view/frontend/web/js/model/adyen-payment-service.js
+++ b/view/frontend/web/js/model/adyen-payment-service.js
@@ -55,12 +55,15 @@ define(
                     JSON.stringify(payload)
                 );
             },
+
             getPaymentMethods: function() {
                 return this.paymentMethods;
             },
+
             setPaymentMethods: function(paymentMethods) {
                 this.paymentMethods(paymentMethods);
             },
+
             getOrderPaymentStatus: function(orderId) {
                 var serviceUrl = urlBuilder.createUrl('/internal/adyen/orders/payment-status', {});
                 var payload = {
@@ -73,18 +76,26 @@ define(
                     true
                 );
             },
-            /**
-             * The results that the components returns in the onComplete callback needs to be sent to the
-             * backend to the /adyen/paymentDetails endpoint and based on the response render a new
-             * component or place the order (validateThreeDS2OrPlaceOrder)
-             */
-            paymentDetails: function(data) {
-                var payload = {
+
+            paymentDetails: function(data, orderId) {
+                let serviceUrl;
+                let payload = {
                     'payload': JSON.stringify(data),
-                    form_key: $.mage.cookies.get('form_key')
+                    'orderId': orderId
                 };
-                var serviceUrl = urlBuilder.createUrl('/adyen/payment-details',
-                    {});
+
+                if (customer.isLoggedIn()) {
+                    serviceUrl = urlBuilder.createUrl(
+                        '/adyen/carts/mine/payments-details',
+                        {}
+                    );
+                } else {
+                    serviceUrl = urlBuilder.createUrl(
+                        '/adyen/guest-carts/:cartId/payments-details', {
+                            cartId: quote.getQuoteId(),
+                        }
+                    );
+                }
 
                 return storage.post(
                     serviceUrl,

--- a/view/frontend/web/js/view/payment/method-renderer/adyen-cc-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-cc-method.js
@@ -316,10 +316,9 @@ define(
                 let request = result.data;
                 AdyenPaymentModal.hideModalLabel(this.modalLabel);
                 fullScreenLoader.startLoader();
-                request.orderId = self.orderId;
                 let popupModal = self.showModal();
 
-                adyenPaymentService.paymentDetails(request).
+                adyenPaymentService.paymentDetails(request, self.orderId).
                     done(function(responseJSON) {
                         fullScreenLoader.stopLoader();
                         self.handleAdyenResult(responseJSON, self.orderId);

--- a/view/frontend/web/js/view/payment/method-renderer/adyen-oneclick-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-oneclick-method.js
@@ -129,13 +129,12 @@ define(
             handleOnAdditionalDetails: function (result) {
                 var self = this;
                 var request = result.data;
-                request.orderId = self.orderId;
 
                 fullScreenLoader.stopLoader();
 
                 let popupModal = self.showModal();
 
-                adyenPaymentService.paymentDetails(request).done(function (responseJSON) {
+                adyenPaymentService.paymentDetails(request, self.orderId).done(function (responseJSON) {
                     self.handleAdyenResult(responseJSON,
                         self.orderId);
                 }).fail(function (response) {

--- a/view/frontend/web/js/view/payment/method-renderer/adyen-pm-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-pm-method.js
@@ -438,10 +438,9 @@ define(
                     request = state.data;
                 }
 
-                request.orderId = self.orderId;
                 request.cancelled = true;
 
-                adyenPaymentService.paymentDetails(request).done(function() {
+                adyenPaymentService.paymentDetails(request, self.orderId).done(function() {
                     $.mage.redirect(
                         window.checkoutConfig.payment[quote.paymentMethod().method].successPage,
                     );
@@ -464,9 +463,7 @@ define(
                     request = state.data;
                 }
 
-                request.orderId = self.orderId;
-
-                adyenPaymentService.paymentDetails(request).done(function() {
+                adyenPaymentService.paymentDetails(request, self.orderId).done(function() {
                     $.mage.redirect(
                         window.checkoutConfig.payment.adyen.successPage,
                     );

--- a/view/frontend/web/js/view/payment/method-renderer/vault.js
+++ b/view/frontend/web/js/view/payment/method-renderer/vault.js
@@ -91,13 +91,12 @@ define([
         handleOnAdditionalDetails: function (result) {
             let self = this;
             let request = result.data;
-            request.orderId = self.orderId;
 
             fullScreenLoader.stopLoader();
 
             let popupModal = self.showModal();
 
-            adyenPaymentService.paymentDetails(request).done(function (responseJSON) {
+            adyenPaymentService.paymentDetails(request, self.orderId).done(function (responseJSON) {
                 self.handleAdyenResult(responseJSON,
                     self.orderId);
             }).fail(function (response) {


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
`payments-details` related interfaces, classes and JS files were refactored.

- Plugin's `payments-details` endpoint set to use `cartId` for guest carts for an extra layer of security.
- Interfaces and endpoints renamed to `payments-details` to follow the same naming convention with Checkout API.
- JS files updated.
- Unused code fragments removed.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
Following scenarios were tested with guest/logged-in user cases for normal and headless integrations. 
- Card payments w/wo 3DS
- Vault w/wo 3DS
- PayPal