### PR TITLE
Switch logic between X-Forwarded-For and standard RemoteIP

### DIFF
--- a/Gateway/Request/CustomerIpDataBuilder.php
+++ b/Gateway/Request/CustomerIpDataBuilder.php
@@ -43,10 +43,10 @@ class CustomerIpDataBuilder implements BuilderInterface
         /** @var \Magento\Payment\Gateway\Data\PaymentDataObject $paymentDataObject */
         $paymentDataObject = \Magento\Payment\Gateway\Helper\SubjectReader::readPayment($buildSubject);
         $order = $paymentDataObject->getPayment()->getOrder();
-        $shopperIp = $order->getRemoteIp();
+        $shopperIp = $order->getXForwardedFor();
 
         if (empty($shopperIp)) {
-            $shopperIp = $order->getXForwardedFor();
+            $shopperIp = $order->getRemoteIp();
         }
 
         $request['body'] = $this->adyenRequestsHelper->buildCustomerIpData($shopperIp, []);


### PR DESCRIPTION


<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
As I understand it:

- Adyen wants to get the _shopper IP_
- The X-Forwarded-For header is used to store the _original Client IP_

So I think the logic should be as follows:
If X-Forwarded-For header is present, this should be the client IP. If no X-Forwarded-For header is present, the standard 'remote IP' should be the client IP.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

Fixes  <!-- #-prefixed github issue number -->
