### PR TITLE
PW-8374 - Add support for vault on RC-V9 for wallet payment methods

### DIFF
--- a/Helper/Vault.php
+++ b/Helper/Vault.php
@@ -342,15 +342,8 @@ class Vault
 
         // If wallet payment method
         if ($paymentMethodCode !== PaymentMethods::ADYEN_CC && $paymentMethodInstance instanceof PaymentMethodInterface) {
-            $txVariant = new TxVariant($payment->getCcType());
-            $details = [
-                'type' => $txVariant->getCard(),
-                'walletType' => $txVariant->getPaymentMethod()
-            ];
-        } else {
             $details = ['type' => $additionalData[self::PAYMENT_METHOD]];
         }
-
         if (!empty($additionalData[self::CARD_SUMMARY])) {
             $details['maskedCC'] =  $additionalData[self::CARD_SUMMARY];
         }


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

Due to the new separate payment methods on RC-V9. In order to have vault on the wallet payment methods. 

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->

Remove validation for cards and Tx variants as this shouldn't be gotten from there with the changes on RC-V9. 

**Tested scenarios**
<!-- Description of tested scenarios -->
Tested vault payment methods on express checkout. 

<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

Fixes  <!-- #-prefixed github issue number -->
