### PR TITLE
[PW-8209] Add storeId parameter to ratepayId config getter

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -1061,9 +1061,9 @@ class Data extends AbstractHelper
         return strpos($paymentMethod, $type) !== false;
     }
 
-    public function getRatePayId()
+    public function getRatePayId($storeId = null)
     {
-        return $this->getAdyenHppConfigData("ratepay_id");
+        return $this->getAdyenHppConfigData("ratepay_id", $storeId);
     }
 
     /**

--- a/Model/Ui/AdyenHppConfigProvider.php
+++ b/Model/Ui/AdyenHppConfigProvider.php
@@ -100,6 +100,8 @@ class AdyenHppConfigProvider implements ConfigProviderInterface
      */
     public function getConfig()
     {
+        $storeId = $this->storeManager->getStore()->getId();
+
         // set to active
         $config = [
             'payment' => [
@@ -132,7 +134,7 @@ class AdyenHppConfigProvider implements ConfigProviderInterface
         }
 
         $adyenHppConfig['locale'] = $this->adyenHelper->getCurrentLocaleCode(
-            $this->storeManager->getStore()->getId()
+            $storeId
         );
 
         // add to config
@@ -142,7 +144,7 @@ class AdyenHppConfigProvider implements ConfigProviderInterface
         // gender types
         $adyenHppConfig['genderTypes'] =  $this->gender->getGenderTypes();
 
-        $adyenHppConfig['ratePayId'] = $this->adyenHelper->getRatePayId();
+        $adyenHppConfig['ratePayId'] = $this->adyenHelper->getRatePayId($storeId);
         $adyenHppConfig['deviceIdentToken'] = hash("sha256", $this->session->getQuoteId() . date('c'));
         $adyenHppConfig['nordicCountries'] = ['SE', 'NO', 'DK', 'FI'];
 


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
`storeId` parameter added to `getRatePayId()` method to obtain related RatePay ID regarding to the selected store.