### PR TITLE
[PW-8305] Fix PHP 8 compatibility of allowRecurringOnPaymentMethod method

### DIFF
--- a/Helper/Vault.php
+++ b/Helper/Vault.php
@@ -261,13 +261,19 @@ class Vault
             $methodSupportsRecurring = $adyenPaymentMethod->supportsSubscription();
         }
 
-        $tokenizedPaymentMethods = array_map(
-            'trim',
-            explode(',', $this->config->getTokenizedPaymentMethods($storeId))
-        );
-        $shouldTokenize = in_array($adyenPaymentMethod->getTxVariant(), $tokenizedPaymentMethods);
+        $tokenizedPaymentMethods = $this->config->getTokenizedPaymentMethods($storeId);
 
-        return $methodSupportsRecurring && $shouldTokenize;
+        if (isset($tokenizedPaymentMethods)) {
+            $tokenizedPaymentMethods = array_map(
+                'trim',
+                explode(',', $tokenizedPaymentMethods)
+            );
+            $shouldTokenize = in_array($adyenPaymentMethod->getTxVariant(), $tokenizedPaymentMethods);
+
+            return $methodSupportsRecurring && $shouldTokenize;
+        } else {
+            return false;
+        }
     }
 
     /**


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
`allowRecurringOnPaymentMethod()` function throws an exception if recurring payments is enabled for alternative payment methods but no payment method has been selected to tokenize.

As as fix, if there is not payment method has been selected, `allowRecurringOnPaymentMethod()` method returns `false.`

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- PayPal tokenization with happy/unhappy flow