### PR TITLE
Fix: Remove CSP headers from JSON endpoint

### DIFF
--- a/Controller/Process/Json.php
+++ b/Controller/Process/Json.php
@@ -33,11 +33,12 @@ use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Serialize\SerializerInterface;
 use Symfony\Component\Config\Definition\Exception\Exception;
 use Magento\Framework\HTTP\PhpEnvironment\RemoteAddress;
+use Magento\Csp\Api\CspAwareActionInterface;
 
 /**
  * Class Json extends Action
  */
-class Json extends Action
+class Json extends Action implements CspAwareActionInterface
 {
     /**
      * @var NotificationFactory
@@ -206,6 +207,14 @@ class Json extends Action
         } catch (Exception $e) {
             throw new LocalizedException(__($e->getMessage()));
         }
+    }
+
+    /**
+     * Remove CSP policies, as not needed in API routes
+     */
+    public function modifyCsp(array $appliedPolicies): array
+    {
+       return [];
     }
 
     /**


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Removed the CSP headers from the Json controller, to fix the "Maximum line length limit exceeded" webhook error for  stores with large CSP headers. 

Fixes  <!-- #-prefixed github issue number -->
#1852 