### PR TITLE
[ECP-8484] - Add support for tokenization for ApplePay using subscription and unscheduledcard-on-file

### DIFF
--- a/Helper/PaymentMethods/ApplePayPaymentMethod.php
+++ b/Helper/PaymentMethods/ApplePayPaymentMethod.php
@@ -44,11 +44,11 @@ class ApplePayPaymentMethod extends AbstractWalletPaymentMethod
 
     public function supportsSubscription(): bool
     {
-        return false;
+        return true;
     }
 
     public function supportsUnscheduledCardOnFile(): bool
     {
-        return false;
+        return true;
     }
 }

--- a/Model/Config/Source/TokenizedPaymentMethods.php
+++ b/Model/Config/Source/TokenizedPaymentMethods.php
@@ -14,11 +14,11 @@ class TokenizedPaymentMethods implements OptionSourceInterface
     {
         return [
             /** TODO: These PMs can be enabled for recurring purposes once tested */
-            /*[
+            [
                 'value' => PaymentMethods\ApplePayPaymentMethod::TX_VARIANT,
                 'label' => PaymentMethods\ApplePayPaymentMethod::NAME
             ],
-            [
+            /*[
                 'value' => PaymentMethods\AmazonPayPaymentMethod::TX_VARIANT,
                 'label' => PaymentMethods\AmazonPayPaymentMethod::NAME
             ],*/


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->

In order to be able to handle recurring transactions for ApplePay we need to enable unscheduled card on file and subscription as these two are best practice for wallet payment methods. 

**Tested scenarios**
<!-- Description of tested scenarios -->

Tested a ApplePay payment which was tokenized. 


<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

Fixes  <!-- #-prefixed github issue number -->

#2087
