### PR TITLE
Fix strategy 'Refund from last payment first' payment filter order

### DIFF
--- a/Model/ResourceModel/Order/Payment/Collection.php
+++ b/Model/ResourceModel/Order/Payment/Collection.php
@@ -83,7 +83,7 @@ class Collection extends \Magento\Framework\Model\ResourceModel\Db\Collection\Ab
     public function addPaymentFilterDescending($paymentId)
     {
         $this->addFieldToFilter('payment_id', $paymentId);
-        $this->getSelect()->order(['created_at DESC']);
+        $this->getSelect()->order(['created_at DESC', 'entity_id DESC']);
         return $this;
     }
 }


### PR DESCRIPTION
**Description**
In one of my projects, we are using `Refund from last payment first` for refund strategy. We noticed that there are a few order payments where the first refunded is still the first created row from `adyen_order_payment` table, which is not expected. Upon checking, they have the the same `created_at` value. I believe this issue doesn't always occur. 

**Tested scenarios**
- Current issue:
```sql
MariaDB [magento]> SELECT entity_id, pspreference, payment_id, payment_method, created_at FROM adyen_order_payment ORDER BY created_at DESC;
+-----------+--------------+------------+----------------+---------------------+
| entity_id | pspreference | payment_id | payment_method | created_at          |
+-----------+--------------+------------+----------------+---------------------+
|       225 | PSPREFXXXXX1 |        123 | svs            | 2023-06-03 20:38:07 |
|       226 | PSPREFXXXXX2 |        123 | mc             | 2023-06-03 20:38:07 |
+-----------+--------------+------------+----------------+---------------------+
```
- Expected fix:
```sql
MariaDB [magento]> SELECT entity_id, pspreference, payment_id, payment_method, created_at FROM adyen_order_payment ORDER BY created_at DESC, entity_id DESC;
+-----------+--------------+------------+----------------+---------------------+
| entity_id | pspreference | payment_id | payment_method | created_at          |
+-----------+--------------+------------+----------------+---------------------+
|       226 | PSPREFXXXXX2 |        123 | mc             | 2023-06-03 20:38:07 |
|       225 | PSPREFXXXXX1 |        123 | svs            | 2023-06-03 20:38:07 |
+-----------+--------------+------------+----------------+---------------------+
```

Fixes: N/A

Kindly close this PR if deemed unnecessary.
