### PR TITLE
[PW-8318] Support Click to Pay

### DIFF
--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -38,6 +38,7 @@ class Config
     const XML_HOUSE_NUMBER_STREET_LINE = "house_number_street_line";
     const XML_ADYEN_ONECLICK = 'adyen_oneclick';
     const XML_ADYEN_HPP = 'adyen_hpp';
+    const XML_ADYEN_CC = 'adyen_cc';
     const XML_ADYEN_HPP_VAULT = 'adyen_hpp_vault';
     const XML_ADYEN_CC_VAULT = 'adyen_cc_vault';
     const XML_ADYEN_MOTO = 'adyen_moto';
@@ -490,6 +491,11 @@ class Config
     public function getCardRecurringType($storeId): ?string
     {
         return $this->getConfigData('card_type', self::XML_ADYEN_ONECLICK, $storeId);
+    }
+
+    public function isClickToPayEnabled($storeId): ?bool
+    {
+        return $this->getConfigData('enable_click_to_pay', self::XML_ADYEN_CC, $storeId);
     }
 
     public function getTokenizedPaymentMethods($storeId)

--- a/Model/Ui/AdyenCcConfigProvider.php
+++ b/Model/Ui/AdyenCcConfigProvider.php
@@ -153,7 +153,7 @@ class AdyenCcConfigProvider implements ConfigProviderInterface
         $config['payment']['adyenCc']['locale'] = $this->_adyenHelper->getStoreLocale($storeId);
         $config['payment']['adyenCc']['isOneClickEnabled'] = $recurringEnabled;
         $config['payment']['adyenCc']['icons'] = $this->getIcons();
-
+        $config['payment']['adyenCc']['isClickToPayEnabled'] = $this->configHelper->isClickToPayEnabled($storeId);
 
         // has installments by default false
         $config['payment']['adyenCc']['hasInstallments'] = false;

--- a/Model/Ui/AdyenGenericConfigProvider.php
+++ b/Model/Ui/AdyenGenericConfigProvider.php
@@ -69,6 +69,7 @@ class AdyenGenericConfigProvider implements ConfigProviderInterface
         }
 
         $config['payment']['adyen']['clientKey'] = $this->adyenHelper->getClientKey();
+        $config['payment']['adyen']['merchantAccount'] = $this->adyenConfigHelper->getMerchantAccount($storeId);
         $config['payment']['adyen']['checkoutEnvironment'] = $this->adyenHelper->getCheckoutEnvironment($storeId);
         $config['payment']['adyen']['locale'] = $this->adyenHelper->getStoreLocale($storeId);
         $config['payment']['adyen']['chargedCurrency'] = $this->adyenConfigHelper->getChargedCurrency($storeId);

--- a/etc/adminhtml/system/adyen_cc.xml
+++ b/etc/adminhtml/system/adyen_cc.xml
@@ -42,6 +42,11 @@
             <label>Maximum order total</label>
             <config_path>payment/adyen_cc/max_order_total</config_path>
         </field>
+        <field id="enable_click_to_pay" translate="label" type="select" sortOrder="60" showInDefault="1" showInWebsite="1">
+            <label>Click to Pay Enabled</label>
+            <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+            <config_path>payment/adyen_cc/enable_click_to_pay</config_path>
+        </field>
         <group id="adyen_cc_advanced_settings" translate="label" showInDefault="1" showInWebsite="1" showInStore="1"
                sortOrder="60">
             <label>Installments Setup</label>

--- a/etc/adyen_payment.xml
+++ b/etc/adyen_payment.xml
@@ -121,5 +121,13 @@
             <label>Apple Pay Girocard</label>
             <code_alt>girocard_applepay</code_alt>
         </type>
+        <type id="CLICKTOPAYMC" order="260">
+            <label>Click to Pay - MasterCard</label>
+            <code_alt>mc_clicktopay</code_alt>
+        </type>
+        <type id="CLICKTOPAYVISA" order="260">
+            <label>Click to Pay - Visa</label>
+            <code_alt>visa_clicktopay</code_alt>
+        </type>
     </adyen_credit_cards>
 </payment>

--- a/view/frontend/web/css/styles.css
+++ b/view/frontend/web/css/styles.css
@@ -21,3 +21,8 @@
 #adyen_pos_cloud_installments_div {
     margin-bottom: 15px;
 }
+
+.adyen-checkout-ctp__card-image {
+    height: 24px;
+    width: auto;
+}

--- a/view/frontend/web/js/model/adyen-configuration.js
+++ b/view/frontend/web/js/model/adyen-configuration.js
@@ -15,6 +15,9 @@ define(
             getClientKey: function() {
                 return window.checkoutConfig.payment.adyen.clientKey;
             },
+            getMerchantAccount: function() {
+                return window.checkoutConfig.payment.adyen.merchantAccount;
+            },
             showLogo: function() {
                 return window.checkoutConfig.payment.adyen.showLogo;
             },

--- a/view/frontend/web/js/view/payment/method-renderer/adyen-cc-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-cc-method.js
@@ -182,6 +182,13 @@ define(
                     }
                 }
 
+                if (self.isClickToPayEnabled()) {
+                    componentConfig.clickToPayConfiguration = {
+                        merchantDisplayName: adyenConfiguration.getMerchantAccount(),
+                        shopperEmail: self.getShopperEmail()
+                    };
+                }
+
                 self.cardComponent = adyenCheckout.mountPaymentMethodComponent(
                     this.checkoutComponent,
                     'card',
@@ -398,6 +405,16 @@ define(
                 }
 
                 return false;
+            },
+            getShopperEmail: function () {
+                if (customer.isLoggedIn()) {
+                    return customer.customerData.email;
+                } else {
+                    return quote.guestEmail;
+                }
+            },
+            isClickToPayEnabled: function () {
+                return window.checkoutConfig.payment.adyenCc.isClickToPayEnabled;
             },
             getIcons: function(type) {
                 return window.checkoutConfig.payment.adyenCc.icons.hasOwnProperty(


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Click to Pay is now supported by the plugin. First, Click to Pay should be enabled under the `Card Configuration` section of the plugin configuration.

Note that, Click to Pay should be enabled on Adyen Customer Area also.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- Guest shoppers
- Logged-in users
