### PR TITLE
[PW-6340] Use payment method svg logos instead of png

### DIFF
--- a/Helper/PaymentMethods.php
+++ b/Helper/PaymentMethods.php
@@ -486,28 +486,7 @@ class PaymentMethods extends AbstractHelper
                 ? self::METHODS_WITH_LOGO_FILE_MAPPING[$paymentMethod['type']]
                 : $paymentMethodCode;
 
-            $asset = $this->assetRepo->createAsset(
-                'Adyen_Payment::images/logos/' .
-                $paymentMethodCode . '.png',
-                $params
-            );
-
-            $placeholder = $this->assetSource->findSource($asset);
-
-            if ($placeholder) {
-                list($width, $height) = getimagesize($asset->getSourceFile());
-                $icon = [
-                    'url' => $asset->getUrl(),
-                    'width' => $width,
-                    'height' => $height
-                ];
-            } else {
-                $icon = [
-                    'url' => 'https://checkoutshopper-live.adyen.com/checkoutshopper/images/logos/medium/' . $paymentMethodCode . '.png',
-                    'width' => 77,
-                    'height' => 50
-                ];
-            }
+            $icon = $this->buildPaymentMethodIcon($paymentMethodCode, $params);
 
             $paymentMethodsExtraDetails[$paymentMethodCode]['icon'] = $icon;
 
@@ -894,5 +873,33 @@ class PaymentMethods extends AbstractHelper
         }
 
         return $status;
+    }
+
+    /**
+     * @param string $paymentMethodCode
+     * @param array $params
+     * @return array
+     * @throws LocalizedException
+     */
+    public function buildPaymentMethodIcon(string $paymentMethodCode, array $params): array
+    {
+        $svgAsset = $this->assetRepo->createAsset("Adyen_Payment::images/logos/$paymentMethodCode.svg", $params);
+        $pngAsset = $this->assetRepo->createAsset("Adyen_Payment::images/logos/$paymentMethodCode.png", $params);
+
+        if ($this->assetSource->findSource($svgAsset)) {
+            $asset = $svgAsset;
+        } elseif ($this->assetSource->findSource($pngAsset)) {
+            $asset = $pngAsset;
+        }
+
+        if (isset($asset)) {
+            list($width, $height) = getimagesize($asset->getSourceFile());
+            $icon = ['url' => $asset->getUrl(), 'width' => $width, 'height' => $height];
+        } else {
+            $url = "https://checkoutshopper-live.adyen.com/checkoutshopper/images/logos/$paymentMethodCode.svg";
+            $icon = ['url' => $url, 'width' => 77, 'height' => 50];
+        }
+
+        return $icon;
     }
 }

--- a/view/frontend/web/template/payment/hpp-form.html
+++ b/view/frontend/web/template/payment/hpp-form.html
@@ -30,7 +30,6 @@
             <label data-bind="attr: {'for': 'adyen_' + paymentMethod.methodIdentifier}" class="label">
 
                 <!-- ko if: icon -->
-
                 <img data-bind="attr: {
                             'src': icon.url,
                             'alt': paymentMethod.name + ' logo',

--- a/view/frontend/web/template/payment/hpp-form.html
+++ b/view/frontend/web/template/payment/hpp-form.html
@@ -30,9 +30,12 @@
             <label data-bind="attr: {'for': 'adyen_' + paymentMethod.methodIdentifier}" class="label">
 
                 <!-- ko if: icon -->
+
                 <img data-bind="attr: {
                             'src': icon.url,
-                            'alt': paymentMethod.name + ' logo'
+                            'alt': paymentMethod.name + ' logo',
+                            'hight': icon.height,
+                            'width': icon.width
                             }">
                 <!--/ko-->
 

--- a/view/frontend/web/template/payment/multishipping/hpp-form.html
+++ b/view/frontend/web/template/payment/multishipping/hpp-form.html
@@ -13,7 +13,9 @@
             <!-- ko if: icon -->
             <img data-bind="attr: {
                             'src': icon.url,
-                            'alt': paymentMethod.methodIdentifier + ' logo'
+                            'alt': paymentMethod.methodIdentifier + ' logo',
+                            'width': icon.width,
+                            'hight': icon.height
                             }">
             <!--/ko-->
 


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
It's recommended that the SVG version of the logo should be used instead of the PNG. 

**Tested scenarios**

Manuel test shows in checkout\payment step that if you have payment method icon in your assets in SVG or PNG then it will show it, if not it will get the SVG version from Adyen payment method logos in SVG format

See: https://docs.adyen.com/online-payments/build-your-integration?platform=iOS&integration=API+Only&version=70#payment-method-logos
