### PR TITLE
[PW-8428] SVS Giftcard - Cancel the order after unsuccessful payment

### DIFF
--- a/Controller/Process/Result.php
+++ b/Controller/Process/Result.php
@@ -225,12 +225,10 @@ class Result extends Action
 
         if ($response) {
             $result = $this->validateResponse($response);
-            $paymentMethodType = $this->_order->getPayment()->getAdditionalInformation('action')['paymentMethodType'];
-
-            if (isset($paymentMethodType) && $paymentMethodType === 'giftcard' && $response['resultCode'] === 'cancelled') {
-                $status = Order::STATE_CANCELED;
-                $this->orderHelper->holdCancelOrder($this->_order, true);
-                $this->_order->setStatus($status);
+            $order = $this->_order;
+            $paymentBrandCode = $order->getPayment()->getAdditionalInformation()['brand_code'];
+            if ($response['resultCode'] === 'cancelled' && isset($paymentBrandCode) && $paymentBrandCode === 'svs') {
+                $this->dataHelper->cancelOrder($order);
             }
 
             // Adjust the success path, fail path, and restore quote based on if it is a multishipping quote

--- a/Controller/Process/Result.php
+++ b/Controller/Process/Result.php
@@ -14,7 +14,6 @@ namespace Adyen\Payment\Controller\Process;
 use Adyen\Payment\Exception\PaymentMethodException;
 use Adyen\Payment\Helper\Config;
 use Adyen\Payment\Helper\Data;
-use Adyen\Payment\Helper\Order as OrderHelper;
 use Adyen\Payment\Helper\Idempotency;
 use Adyen\Payment\Helper\PaymentMethods\AbstractWalletPaymentMethod;
 use Adyen\Payment\Helper\PaymentMethods\PaymentMethodFactory;
@@ -66,11 +65,6 @@ class Result extends Action
      * @var Data
      */
     protected $_adyenHelper;
-
-    /**
-     * @var OrderHelper
-     */
-    protected $orderHelper;
 
     /**
      * @var OrderFactory
@@ -157,7 +151,6 @@ class Result extends Action
     /**
      * @param Context $context
      * @param Data $adyenHelper
-     * @param OrderHelper $orderHelper
      * @param OrderFactory $orderFactory
      * @param HistoryFactory $orderHistoryFactory
      * @param Session $session
@@ -177,7 +170,6 @@ class Result extends Action
     public function __construct(
         Context $context,
         Data $adyenHelper,
-        OrderHelper $orderHelper,
         OrderFactory $orderFactory,
         HistoryFactory $orderHistoryFactory,
         Session $session,
@@ -197,7 +189,6 @@ class Result extends Action
         parent::__construct($context);
 
         $this->_adyenHelper = $adyenHelper;
-        $this->orderHelper = $orderHelper;
         $this->_orderFactory = $orderFactory;
         $this->_orderHistoryFactory = $orderHistoryFactory;
         $this->_session = $session;

--- a/Controller/Process/Result.php
+++ b/Controller/Process/Result.php
@@ -217,8 +217,10 @@ class Result extends Action
         if ($response) {
             $result = $this->validateResponse($response);
             $order = $this->_order;
-            $paymentBrandCode = $order->getPayment()->getAdditionalInformation()['brand_code'];
-            if ($response['resultCode'] === 'cancelled' && isset($paymentBrandCode) && $paymentBrandCode === 'svs') {
+            $additionalInformation = $order->getPayment()->getAdditionalInformation();
+            $resultCode = isset($response['resultCode']) ? $response['resultCode'] : null;
+            $paymentBrandCode = isset($additionalInformation['brand_code']) ? $additionalInformation['brand_code'] : null;
+            if ($resultCode === 'cancelled' && $paymentBrandCode === 'svs') {
                 $this->dataHelper->cancelOrder($order);
             }
 


### PR DESCRIPTION
**Description**
This PR improves the SVS giftcard cancellation flow. Usually, when a paymentDetails call happens to Adyen platform (when the shopper is redirected in order to complete the payment), an offer is created on Adyen side. However, this does not happen with SVS Giftcards. It is an exception. Therefore, since there is no offer present on Adyen side, Adyen will not send out OFFER_CLOSED notification for payments with this payment method. This is important, as we are relying on that notification to eventually close the order in Magento admin panel.

With this PR, we are now cancelling the SVS Giftcard payments immediately after the synchronous API response as oppose to relying on the notifications.

There is still an edge case which can't be handled within the plugin -> cases where the shoppers completely abandon the payment session after being redirected to SVS hosted page (for example, closing the tab). As there is no notification coming from Adyen platform for this case (as no offer is created) and the paymentDetails call is not made due to the shopper abandoning the session prematurely, these orders will still stay open and have to be closed manually in the admin panel.

**Tested scenarios**
Proceed with a payment with an SVS Giftcard and when redirected from the checkout page to SVS hosted page, click 'Previous'. Confirm that the order has a Cancelled status.
