### PR TITLE
[PW-8395] Remove Max-Min order configuration field

### DIFF
--- a/etc/adminhtml/system/adyen_cc.xml
+++ b/etc/adminhtml/system/adyen_cc.xml
@@ -28,15 +28,7 @@
             <frontend_class>validate-number</frontend_class>
             <config_path>payment/adyen_cc/sort_order</config_path>
         </field>
-        <field id="min_order_total" translate="label" type="text" sortOrder="40" showInDefault="1" showInWebsite="1">
-            <label>Minimum order total</label>
-            <config_path>payment/adyen_cc/min_order_total</config_path>
-        </field>
-        <field id="max_order_total" translate="label" type="text" sortOrder="50" showInDefault="1" showInWebsite="1">
-            <label>Maximum order total</label>
-            <config_path>payment/adyen_cc/max_order_total</config_path>
-        </field>
-        <field id="enable_click_to_pay" translate="label" type="select" sortOrder="60" showInDefault="1" showInWebsite="1">
+        <field id="enable_click_to_pay" translate="label" type="select" sortOrder="40" showInDefault="1" showInWebsite="1">
             <label>Click to Pay Enabled</label>
             <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
             <config_path>payment/adyen_cc/enable_click_to_pay</config_path>

--- a/etc/adminhtml/system/adyen_hpp.xml
+++ b/etc/adminhtml/system/adyen_hpp.xml
@@ -25,20 +25,6 @@
                 <field id="active">1</field>
             </depends>
         </field>
-        <field id="min_order_total" translate="label" type="text" sortOrder="21" showInDefault="1" showInWebsite="1">
-            <label>Minimum order total</label>
-            <config_path>payment/adyen_hpp/min_order_total</config_path>
-            <depends>
-                <field id="active">1</field>
-            </depends>
-        </field>
-        <field id="max_order_total" translate="label" type="text" sortOrder="22" showInDefault="1" showInWebsite="1">
-            <label>Maximum order total</label>
-            <config_path>payment/adyen_hpp/max_order_total</config_path>
-            <depends>
-                <field id="active">1</field>
-            </depends>
-        </field>
         <field id="adyen_hpp_vault_active" translate="label" type="select" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
             <label>Store alternative payment methods</label>
             <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>


### PR DESCRIPTION
**Description**
In v8, we added the configuration fields to our credit card and alternative payment section of our plugin to limit the minimum and maximum amount of orders within the plugin. As this is something that can be configured in Adyen Customer Area with [transaction rules](https://docs.adyen.com/issuing/authorisation/transaction-rules), we are removing those fields from the configuration.

This PR only removes the fields from the admin panel, the database config paths will be removed in a follow-up PR.

**Tested scenarios**
- add an example transaction rule in the Customer Area for a minimum and maximum value of order for which the payment method should appear
- add items into the shopping cart, proceed to the checkout page and observe whether the transaction rule is correctly applied so that the payment method doesn't show outside of the determined order value scope and that it shows when the amount of the order is within the scope of what the transaction rule defines
Fixes  <!-- #-prefixed github issue number -->
