### PR TITLE
[PW-8277] Write unit tests for AuthorisationWebhookHandler

### DIFF
--- a/Test/Unit/Helper/Webhook/AuthorisationWebhookHandlerTest.php
+++ b/Test/Unit/Helper/Webhook/AuthorisationWebhookHandlerTest.php
@@ -26,9 +26,7 @@ use Adyen\Payment\Model\Notification;
 use Adyen\Payment\Test\Unit\AbstractAdyenTestCase;
 use Adyen\Webhook\PaymentStates;
 use Magento\Framework\Serialize\SerializerInterface;
-use Magento\Sales\Api\Data\OrderInterface;
 use Magento\Sales\Model\Order;
-use Magento\Sales\Api\Data\OrderPaymentInterface;
 
 class AuthorisationWebhookHandlerTest extends AbstractAdyenTestCase
 {
@@ -128,47 +126,6 @@ class AuthorisationWebhookHandlerTest extends AbstractAdyenTestCase
         $this->assertEquals($order->toArray(), $result->toArray());
 
     }
-
-    public function testHandleFailedAuthorisation()
-    {
-        // Create the necessary mocks and objects
-
-        // Condition 1: Previous Authorization and Captured Payments
-        // Test when previous Adyen event code is "AUTHORISATION : TRUE"
-        // Assert that the order is not canceled and the appropriate log entry is added
-
-        // Test when there was a previous payment capture
-        // Assert that the order is not canceled and the appropriate log entry is added
-
-        // Condition 2: Check Order Status
-        // Test when the order is already canceled
-        // Assert that the order is not canceled and the appropriate log entry is added
-
-        // Test when the order is on hold
-        // Assert that the order is not canceled and the appropriate log entry is added
-
-        // Condition 3: Check Payment Method
-        // Test when the payment method is "PBL" and can be canceled
-        // Assert that the order is canceled or held based on the failure counter
-
-        // Test when the payment method is "PBL" and cannot be canceled
-        // Assert that the order is not canceled and the appropriate log entry is added
-
-        // Condition 4: Change Order State
-        // Test when the order cannot be canceled and configuration allows canceling orders
-        // Assert that the order state is changed from "PAYMENT_REVIEW" to "NEW"
-
-        // Test when the order cannot be canceled and configuration does not allow canceling orders
-        // Assert that the order state is not changed
-
-        // Condition 5: Cancel or Hold the Order
-        // Test when the order can be canceled or held
-        // Assert that the order is canceled or held based on the configuration
-
-        // Test when the order cannot be canceled or held
-        // Assert that the order is returned without further processing
-    }
-
 
     protected function createAuthorisationWebhookHandler(
         $mockAdyenOrderPayment = null,

--- a/Test/Unit/Helper/Webhook/AuthorisationWebhookHandlerTest.php
+++ b/Test/Unit/Helper/Webhook/AuthorisationWebhookHandlerTest.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2023 Adyen NV (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\Payment\Test\Unit\Helper;
+
+use Adyen\Payment\Helper\AdyenOrderPayment;
+use Adyen\Payment\Helper\ChargedCurrency;
+use Adyen\Payment\Helper\Config;
+use Adyen\Payment\Helper\Invoice;
+use Adyen\Payment\Helper\Order;
+use Adyen\Payment\Helper\PaymentMethods;
+use Adyen\Payment\Helper\Webhook\AuthorisationWebhookHandler;
+use Adyen\Payment\Logger\AdyenLogger;
+use Adyen\Payment\Test\Unit\AbstractAdyenTestCase;
+use Magento\Framework\Serialize\SerializerInterface;
+
+class AuthorisationWebhookHandlerTest extends AbstractAdyenTestCase
+{
+    protected function createAuthorisationWebhookHandler(
+        $mockAdyenOrderPayment = null,
+        $mockOrderHelper = null,
+        $mockSerializer = null,
+        $mockAdyenLogger = null,
+        $mockChargedCurrency = null,
+        $mockConfigHelper = null,
+        $mockInvoiceHelper = null,
+        $mockPaymentMethodsHelper = null
+    ): AuthorisationWebhookHandler
+    {
+        if (is_null($mockAdyenOrderPayment)) {
+            $mockAdyenOrderPayment = $this->createMock(AdyenOrderPayment::class);
+        }
+
+        if (is_null($mockOrderHelper)) {
+            $mockOrderHelper = $this->createMock(Order::class);
+        }
+
+        if (is_null($mockSerializer)) {
+            $mockSerializer = $this->createMock(SerializerInterface::class);
+        }
+
+        if (is_null($mockAdyenLogger)) {
+            $mockAdyenLogger = $this->createMock(AdyenLogger::class);
+        }
+
+        if (is_null($mockChargedCurrency)) {
+            $mockChargedCurrency = $this->createMock(ChargedCurrency::class);
+        }
+
+        if (is_null($mockConfigHelper)) {
+            $mockConfigHelper = $this->createMock(Config::class);
+        }
+
+        if (is_null($mockInvoiceHelper)) {
+            $mockInvoiceHelper = $this->createMock(Invoice::class);
+        }
+
+        if (is_null($mockPaymentMethodsHelper)) {
+            $mockPaymentMethodsHelper = $this->createMock(PaymentMethods::class);
+        }
+
+        return new something (
+            $mockAdyenOrderPayment,
+            $mockOrderHelper,
+            $mockSerializer,
+            $mockAdyenLogger,
+            $mockChargedCurrency,
+            $mockConfigHelper,
+            $mockInvoiceHelper,
+            $mockPaymentMethodsHelper
+        );
+    }
+}

--- a/Test/Unit/Helper/Webhook/AuthorisationWebhookHandlerTest.php
+++ b/Test/Unit/Helper/Webhook/AuthorisationWebhookHandlerTest.php
@@ -129,6 +129,47 @@ class AuthorisationWebhookHandlerTest extends AbstractAdyenTestCase
 
     }
 
+    public function testHandleFailedAuthorisation()
+    {
+        // Create the necessary mocks and objects
+
+        // Condition 1: Previous Authorization and Captured Payments
+        // Test when previous Adyen event code is "AUTHORISATION : TRUE"
+        // Assert that the order is not canceled and the appropriate log entry is added
+
+        // Test when there was a previous payment capture
+        // Assert that the order is not canceled and the appropriate log entry is added
+
+        // Condition 2: Check Order Status
+        // Test when the order is already canceled
+        // Assert that the order is not canceled and the appropriate log entry is added
+
+        // Test when the order is on hold
+        // Assert that the order is not canceled and the appropriate log entry is added
+
+        // Condition 3: Check Payment Method
+        // Test when the payment method is "PBL" and can be canceled
+        // Assert that the order is canceled or held based on the failure counter
+
+        // Test when the payment method is "PBL" and cannot be canceled
+        // Assert that the order is not canceled and the appropriate log entry is added
+
+        // Condition 4: Change Order State
+        // Test when the order cannot be canceled and configuration allows canceling orders
+        // Assert that the order state is changed from "PAYMENT_REVIEW" to "NEW"
+
+        // Test when the order cannot be canceled and configuration does not allow canceling orders
+        // Assert that the order state is not changed
+
+        // Condition 5: Cancel or Hold the Order
+        // Test when the order can be canceled or held
+        // Assert that the order is canceled or held based on the configuration
+
+        // Test when the order cannot be canceled or held
+        // Assert that the order is returned without further processing
+    }
+
+
     protected function createAuthorisationWebhookHandler(
         $mockAdyenOrderPayment = null,
         $mockOrderHelper = null,


### PR DESCRIPTION
**Description**
With this PR we are setting up the unit tests for AuthorisationWebhookHandler class. We are including 2 unit tests that test whether the handleWebhook() method is executed correctly and that the correct block if code is accessed depending on the value of the transition state. 

**Tested scenarios**
- run the unit tests
