### PR TITLE
[PW-8378] Make CVC field configurable for card vault payments

### DIFF
--- a/Model/Ui/AdyenCcConfigProvider.php
+++ b/Model/Ui/AdyenCcConfigProvider.php
@@ -169,6 +169,15 @@ class AdyenCcConfigProvider implements ConfigProviderInterface
             $config['payment']['adyenCc']['installments'] = [];
         }
 
+        // fetch the config value of require_cvc
+        $cvcReq = $this->configHelper->getConfigData(
+            'require_cvc',
+            Config::XML_ADYEN_CC_VAULT,
+            $storeId,
+            true);
+
+        $config['payment']['adyenCc']['cvcRequired'] = $cvcReq;
+
         return $config;
     }
 

--- a/Model/Ui/AdyenCcConfigProvider.php
+++ b/Model/Ui/AdyenCcConfigProvider.php
@@ -169,14 +169,12 @@ class AdyenCcConfigProvider implements ConfigProviderInterface
             $config['payment']['adyenCc']['installments'] = [];
         }
 
-        // fetch the config value of require_cvc
-        $cvcReq = $this->configHelper->getConfigData(
+        // check if cvc is required
+        $config['payment']['adyenCc']['cvcRequired'] = $this->configHelper->getConfigData(
             'require_cvc',
             Config::XML_ADYEN_CC_VAULT,
             $storeId,
             true);
-
-        $config['payment']['adyenCc']['cvcRequired'] = $cvcReq;
 
         return $config;
     }

--- a/Model/Ui/AdyenCcConfigProvider.php
+++ b/Model/Ui/AdyenCcConfigProvider.php
@@ -174,7 +174,8 @@ class AdyenCcConfigProvider implements ConfigProviderInterface
             'require_cvc',
             Config::XML_ADYEN_CC_VAULT,
             $storeId,
-            true);
+            true
+        );
 
         return $config;
     }

--- a/Model/Ui/AdyenCcConfigProvider.php
+++ b/Model/Ui/AdyenCcConfigProvider.php
@@ -170,7 +170,7 @@ class AdyenCcConfigProvider implements ConfigProviderInterface
         }
 
         // check if cvc is required
