### PR TITLE
[PW-8354] Wrong amount on adyen_invoice table

### DIFF
--- a/Helper/Invoice.php
+++ b/Helper/Invoice.php
@@ -258,7 +258,7 @@ class Invoice extends AbstractHelper
         $adyenInvoice = $this->adyenInvoiceFactory->create();
         $adyenInvoice->setPspreference($pspReference);
         $adyenInvoice->setAdyenPaymentOrderId($adyenOrderPayment[OrderPaymentInterface::ENTITY_ID]);
-        $adyenInvoice->setAmount($this->adyenDataHelper->originalAmount($captureAmountCents, $order->getBaseCurrencyCode()));
+        $adyenInvoice->setAmount($this->adyenDataHelper->originalAmount($captureAmountCents, $order->getOrderCurrencyCode()));
         $adyenInvoice->setStatus(InvoiceInterface::STATUS_PENDING_WEBHOOK);
 
         if (isset($invoiceId)) {

--- a/Helper/Invoice.php
+++ b/Helper/Invoice.php
@@ -258,7 +258,10 @@ class Invoice extends AbstractHelper
         $adyenInvoice = $this->adyenInvoiceFactory->create();
         $adyenInvoice->setPspreference($pspReference);
         $adyenInvoice->setAdyenPaymentOrderId($adyenOrderPayment[OrderPaymentInterface::ENTITY_ID]);
-        $adyenInvoice->setAmount($this->adyenDataHelper->originalAmount($captureAmountCents, $order->getOrderCurrencyCode()));
+        $adyenInvoice->setAmount($this->adyenDataHelper->originalAmount(
+            $captureAmountCents,
+            $order->getOrderCurrencyCode()
+        ));
         $adyenInvoice->setStatus(InvoiceInterface::STATUS_PENDING_WEBHOOK);
 
         if (isset($invoiceId)) {


### PR DESCRIPTION
**Description**

The issue this PR is solving is that currently, if a different currency is used instead of the base currency, decimal amount is picked up from the base currency and not the display currency. 
Consequences of the wrong value on `adyen_invoice` table is wrong manual capture. Order can't be closed since the invoiced amount is wrong.

The fix is to use the `order_currency_code` to set the `amount` field in `adyen_invoice` table.

**Tested scenarios**
- testing the behaviour with base currency EUR and order currency JPY with the currency exchange rate configured in M2 Admin Panel. Manually capture and process the notifications and observe the correct amount field of adyen_invoice table
