### PR TITLE
Remove adyen_hpp config path for E2E pipeline

### DIFF
--- a/.github/Makefile
+++ b/.github/Makefile
@@ -23,7 +23,7 @@ install:
 # Configuration
 configure: n98-magerun2.phar
 	bin/magento config:set payment/adyen_abstract/demo_mode 1
-	bin/magento config:set payment/adyen_hpp/active 1
+	bin/magento config:set payment/adyen_abstract/payment_methods_active 1
 	bin/magento config:set payment/adyen_cc/active 1
 	bin/magento config:set payment/adyen_oneclick/active 1
 	bin/magento config:set payment/adyen_oneclick/card_mode 'Magento Vault'

--- a/.github/Makefile
+++ b/.github/Makefile
@@ -23,7 +23,6 @@ install:
 # Configuration
 configure: n98-magerun2.phar
 	bin/magento config:set payment/adyen_abstract/demo_mode 1
-	bin/magento config:set payment/adyen_abstract/payment_methods_active 1
 	bin/magento config:set payment/adyen_oneclick/active 1
 	bin/magento config:set payment/adyen_oneclick/card_mode 'Magento Vault'
 	bin/magento config:set payment/adyen_oneclick/card_type 'CardOnFile'

--- a/.github/Makefile
+++ b/.github/Makefile
@@ -24,7 +24,6 @@ install:
 configure: n98-magerun2.phar
 	bin/magento config:set payment/adyen_abstract/demo_mode 1
 	bin/magento config:set payment/adyen_abstract/payment_methods_active 1
-	bin/magento config:set payment/adyen_cc/active 1
 	bin/magento config:set payment/adyen_oneclick/active 1
 	bin/magento config:set payment/adyen_oneclick/card_mode 'Magento Vault'
 	bin/magento config:set payment/adyen_oneclick/card_type 'CardOnFile'


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Config path `payment/adyen_hpp/active` and `payment/adyen_cc/active` were replaced with `payment/adyen_abstract/payment_methods_active`.
