### PR TITLE
Fixed invalid method call

### DIFF
--- a/Model/Resolver/GetAdyenPaymentStatus.php
+++ b/Model/Resolver/GetAdyenPaymentStatus.php
@@ -102,7 +102,7 @@ class GetAdyenPaymentStatus implements ResolverInterface
 
             return $this->getAdyenPaymentStatusDataProvider->getGetAdyenPaymentStatus($orderId);
         } catch (NoSuchEntityException $e) {
-            $this->adyenLogger->addWarning(sprintf(
+            $this->adyenLogger->addAdyenWarning(sprintf(
                 'Attempted to get the payment status for order %s. Exception: %s',
                 $orderIncrementId,
                 $e->getMessage()


### PR DESCRIPTION
The addWarning method is not defined in AdyenLogger

<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
When the order matching fails, the call to log the error is using a method that is not defined

**Tested scenarios**

* Chack payment status with wrong order number