### PR TITLE
[PW-8220] Support installments with vault tokens

### DIFF
--- a/view/frontend/web/template/payment/card-vault-form.html
+++ b/view/frontend/web/template/payment/card-vault-form.html
@@ -70,6 +70,34 @@
                 <div class="checkout-component-dock" afterRender="renderCardVaultToken()" data-bind="attr: { id: 'cvcContainer-' + getId()}"></div>
             </fieldset>
         </form>
+
+        <!-- ko if: (hasInstallments())-->
+
+        <div class="field required"
+             data-bind="attr: {id: getCode() + '_installments_div'}, visible: installments().length > 0">
+            <label data-bind="attr: {for: getCode() + '_installments'}" class="label">
+                <span><!-- ko text: $t('Installments')--><!-- /ko --></span>
+            </label>
+            <div class="control">
+
+                <select class="select"
+                        name="payment[number_of_installments]"
+                        data-bind="attr: {id: getCode() + '_installments', 'data-container': getCode() + '-installments', 'data-validate': JSON.stringify({required:false})},
+
+                                        enable: isActive($parents),
+                                        options: installments,
+                                        optionsValue: 'value',
+                                        optionsText: 'key',
+                                        optionsCaption: $t('Do not use Installments'),
+                                        value: installment"
+                        data-validate="{required:true}">
+                </select>
+            </div>
+        </div>
+        <br/>
+
+        <!-- /ko -->
+
         <div class="checkout-agreements-block">
             <!-- ko foreach: $parent.getRegion('before-place-order') -->
             <!-- ko template: getTemplate() --><!-- /ko -->


### PR DESCRIPTION
**Description**
This PR adds the support to the functionality of the shopper being able to select the number of installments in the payment form when the vault tokenisation recurring mode is enabled in the admin panel.

**Tested scenarios**
- storing the card and making sure the installments block shows correctly and in accordance with the related amin panel setting
- storing the card and making a subsequential payment using the installment option

Fixes  <!-- #-prefixed github issue number -->
