### PR TITLE
[PW-8319] Create admin configurations for separate payment methods

### DIFF
--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -300,6 +300,7 @@ class Config
     /**
      * @param $storeId
      * @return bool|mixed
+     * @deprecated
      */
     public function isAlternativePaymentMethodsEnabled($storeId = null): bool
     {

--- a/Model/Config/Backend/PaymentMethodsStatus.php
+++ b/Model/Config/Backend/PaymentMethodsStatus.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2023 Adyen NV (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\Payment\Model\Config\Backend;
+
+use Adyen\Payment\Helper\PaymentMethods;
+use Magento\Framework\App\Config\Storage\WriterInterface;
+
+class PaymentMethodsStatus extends \Magento\Framework\App\Config\Value
+{
+    /**
+     * @var PaymentMethods
+     */
+    protected $paymentMethodsHelper;
+
+    /**
+     * @var WriterInterface
+     */
+    private $configWriter;
+
+    /**
+     * @param \Magento\Framework\Model\Context $context
+     * @param \Magento\Framework\Registry $registry
+     * @param \Magento\Framework\App\Config\ScopeConfigInterface $config
+     * @param \Magento\Framework\App\Cache\TypeListInterface $cacheTypeList
+     * @param \Magento\Framework\Model\ResourceModel\AbstractResource|null $resource
+     * @param \Magento\Framework\Data\Collection\AbstractDb|null $resourceCollection
+     * @param WriterInterface $configWriter
+     * @param array $data
+     */
+    public function __construct(
+        \Magento\Framework\Model\Context $context,
+        \Magento\Framework\Registry $registry,
+        \Magento\Framework\App\Config\ScopeConfigInterface $config,
+        \Magento\Framework\App\Cache\TypeListInterface $cacheTypeList,
+        \Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
+        \Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
+        WriterInterface $configWriter,
+        PaymentMethods $paymentMethodsHelper,
+        array $data = []
+    ) {
+        $this->configWriter = $configWriter;
+        $this->paymentMethodsHelper = $paymentMethodsHelper;
+
+        parent::__construct($context, $registry, $config, $cacheTypeList, $resource, $resourceCollection, $data);
+    }
+
+    /**
+     * @return $this|OrderStatus
+     */
+    public function afterSave()
+    {
+        $value = $this->getValue();
+        $adyenPaymentMethods = $this->paymentMethodsHelper->getAdyenPaymentMethods();
+
+        foreach ($adyenPaymentMethods as $adyenPaymentMethod) {
+            $this->configWriter->save(
+                'payment/' . $adyenPaymentMethod . '/active',
+                $value,
+            );
+        }
+
+        return $this;
+    }
+}

--- a/etc/adminhtml/system/adyen_cc.xml
+++ b/etc/adminhtml/system/adyen_cc.xml
@@ -17,12 +17,6 @@
         <frontend_model>Magento\Config\Block\System\Config\Form\Fieldset</frontend_model>
         <comment> <![CDATA[<p>Process credit card payments inside your checkout.</p>]]>
         </comment>
-        <field id="active" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="1"
-               showInStore="1">
-            <label>Enabled</label>
-            <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-            <config_path>payment/adyen_cc/active</config_path>
-        </field>
         <field id="title" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="1"
                showInStore="1">
             <label>Title</label>

--- a/etc/adminhtml/system/adyen_configure_payment_methods.xml
+++ b/etc/adminhtml/system/adyen_configure_payment_methods.xml
@@ -17,6 +17,7 @@
            showInStore="1">
         <label><![CDATA[Configure payment methods]]></label>
         <frontend_model>Magento\Config\Block\System\Config\Form\Fieldset</frontend_model>
+        <include path="Adyen_Payment::system/adyen_payment_methods.xml" />
         <include path="Adyen_Payment::system/adyen_cc.xml"/>
         <include path="Adyen_Payment::system/adyen_oneclick.xml"/>
         <include path="Adyen_Payment::system/adyen_hpp.xml"/>

--- a/etc/adminhtml/system/adyen_hpp.xml
+++ b/etc/adminhtml/system/adyen_hpp.xml
@@ -17,11 +17,6 @@
         <frontend_model>Magento\Config\Block\System\Config\Form\Fieldset</frontend_model>
         <fieldset_css>adyen-method-adyen-cc</fieldset_css>
         <comment>Process alternative payments methods</comment>
-        <field id="active" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
-            <label>Enabled</label>
-            <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-            <config_path>payment/adyen_hpp/active</config_path>
-        </field>
         <field id="sort_order" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="0">
             <label>Sort Order</label>
             <frontend_class>validate-number</frontend_class>

--- a/etc/adminhtml/system/adyen_payment_methods.xml
+++ b/etc/adminhtml/system/adyen_payment_methods.xml
@@ -15,7 +15,6 @@
            showInStore="1">
         <label><![CDATA[Payment methods]]></label>
         <frontend_model>Magento\Config\Block\System\Config\Form\Fieldset</frontend_model>
-<!--        TODO link the correct documentation -->
         <comment> <![CDATA[<p>You can make changes to an individual payment method in Adyen Customer Area.
         Use our documentation in case you have any doubt how to set up payment methods</p>]]>
         </comment>

--- a/etc/adminhtml/system/adyen_payment_methods.xml
+++ b/etc/adminhtml/system/adyen_payment_methods.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<!--
+/**
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2023 Adyen NV (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+-->
+<include xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_include.xsd">
+    <group id="adyen_payment_methods" translate="label" type="text" sortOrder="50" showInDefault="1" showInWebsite="1"
+           showInStore="1">
+        <label><![CDATA[Payment methods]]></label>
+        <frontend_model>Magento\Config\Block\System\Config\Form\Fieldset</frontend_model>
+<!--        TODO link the correct documentation -->
+        <comment> <![CDATA[<p>You can make changes to an individual payment method in Adyen Customer Area.
+        Use our documentation in case you have any doubt how to set up payment methods</p>]]>
+        </comment>
+        <field id="active" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="1"
+               showInStore="1">
+            <label>Payment methods enabled</label>
+            <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+            <backend_model>Adyen\Payment\Model\Config\Backend\PaymentMethodsStatus</backend_model>
+            <config_path>payment/adyen_abstract/payment_methods_active</config_path>
+        </field>
+    </group>
+</include>


### PR DESCRIPTION
**Description**
To fully make separate payment methods configurable by Magento, we need to add new entries to the payment methods config.

With this PR, we are handling the following:
1. Adding deprecation tags to `isAlternativePaymentMethodsEnabled()` method in Config.php
2. Removing the configuration field from `adyen_cc.xml`.
3. Removing the configuration field from `adyen_hpp.xml`.
4. Adding a new section under `Configure Payment Methods` with title `Payment Methods`.
5. Adding a new config field -> `payment/adyen_abstract/payment_methods_active`
6. Adding a new backend model for updating new `active` fields of all payment methods in `core_config_data`

**Tested scenarios**
After saving the configuration field via the admin panel, all of the payment methods have their active field in the `core_config_data` table of DB.
