### PR TITLE
[PW-8478] Create a CLI command to enable all payment methods

### DIFF
--- a/.github/Makefile
+++ b/.github/Makefile
@@ -23,15 +23,11 @@ install:
 # Configuration
 configure: n98-magerun2.phar
 	bin/magento config:set payment/adyen_abstract/demo_mode 1
-	bin/magento config:set payment/adyen_hpp/active 1
-	bin/magento config:set payment/adyen_cc/active 1
-	bin/magento config:set payment/adyen_oneclick/active 1
+	bin/magento adyen:enablepaymentmethods:run
 	bin/magento config:set payment/adyen_oneclick/card_mode 'Magento Vault'
 	bin/magento config:set payment/adyen_oneclick/card_type 'CardOnFile'
 	bin/magento config:set payment/adyen_abstract/has_holder_name 1
-	bin/magento config:set payment/adyen_boleto/active 1
 	bin/magento config:set payment/adyen_boleto/boletotypes 'boletobancario_santander'
-	bin/magento config:set payment/adyen_pay_by_link/active 1
 	bin/magento config:set payment/adyen_pay_by_link/days_to_expire 5
 	bin/magento config:set payment/adyen_giving/active 1
 	bin/magento config:set payment/adyen_giving/charity_description 'test'
@@ -40,7 +36,6 @@ configure: n98-magerun2.phar
 	bin/magento config:set payment/adyen_giving/donation_amounts '1,5,10'
 	bin/magento config:set payment/adyen_giving/background_image ''
 	bin/magento config:set payment/adyen_abstract/merchant_account "${ADYEN_MERCHANT}"
-	bin/magento config:set payment/adyen_moto/active 1
 	bin/magento config:set payment/adyen_abstract/notifications_ip_check 0
 	./n98-magerun2.phar config:store:set --encrypt payment/adyen_abstract/api_key_test "${ADYEN_API_KEY}" > /dev/null
 	bin/magento config:set payment/adyen_abstract/client_key_test "${ADYEN_CLIENT_KEY}"

--- a/Console/Command/EnablePaymentMethodsCommand.php
+++ b/Console/Command/EnablePaymentMethodsCommand.php
@@ -15,10 +15,7 @@ class EnablePaymentMethodsCommand extends Command
      */
     private $paymentMethods;
 
-    /**
-     * @var Config
-     */
-    private $configHelper;
+    private Config $configHelper;
 
     public function __construct(
         PaymentMethods $paymentMethods,

--- a/Console/Command/EnablePaymentMethodsCommand.php
+++ b/Console/Command/EnablePaymentMethodsCommand.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Adyen\Payment\Console\Command;
+
+use Adyen\Payment\Helper\PaymentMethods;
+use Adyen\Payment\Helper\Config;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class EnablePaymentMethodsCommand extends Command
+{
+    /**
+     * @var PaymentMethods
+     */
+    private $paymentMethods;
+
+    /**
+     * @var Config
+     */
+    private $configHelper;
+
+    public function __construct(
+        PaymentMethods $paymentMethods,
+        Config $configHelper
+    )
+    {
+        $this->paymentMethods = $paymentMethods;
+        $this->configHelper = $configHelper;
+        parent::__construct();
+    }
+
+    protected function configure()
+    {
+        $this->setName('adyen:enablepaymentmethods:run');
+        parent::configure();
+    }
+
+    /**
+     * @throws \Exception
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $output->writeln('Starting enabling payment methods.');
+        $availablePaymentMethods = $this->paymentMethods->getAdyenPaymentMethods();
+
+        foreach ($availablePaymentMethods as $paymentMethod) {
+            $value = '1';
+            $field = 'active';
+            $this->configHelper->setConfigData($value, $field, $paymentMethod);
+            $output->writeln("Enabled payment method: {$paymentMethod}");
+        }
+
+        $output->writeln('Completed enabling payment methods.');
+    }
+}

--- a/Console/Command/EnablePaymentMethodsCommand.php
+++ b/Console/Command/EnablePaymentMethodsCommand.php
@@ -17,8 +17,7 @@ class EnablePaymentMethodsCommand extends Command
     public function __construct(
         PaymentMethods $paymentMethods,
         Config $configHelper
-    )
-    {
+    ) {
         $this->paymentMethods = $paymentMethods;
         $this->configHelper = $configHelper;
         parent::__construct();

--- a/Console/Command/EnablePaymentMethodsCommand.php
+++ b/Console/Command/EnablePaymentMethodsCommand.php
@@ -10,10 +10,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class EnablePaymentMethodsCommand extends Command
 {
-    /**
-     * @var PaymentMethods
-     */
-    private $paymentMethods;
+    private PaymentMethods $paymentMethods;
 
     private Config $configHelper;
 

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1391,6 +1391,7 @@
         <arguments>
             <argument name="commands" xsi:type="array">
                 <item name="adyen_webhookprocessorcommand" xsi:type="object">Adyen\Payment\Console\Command\WebhookProcessorCommand</item>
+                <item name="adyen_enablepaymentmethodscommand" xsi:type="object">Adyen\Payment\Console\Command\EnablePaymentMethodsCommand</item>
             </argument>
         </arguments>
     </type>


### PR DESCRIPTION
**Description**
E2E tests expect that payment methods should be enabled beforehand. However, after implementing separate payment methods to `rc-v9`, we removed configuration paths `payment/adyen_cc/active` and `payment/adyen_hpp/active` from admin configuration page and implement one path for all payment methods `payment/adyen_abstract/payment_methods_active`.
This PR creates a new CLI command to enable/disable all payment methods at the same time and uses this command in the Makefile.

**Tested scenarios**
Running the command and confirming the values of the active fields for each payment method that is returned from the config.xml is indeed set to 1.
Pushing the PR and make sure the E2E tests in the pipeline don't throw any errors related to enabling the payment method config paths -> check this part of the E2E test passing [here](https://github.com/Adyen/adyen-magento2/actions/runs/5454741449/jobs/9925266572?pr=2102#step:7:1059)