-        $config['payment']['adyenCc']['cvcRequired'] = $this->configHelper->getConfigData(
+        $config['payment']['adyenCc']['requireCvc'] = $this->configHelper->getConfigData(
             'require_cvc',
             Config::XML_ADYEN_CC_VAULT,
             $storeId,

--- a/etc/adminhtml/system/adyen_oneclick.xml
+++ b/etc/adminhtml/system/adyen_oneclick.xml
@@ -35,7 +35,16 @@
                 <field id="active">1</field>
             </depends>
         </field>
-        <field id="recurring_card_token_type" translate="label" type="select" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
+        <field id="cvc_required" translate="label" type="select" sortOrder="20" showInDefault="1" showInWebsite="1"
+               showInStore="1">
+            <label>CVC required for stored methods</label>
+            <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+            <config_path>payment/adyen_cc_vault/require_cvc</config_path>
+            <depends>
+                <field id="recurring_card_mode">Magento Vault</field>
+            </depends>
+        </field>
+        <field id="recurring_card_token_type" translate="label" type="select" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
             <label>Token Type</label>
             <tooltip>
                 Choose between CardOnFile (one-click), UnscheduledCardOnFile (non-fixed schedule MIT payments) or Subscription (fixed schedule MIT payments)

--- a/etc/adminhtml/system/adyen_oneclick.xml
+++ b/etc/adminhtml/system/adyen_oneclick.xml
@@ -37,7 +37,7 @@
         </field>
         <field id="cvc_required" translate="label" type="select" sortOrder="20" showInDefault="1" showInWebsite="1"
                showInStore="1">
-            <label>CVC required for stored methods</label>
+            <label>Require CVC</label>
             <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
             <config_path>payment/adyen_cc_vault/require_cvc</config_path>
             <depends>

--- a/etc/adminhtml/system/adyen_oneclick.xml
+++ b/etc/adminhtml/system/adyen_oneclick.xml
@@ -35,7 +35,7 @@
                 <field id="active">1</field>
             </depends>
         </field>
-        <field id="cvc_required" translate="label" type="select" sortOrder="20" showInDefault="1" showInWebsite="1"
+        <field id="require_cvc" translate="label" type="select" sortOrder="20" showInDefault="1" showInWebsite="1"
                showInStore="1">
             <label>Require CVC</label>
             <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -58,6 +58,7 @@
             <adyen_cc_vault>
                 <model>AdyenPaymentCcVaultFacade</model>
                 <title>Stored Cards (Adyen)</title>
+                <require_cvc>1</require_cvc>
                 <instant_purchase>
                     <available>Adyen\Payment\Model\InstantPurchase\CreditCard\AvailabilityChecker</available>
                     <tokenFormat>Adyen\Payment\Model\InstantPurchase\CreditCard\TokenFormatter</tokenFormat>

--- a/view/frontend/web/js/view/payment/method-renderer/vault.js
+++ b/view/frontend/web/js/view/payment/method-renderer/vault.js
@@ -112,10 +112,10 @@ define([
                 return false
             }
 
-            let cvcRequired = window.checkoutConfig.payment.adyenCc.cvcRequired;
+            let requireCvc = window.checkoutConfig.payment.adyenCc.requireCvc;
 
             let componentConfig = {
-                hideCVC: !cvcRequired,
+                hideCVC: !requireCvc,
                 brand: this.getCardType(),
                 storedPaymentMethodId: this.getGatewayToken(),
                 expiryMonth: this.getExpirationMonth(),

--- a/view/frontend/web/js/view/payment/method-renderer/vault.js
+++ b/view/frontend/web/js/view/payment/method-renderer/vault.js
@@ -112,8 +112,13 @@ define([
                 return false
             }
 
+            let cvcRequired = window.checkoutConfig.payment.adyenCc.cvcRequired;
+
+            debugger;
+
+            console.log('cvc Required: ', cvcRequired);
             let componentConfig = {
-                hideCVC: false,
+                hideCVC: cvcRequired,
                 brand: this.getCardType(),
                 storedPaymentMethodId: this.getGatewayToken(),
                 expiryMonth: this.getExpirationMonth(),

--- a/view/frontend/web/js/view/payment/method-renderer/vault.js
+++ b/view/frontend/web/js/view/payment/method-renderer/vault.js
@@ -114,11 +114,8 @@ define([
 
             let cvcRequired = window.checkoutConfig.payment.adyenCc.cvcRequired;
 
-            debugger;
-
-            console.log('cvc Required: ', cvcRequired);
             let componentConfig = {
-                hideCVC: cvcRequired,
+                hideCVC: !cvcRequired,
                 brand: this.getCardType(),
                 storedPaymentMethodId: this.getGatewayToken(),
                 expiryMonth: this.getExpirationMonth(),


### PR DESCRIPTION
**Description**
This PR introduces a new configuration field in the admin panel for `Magento Vault` recurring mode. It enables the merchants that have the ADP `skipCVCForOneClick` enabled in Adyen Customer Area to control whether the CVC field is required or not for vault payments. 

Newly added admin config field and correlated config path in `core_config_data` db table solve the issue introduced by [this PR](https://github.com/Adyen/adyen-magento2/pull/1991) where we added the checkout component for card vault payments under the assumption that all the CardOnFile payments require CVC field, which is not the case. 

**Tested scenarios**
- configure recurring mode to `Magento Vault` in admin panel
- set `Require CVC` field to `Yes` and confirm the CVC field is required in the vault form when the shopper tries to pay with the stored card, confirm payment is successful
- set `Require CVC` field to `No` and confirm the CVC field is not required in the vault form when the shopper tries to pay with the stored card, confirm payment is successful
