### PR TITLE
[PW-8410] Call to undefined getQuoteId() in RecurringVaultDataBuilder

### DIFF
--- a/Gateway/Request/RecurringVaultDataBuilder.php
+++ b/Gateway/Request/RecurringVaultDataBuilder.php
@@ -15,6 +15,7 @@ use Adyen\Payment\Helper\StateData;
 use Adyen\Payment\Helper\Vault;
 use Adyen\Payment\Model\Ui\AdyenCcConfigProvider;
 use Adyen\Payment\Model\Ui\AdyenOneclickConfigProvider;
+use Magento\Quote\Model\ResourceModel\Quote\CollectionFactory;
 use Magento\Payment\Gateway\Data\PaymentDataObject;
 use Magento\Payment\Gateway\Helper\SubjectReader;
 use Magento\Payment\Gateway\Request\BuilderInterface;
@@ -26,9 +27,18 @@ class RecurringVaultDataBuilder implements BuilderInterface
      */
     private $stateData;
 
-    public function __construct(StateData $stateData)
+    /**
+     * @var CollectionFactory
+     */
+    private $quoteCollectionFactory;
+
+    public function __construct(
+        StateData $stateData,
+        CollectionFactory $quoteCollectionFactory
+    )
     {
         $this->stateData = $stateData;
+        $this->quoteCollectionFactory = $quoteCollectionFactory;
     }
 
     /**
@@ -42,13 +52,15 @@ class RecurringVaultDataBuilder implements BuilderInterface
         $paymentDataObject = SubjectReader::readPayment($buildSubject);
         $payment = $paymentDataObject->getPayment();
         $paymentMethod = $payment->getMethodInstance();
-        $order = $paymentDataObject->getOrder();
         $extensionAttributes = $payment->getExtensionAttributes();
         $paymentToken = $extensionAttributes->getVaultPaymentToken();
         $details = json_decode($paymentToken->getTokenDetails() ?: '{}', true);
+        $quoteCollection = $this->quoteCollectionFactory->create();
+        $quoteCollection->setOrder('entity_id', 'desc');
+        $quote = $quoteCollection->getFirstItem();
 
         // Initialize the request body with the current state data
-        $requestBody = $this->stateData->getStateData($order->getQuoteId());
+        $requestBody = $this->stateData->getStateData($quote->getId());
 
         // For now this will only be used by tokens created trough adyen_hpp payment methods
         if (array_key_exists(Vault::TOKEN_TYPE, $details)) {

--- a/Gateway/Request/RecurringVaultDataBuilder.php
+++ b/Gateway/Request/RecurringVaultDataBuilder.php
@@ -15,7 +15,6 @@ use Adyen\Payment\Helper\StateData;
 use Adyen\Payment\Helper\Vault;
 use Adyen\Payment\Model\Ui\AdyenCcConfigProvider;
 use Adyen\Payment\Model\Ui\AdyenOneclickConfigProvider;
-use Magento\Quote\Model\ResourceModel\Quote\CollectionFactory;
 use Magento\Payment\Gateway\Data\PaymentDataObject;
 use Magento\Payment\Gateway\Helper\SubjectReader;
 use Magento\Payment\Gateway\Request\BuilderInterface;
@@ -27,18 +26,9 @@ class RecurringVaultDataBuilder implements BuilderInterface
      */
     private $stateData;
 
-    /**
-     * @var CollectionFactory
-     */
-    private $quoteCollectionFactory;
-
-    public function __construct(
-        StateData $stateData,
-        CollectionFactory $quoteCollectionFactory
-    )
+    public function __construct(StateData $stateData)
     {
         $this->stateData = $stateData;
-        $this->quoteCollectionFactory = $quoteCollectionFactory;
     }
 
     /**
@@ -52,15 +42,13 @@ class RecurringVaultDataBuilder implements BuilderInterface
         $paymentDataObject = SubjectReader::readPayment($buildSubject);
         $payment = $paymentDataObject->getPayment();
         $paymentMethod = $payment->getMethodInstance();
+        $order = $payment->getOrder();
         $extensionAttributes = $payment->getExtensionAttributes();
         $paymentToken = $extensionAttributes->getVaultPaymentToken();
         $details = json_decode($paymentToken->getTokenDetails() ?: '{}', true);
-        $quoteCollection = $this->quoteCollectionFactory->create();
-        $quoteCollection->setOrder('entity_id', 'desc');
-        $quote = $quoteCollection->getFirstItem();
 
         // Initialize the request body with the current state data
-        $requestBody = $this->stateData->getStateData($quote->getId());
+        $requestBody = $this->stateData->getStateData($order->getQuoteId());
 
         // For now this will only be used by tokens created trough adyen_hpp payment methods
         if (array_key_exists(Vault::TOKEN_TYPE, $details)) {


### PR DESCRIPTION
**Description**
When using our module together with Braintree the following error occurs when using a 3DS stored card with Vault mode enabled in admin panel:
`Call to undefined method PayPal\Braintree\Gateway\Data\Order\OrderAdapter::getQuoteId()` caused by `RecurringVaultDataBuilder.php`.

This PR changes the way we are obtaining the quoteId in order to overcome the conflict with Braintree module.

**Tested scenarios**
- test a transaction with a stored 3DS2 card

Fixes  #2053
