### PR TITLE
Fix case where order does not have a quote ID

### DIFF
--- a/Gateway/Request/ChannelDataBuilder.php
+++ b/Gateway/Request/ChannelDataBuilder.php
@@ -19,8 +19,7 @@ use Magento\Sales\Model\Order;
 
 class ChannelDataBuilder implements BuilderInterface
 {
-    /** @var StateData */
-    private $stateDataHelper;
+    private StateData $stateDataHelper;
 
     public function __construct(StateData $stateDataHelper)
     {
@@ -35,8 +34,10 @@ class ChannelDataBuilder implements BuilderInterface
         /** @var Order $order */
         $order = $payment->getOrder();
 
-        $stateData = $this->stateDataHelper->getStateData($order->getQuoteId());
-        $request['body']['channel'] = array_key_exists('channel', $stateData) ? $stateData['channel'] : 'web';
+        if ($order->getQuoteId()) {
+            $stateData = $this->stateDataHelper->getStateData((int)$order->getQuoteId());
+            $request['body']['channel'] = $stateData['channel'] ?? 'web';
+        }
 
         return $request;
     }

--- a/Gateway/Request/ChannelDataBuilder.php
+++ b/Gateway/Request/ChannelDataBuilder.php
@@ -28,17 +28,13 @@ class ChannelDataBuilder implements BuilderInterface
 
     public function build(array $buildSubject): array
     {
-        /** @var PaymentDataObject $paymentDataObject */
-        $paymentDataObject = SubjectReader::readPayment($buildSubject);
-        $payment = $paymentDataObject->getPayment();
-        /** @var Order $order */
-        $order = $payment->getOrder();
+        $order = SubjectReader::readPayment($buildSubject)->getPayment()->getOrder();
+        $stateData = $order->getQuoteId() ? $this->stateDataHelper->getStateData((int)$order->getQuoteId()) : [];
 
-        if ($order->getQuoteId()) {
-            $stateData = $this->stateDataHelper->getStateData((int)$order->getQuoteId());
-            $request['body']['channel'] = $stateData['channel'] ?? 'web';
-        }
-
-        return $request;
+        return [
+            'body' => [
+                'channel' => $stateData['channel'] ?? 'web'
+            ]
+        ];
     }
 }

--- a/Gateway/Request/CheckoutDataBuilder.php
+++ b/Gateway/Request/CheckoutDataBuilder.php
@@ -34,42 +34,18 @@ class CheckoutDataBuilder implements BuilderInterface
         AdyenBoletoConfigProvider::CODE
     ];
 
-    /**
-     * @var Data
-     */
-    private $adyenHelper;
+    private Data $adyenHelper;
 
-    /**
-     * @var CartRepositoryInterface
-     */
-    private $cartRepository;
+    private CartRepositoryInterface $cartRepository;
 
-    /**
-     * @var ChargedCurrency
-     */
-    private $chargedCurrency;
+    private ChargedCurrency $chargedCurrency;
 
-    /**
-     * @var Image
-     */
-    private $imageHelper;
-    /**
-     * @var StateData
-     */
-    private $stateData;
+    private Image $imageHelper;
 
-    /** @var Config */
-    private $configHelper;
+    private StateData $stateData;
 
-    /**
-     * CheckoutDataBuilder constructor.
-     * @param Data $adyenHelper
-     * @param StateData $stateData
-     * @param CartRepositoryInterface $cartRepository
-     * @param ChargedCurrency $chargedCurrency
-     * @param Image $imageHelper
-     * @param Config $configHelper
-     */
+    private Config $configHelper;
+
     public function __construct(
         Data $adyenHelper,
         StateData $stateData,
@@ -102,9 +78,9 @@ class CheckoutDataBuilder implements BuilderInterface
 
         // Initialize the request body with the current state data
         // Multishipping checkout uses the cc_number field for state data
-        $requestBody = $this->stateData->getStateData($order->getQuoteId());
+        $requestBody = $order->getQuoteId() ? $this->stateData->getStateData((int)$order->getQuoteId()) : [];
 
-        if (empty($requestBody) && !is_null($payment->getCcNumber())) {
+        if (!$requestBody && $payment->getCcNumber() !== null) {
             $requestBody = json_decode($payment->getCcNumber(), true);
         }
 

--- a/Gateway/Request/RecurringVaultDataBuilder.php
+++ b/Gateway/Request/RecurringVaultDataBuilder.php
@@ -48,7 +48,7 @@ class RecurringVaultDataBuilder implements BuilderInterface
         $details = json_decode($paymentToken->getTokenDetails() ?: '{}', true);
 
         // Initialize the request body with the current state data
-        $requestBody = $this->stateData->getStateData($order->getQuoteId());
+        $requestBody = $order->getQuoteId() ? $this->stateData->getStateData((int)$order->getQuoteId()) : [];
 
         // For now this will only be used by tokens created trough adyen_hpp payment methods
         if (array_key_exists(Vault::TOKEN_TYPE, $details)) {

--- a/Helper/Requests.php
+++ b/Helper/Requests.php
@@ -353,11 +353,14 @@ class Requests extends AbstractHelper
         }
 
         $storePaymentMethod = false;
+        $order = $payment->getOrder();
 
         // Initialize the request body with the current state data
         // Multishipping checkout uses the cc_number field for state data
-        $stateData = $this->stateData->getStateData($payment->getOrder()->getQuoteId()) ?:
-            (json_decode($payment->getCcNumber(), true) ?: []);
+        $stateData = $order->getQuoteId() ? $this->stateData->getStateData((int)$order->getQuoteId()) : [];
+        if (!$stateData) {
+            $stateData = json_decode($payment->getCcNumber(), true) ?: [];
+        }
 
         // If PayByLink
         // Else, if option to store token exists, get the value from the checkbox


### PR DESCRIPTION
**Description**
Fix the following error and improve code quality:

```
report.CRITICAL: Error when running a cron job {"exception":"[object] (RuntimeException(code: 0): Error when running a cron job at /app/x/vendor/magento/module-cron/Observer/ProcessCronQueueObserver.php:362, TypeError(code: 0): Argument 1 passed to Adyen\\Payment\\Helper\\StateData::getStateData() must be of the type int, null given, called in /app/x/vendor/adyen/module-payment/Gateway/Request/ChannelDataBuilder.php on line 38 at /app/x/vendor/adyen/module-payment/Helper/StateData.php:86)"} []
```


