### PR TITLE
[PW-8520] Fix used country code for paymentMethods call

### DIFF
--- a/Api/AdyenPaymentMethodManagementInterface.php
+++ b/Api/AdyenPaymentMethodManagementInterface.php
@@ -3,7 +3,7 @@
  *
  * Adyen Payment module (https://www.adyen.com/)
  *
- * Copyright (c) 2023 Adyen BV (https://www.adyen.com/)
+ * Copyright (c) 2023 Adyen N.V. (https://www.adyen.com/)
  * See LICENSE.txt for license details.
  *
  * Author: Adyen <magento@adyen.com>
@@ -21,7 +21,8 @@ interface AdyenPaymentMethodManagementInterface
      *
      * @param string $cartId
      * @param string|null $shopperLocale
+     * @param string|null $country
      * @return string
      */
-    public function getPaymentMethods(string $cartId, ?string $shopperLocale = null) :string;
+    public function getPaymentMethods(string $cartId, ?string $shopperLocale = null, ?string $country = null) :string;
 }

--- a/Api/GuestAdyenPaymentMethodManagementInterface.php
+++ b/Api/GuestAdyenPaymentMethodManagementInterface.php
@@ -3,15 +3,13 @@
  *
  * Adyen Payment module (https://www.adyen.com/)
  *
- * Copyright (c) 2023 Adyen BV (https://www.adyen.com/)
+ * Copyright (c) 2023 Adyen N.V. (https://www.adyen.com/)
  * See LICENSE.txt for license details.
  *
  * Author: Adyen <magento@adyen.com>
  */
 
 namespace Adyen\Payment\Api;
-
-use Magento\Quote\Api\Data\AddressInterface;
 
 /**
  * Interface for fetching payment methods from Adyen for guest customers
@@ -23,7 +21,8 @@ interface GuestAdyenPaymentMethodManagementInterface
      *
      * @param string $cartId
      * @param string|null $shopperLocale
+     * @param string|null $country
      * @return string
      */
-    public function getPaymentMethods(string $cartId, ?string $shopperLocale = null): string;
+    public function getPaymentMethods(string $cartId, ?string $shopperLocale = null, ?string $country = null): string;
 }

--- a/Block/Checkout/Multishipping/Success.php
+++ b/Block/Checkout/Multishipping/Success.php
@@ -145,7 +145,8 @@ class Success extends \Magento\Multishipping\Block\Checkout\Success
 
     public function getClientKey()
     {
-        return $this->configHelper->getClientKey();
+        $environment = $this->configHelper->isDemoMode() ? 'test' : 'live';
+        return $this->configHelper->getClientKey($environment);
     }
 
     public function getEnvironment()

--- a/Block/Checkout/Success.php
+++ b/Block/Checkout/Success.php
@@ -182,7 +182,8 @@ class Success extends Template
 
     public function getClientKey()
     {
-        return $this->configHelper->getClientKey();
+        $environment = $this->configHelper->isDemoMode() ? 'test' : 'live';
+        return $this->configHelper->getClientKey($environment);
     }
 
     public function getEnvironment()

--- a/Block/Form/Cc.php
+++ b/Block/Form/Cc.php
@@ -135,7 +135,8 @@ class Cc extends \Magento\Payment\Block\Form\Cc
      */
     public function getClientKey()
     {
-        return $this->configHelper->getClientKey();
+        $environment = $this->configHelper->isDemoMode() ? 'test' : 'live';
+        return $this->configHelper->getClientKey($environment);
     }
 
     /**

--- a/Helper/PaymentMethods.php
+++ b/Helper/PaymentMethods.php
@@ -3,7 +3,7 @@
  *
  * Adyen Payment module (https://www.adyen.com/)
  *
- * Copyright (c) 2015 Adyen BV (https://www.adyen.com/)
+ * Copyright (c) 2023 Adyen N.V. (https://www.adyen.com/)
  * See LICENSE.txt for license details.
  *
  * Author: Adyen <magento@adyen.com>
@@ -22,8 +22,6 @@ use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\App\Helper\AbstractHelper;
 use Magento\Framework\App\Helper\Context;
 use Magento\Framework\App\RequestInterface;
-use Magento\Framework\Exception\LocalizedException;
-use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\Locale\ResolverInterface;
 use Magento\Framework\Serialize\SerializerInterface;
 use Magento\Framework\View\Asset\Repository;
@@ -35,23 +33,18 @@ use Magento\Quote\Api\CartRepositoryInterface;
 use Magento\Sales\Model\Order;
 use Adyen\Payment\Helper\Data as AdyenDataHelper;
 use Magento\Store\Model\ScopeInterface;
+use Magento\Store\Model\Store;
 
-/**
- * @SuppressWarnings(PHPMD.LongVariable)
- */
 class PaymentMethods extends AbstractHelper
 {
     const ADYEN_HPP = 'adyen_hpp';
     const ADYEN_CC = 'adyen_cc';
     const ADYEN_ONE_CLICK = 'adyen_oneclick';
     const ADYEN_PAY_BY_LINK = 'adyen_pay_by_link';
-
     const ADYEN_PREFIX = 'adyen_';
-
     const METHODS_WITH_BRAND_LOGO = [
         "giftcard"
     ];
-
     const METHODS_WITH_LOGO_FILE_MAPPING = [
         "scheme" => "card"
     ];
@@ -59,84 +52,23 @@ class PaymentMethods extends AbstractHelper
     const FUNDING_SOURCE_DEBIT = 'debit';
     const FUNDING_SOURCE_CREDIT = 'credit';
 
-    /**
-     * @var CartRepositoryInterface
-     */
-    protected $quoteRepository;
-
-    /**
-     * @var ScopeConfigInterface $config
-     */
-    protected $config;
-
-    /**
-     * @var Data
-     */
-    protected $adyenHelper;
-
-    /**
-     * @var MagentoDataHelper
-     */
-    private $dataHelper;
-
-    /**
-     * @var ResolverInterface
-     */
-    protected $localeResolver;
-
-    /**
-     * @var AdyenLogger
-     */
-    protected $adyenLogger;
-
-    /**
-     * @var AdyenDataHelper
-     */
-    protected $adyenDataHelper;
-
-    /**
-     * @var Repository
-     */
-    protected $assetRepo;
-
-    /**
-     * @var RequestInterface
-     */
-    protected $request;
-
-    /**
-     * @var Source
-     */
-    protected $assetSource;
-
-    /**
-     * @var DesignInterface
-     */
-    protected $design;
-
-    /**
-     * @var ThemeProviderInterface
-     */
-    protected $themeProvider;
-
-    /**
-     * @var \Magento\Quote\Model\Quote
-     */
-    protected $quote;
-
-    /**
-     * @var ChargedCurrency
-     */
-    private $chargedCurrency;
-
-    /** @var Config */
-    private $configHelper;
-
-    /** @var ManualCapture  */
-    private $manualCapture;
-
-    /** @var SerializerInterface */
-    private $serializer;
+    protected CartRepositoryInterface $quoteRepository;
+    protected ScopeConfigInterface $config;
+    protected Data $adyenHelper;
+    private MagentoDataHelper $dataHelper;
+    protected ResolverInterface $localeResolver;
+    protected AdyenLogger $adyenLogger;
+    protected Data $adyenDataHelper;
+    protected Repository $assetRepo;
+    protected RequestInterface $request;
+    protected Source $assetSource;
+    protected DesignInterface $design;
+    protected ThemeProviderInterface $themeProvider;
+    protected \Magento\Quote\Model\Quote $quote;
+    private ChargedCurrency $chargedCurrency;
+    private Config $configHelper;
+    private ManualCapture $manualCapture;
+    private SerializerInterface $serializer;
 
     public function __construct(
         Context $context,
@@ -176,7 +108,7 @@ class PaymentMethods extends AbstractHelper
         $this->adyenDataHelper = $adyenDataHelper;
     }
 
-    public function getPaymentMethods(int $quoteId, string $country = null, ?string $shopperLocale = null): string
+    public function getPaymentMethods(int $quoteId, ?string $country = null, ?string $shopperLocale = null): string
     {
         // get quote from quoteId
         $quote = $this->quoteRepository->getActive($quoteId);
@@ -190,20 +122,11 @@ class PaymentMethods extends AbstractHelper
         return $this->fetchPaymentMethods($country, $shopperLocale);
     }
 
-    /**
-     * @param string $methodCode
-     * @return bool
-     */
     public function isAdyenPayment(string $methodCode): bool
     {
         return in_array($methodCode, $this->getAdyenPaymentMethods(), true);
     }
 
-    /**
-     * Returns an array of Adyen payment method codes
-     *
-     * @return string[]
-     */
     public function getAdyenPaymentMethods() : array
     {
         $paymentMethods = $this->dataHelper->getPaymentMethodList();
@@ -219,13 +142,6 @@ class PaymentMethods extends AbstractHelper
         return array_keys($filtered);
     }
 
-    /**
-     * @param string|null $country
-     * @param string|null $shopperLocale
-     * @return string
-     * @throws AdyenException
-     * @throws LocalizedException
-     */
     protected function fetchPaymentMethods(?string $country = null, ?string $shopperLocale = null): string
     {
         $quote = $this->getQuote();
@@ -236,7 +152,7 @@ class PaymentMethods extends AbstractHelper
             return json_encode([]);
         }
 
-        $requestData = $this->getPaymentMethodsRequest($merchantAccount, $store, $quote, $country, $shopperLocale);
+        $requestData = $this->getPaymentMethodsRequest($merchantAccount, $store, $quote, $shopperLocale, $country);
         $responseData = $this->getPaymentMethodsResponse($requestData, $store);
         if (empty($responseData['paymentMethods'])) {
             return json_encode([]);
@@ -258,11 +174,7 @@ class PaymentMethods extends AbstractHelper
         return json_encode($response);
     }
 
-    /**
-     * @return float
-     * @throws \Exception
-     */
-    protected function getCurrentPaymentAmount()
+    protected function getCurrentPaymentAmount(): float
     {
         $total = $this->chargedCurrency->getQuoteAmountCurrency($this->getQuote())->getAmount();
 
@@ -290,21 +202,11 @@ class PaymentMethods extends AbstractHelper
         );
     }
 
-    /**
-     * @param $store
-     * @return string
-     */
-    protected function getCurrentCountryCode($store): string
+    protected function getCurrentCountryCode(Store $store): string
     {
-        // if fixed countryCode is setup in config use this
-        $countryCode = $this->configHelper->getAdyenHppConfigData('country_code', $store->getId());
-
-        if ($countryCode != "") {
-            return $countryCode;
-        }
-
         $quote = $this->getQuote();
         $billingAddressCountry = $quote->getBillingAddress()->getCountryId();
+
         // If customer is guest, billing address country might not be set yet
         if (isset($billingAddressCountry)) {
             return $billingAddressCountry;
@@ -323,13 +225,7 @@ class PaymentMethods extends AbstractHelper
         return "";
     }
 
-    /**
-     * @param $requestParams
-     * @param $store
-     * @return array
-     * @throws AdyenException
-     */
-    protected function getPaymentMethodsResponse($requestParams, $store)
+    protected function getPaymentMethodsResponse(array $requestParams, Store $store): array
     {
         // initialize the adyen client
         $client = $this->adyenHelper->initializeAdyenClient($store->getId());
@@ -356,50 +252,34 @@ class PaymentMethods extends AbstractHelper
         return $responseData;
     }
 
-    /**
-     * @return \Magento\Quote\Model\Quote
-     */
-    protected function getQuote()
+    protected function getQuote(): \Magento\Quote\Model\Quote
     {
         return $this->quote;
     }
 
-    /**
-     * @param \Magento\Quote\Model\Quote $quote
-     */
-    protected function setQuote(\Magento\Quote\Model\Quote $quote)
+    protected function setQuote(\Magento\Quote\Model\Quote $quote): void
     {
         $this->quote = $quote;
     }
 
-    /**
-     * @return int
-     */
-    protected function getCurrentShopperReference()
+    protected function getCurrentShopperReference(): int
     {
         return $this->getQuote()->getCustomerId();
     }
 
-    /**
-     * @param $merchantAccount
-     * @param \Magento\Store\Model\Store $store
-     * @param \Magento\Quote\Model\Quote $quote
-     * @param string|null $shopperLocale
-     * @return array
-     * @throws \Exception
-     */
     protected function getPaymentMethodsRequest(
         $merchantAccount,
-        \Magento\Store\Model\Store $store,
+        Store $store,
         \Magento\Quote\Model\Quote $quote,
-        ?string $shopperLocale = null
+        ?string $shopperLocale = null,
+        ?string $country = null
     ): array {
         $currencyCode = $this->chargedCurrency->getQuoteAmountCurrency($quote)->getCurrencyCode();
 
         $paymentMethodRequest = [
             "channel" => "Web",
             "merchantAccount" => $merchantAccount,
-            "countryCode" => $this->getCurrentCountryCode($store),
+            "countryCode" => $country ?? $this->getCurrentCountryCode($store),
             "shopperLocale" => $shopperLocale ?: $this->adyenHelper->getCurrentLocaleCode($store->getId()),
             "amount" => [
                 "currency" => $currencyCode
@@ -426,13 +306,7 @@ class PaymentMethods extends AbstractHelper
         return $paymentMethodRequest;
     }
 
-    /**
-     * @param $paymentMethods
-     * @param array $paymentMethodsExtraDetails
-     * @return array
-     * @throws LocalizedException
-     */
-    protected function showLogosPaymentMethods($paymentMethods, array $paymentMethodsExtraDetails)
+    protected function showLogosPaymentMethods(array $paymentMethods, array $paymentMethodsExtraDetails): array
     {
         if (!$this->adyenHelper->showLogos()) {
             return $paymentMethodsExtraDetails;
@@ -500,8 +374,10 @@ class PaymentMethods extends AbstractHelper
         return $paymentMethodsExtraDetails;
     }
 
-    protected function addExtraConfigurationToPaymentMethods($paymentMethods, array $paymentMethodsExtraDetails)
-    {
+    protected function addExtraConfigurationToPaymentMethods(
+        array $paymentMethods,
+        array $paymentMethodsExtraDetails
+    ): array {
         $quote = $this->getQuote();
         $currencyCode = $this->chargedCurrency->getQuoteAmountCurrency($quote)->getCurrencyCode();
         $amountValue = $this->adyenHelper->formatAmount($this->getCurrentPaymentAmount(), $currencyCode);
@@ -521,12 +397,7 @@ class PaymentMethods extends AbstractHelper
         return $paymentMethodsExtraDetails;
     }
 
-    /**
-     * Checks if a payment is wallet payment method
-     * @param $notificationPaymentMethod
-     * @return bool
-     */
-    public function isWalletPaymentMethod($notificationPaymentMethod): bool
+    public function isWalletPaymentMethod(string $notificationPaymentMethod): bool
     {
         $walletPaymentMethods = [
             'googlepay',
@@ -541,24 +412,11 @@ class PaymentMethods extends AbstractHelper
         return in_array($notificationPaymentMethod, $walletPaymentMethods);
     }
 
-    /**
-     * Check if the method of the passed payment is equal to the method passed in this function
-     *
-     * @param $payment
-     * @param string $method
-     * @return bool
-     */
-    public function checkPaymentMethod($payment, string $method): bool
+    public function checkPaymentMethod(Order\Payment $payment, string $method): bool
     {
         return $payment->getMethod() === $method;
     }
 
-    /**
-     * Check if the passed payment method provider is a recurring one or not
-     *
-     * @param string $provider
-     * @return bool
-     */
     public function isRecurringProvider(string $provider): bool
     {
         return in_array($provider, [
@@ -568,11 +426,6 @@ class PaymentMethods extends AbstractHelper
         ]);
     }
 
-    /**
-     * Retrieve available credit card types
-     *
-     * @return array
-     */
     public function getCcAvailableTypes(): array
     {
         $types = [];
@@ -590,11 +443,6 @@ class PaymentMethods extends AbstractHelper
         return $types;
     }
 
-    /**
-     * Retrieve available credit card type codes by alt code
-     *
-     * @return array
-     */
     public function getCcAvailableTypesByAlt(): array
     {
         $types = [];
@@ -612,13 +460,6 @@ class PaymentMethods extends AbstractHelper
         return $types;
     }
 
-    /**
-     * Check if order should be automatically captured
-     *
-     * @param Order $order
-     * @param string $notificationPaymentMethod
-     * @return bool
-     */
     public function isAutoCapture(Order $order, string $notificationPaymentMethod): bool
     {
         // validate if payment methods allows manual capture
@@ -786,13 +627,6 @@ class PaymentMethods extends AbstractHelper
         }
     }
 
-    /**
-     * Compare the payment methods linked to the magento order and the adyen notification
-     *
-     * @param Order $order
-     * @param Notification $notification
-     * @return bool
-     */
     public function compareOrderAndWebhookPaymentMethods(Order $order, Notification $notification): bool
     {
         // For cards, it can be 'VI', 'MI',... For alternatives, it can be 'ideal', 'directEbanking',...
@@ -811,12 +645,6 @@ class PaymentMethods extends AbstractHelper
         return false;
     }
 
-    /**
-     * This function should be removed once we add classes for payment methods
-     *
-     * @param string $paymentMethod
-     * @return bool
-     */
     public function isBankTransfer(string $paymentMethod): bool
     {
         if (strlen($paymentMethod) >= 12 && substr($paymentMethod, 0, 12) == "bankTransfer") {
@@ -827,13 +655,7 @@ class PaymentMethods extends AbstractHelper
         return $isBankTransfer;
     }
 
-    /**
-     * @param Order $order
-     * @param Notification $notification
-     * @param $status
-     * @return bool|mixed
-     */
-    public function getBoletoStatus(Order $order, Notification $notification, $status)
+    public function getBoletoStatus(Order $order, Notification $notification, string $status): ?string
     {
         $additionalData = !empty($notification->getAdditionalData()) ? $this->serializer->unserialize(
             $notification->getAdditionalData()

--- a/Model/Api/AdyenPaymentMethodManagement.php
+++ b/Model/Api/AdyenPaymentMethodManagement.php
@@ -3,7 +3,7 @@
  *
  * Adyen Payment module (https://www.adyen.com/)
  *
- * Copyright (c) 2023 Adyen BV (https://www.adyen.com/)
+ * Copyright (c) 2023 Adyen N.V. (https://www.adyen.com/)
  * See LICENSE.txt for license details.
  *
  * Author: Adyen <magento@adyen.com>
@@ -13,28 +13,19 @@ namespace Adyen\Payment\Model\Api;
 
 use Adyen\Payment\Api\AdyenPaymentMethodManagementInterface;
 use Adyen\Payment\Helper\PaymentMethods;
-use Magento\Quote\Api\Data\AddressInterface;
 
 class AdyenPaymentMethodManagement implements AdyenPaymentMethodManagementInterface
 {
     protected PaymentMethods $paymentMethodsHelper;
 
-    /**
-     * @param PaymentMethods $paymentMethodsHelper
-     */
     public function __construct(
         PaymentMethods $paymentMethodsHelper
     ) {
         $this->paymentMethodsHelper = $paymentMethodsHelper;
     }
 
-    /**
-     * @param string $cartId
-     * @param string|null $shopperLocale
-     * @return string
-     */
-    public function getPaymentMethods(string $cartId, ?string $shopperLocale = null) : string {
-
-        return $this->paymentMethodsHelper->getPaymentMethods($cartId, $shopperLocale);
+    public function getPaymentMethods(string $cartId, ?string $shopperLocale = null, ?string $country = null) : string
+    {
+        return $this->paymentMethodsHelper->getPaymentMethods($cartId, $country, $shopperLocale);
     }
 }

--- a/Model/Api/GuestAdyenPaymentMethodManagement.php
+++ b/Model/Api/GuestAdyenPaymentMethodManagement.php
@@ -3,7 +3,7 @@
  *
  * Adyen Payment module (https://www.adyen.com/)
  *
- * Copyright (c) 2023 Adyen BV (https://www.adyen.com/)
+ * Copyright (c) 2023 Adyen N.V. (https://www.adyen.com/)
  * See LICENSE.txt for license details.
  *
  * Author: Adyen <magento@adyen.com>
@@ -13,19 +13,13 @@ namespace Adyen\Payment\Model\Api;
 
 use Adyen\Payment\Api\GuestAdyenPaymentMethodManagementInterface;
 use Adyen\Payment\Helper\PaymentMethods;
-use Magento\Quote\Api\Data\AddressInterface;
 use Magento\Quote\Model\QuoteIdMaskFactory;
 
 class GuestAdyenPaymentMethodManagement implements GuestAdyenPaymentMethodManagementInterface
 {
     protected QuoteIdMaskFactory $quoteIdMaskFactory;
-
     protected PaymentMethods $paymentMethodsHelper;
 
-    /**
-     * @param QuoteIdMaskFactory $quoteIdMaskFactory
-     * @param PaymentMethods $paymentMethodsHelper
-     */
     public function __construct(
         QuoteIdMaskFactory $quoteIdMaskFactory,
         PaymentMethods $paymentMethodsHelper
@@ -34,15 +28,10 @@ class GuestAdyenPaymentMethodManagement implements GuestAdyenPaymentMethodManage
         $this->paymentMethodsHelper = $paymentMethodsHelper;
     }
 
-    /**
-     * @param string $cartId
-     * @param string|null $shopperLocale
-     * @return string
-     */
-    public function getPaymentMethods(string $cartId, ?string $shopperLocale = null): string {
+    public function getPaymentMethods(string $cartId, ?string $shopperLocale = null, ?string $country = null): string {
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
         $quoteId = $quoteIdMask->getQuoteId();
 
-        return $this->paymentMethodsHelper->getPaymentMethods($quoteId, $shopperLocale);
+        return $this->paymentMethodsHelper->getPaymentMethods($quoteId, $country, $shopperLocale);
     }
 }

--- a/Model/Resolver/GetAdyenPaymentMethods.php
+++ b/Model/Resolver/GetAdyenPaymentMethods.php
@@ -3,7 +3,7 @@
  *
  * Adyen Payment Module
  *
- * Copyright (c) 2021 Adyen B.V.
+ * Copyright (c) 2023 Adyen N.V.
  * This file is open source and available under the MIT license.
  * See the LICENSE file for more info.
  *
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Adyen\Payment\Model\Resolver;
 
-use Adyen\AdyenException;
 use Adyen\Payment\Exception\GraphQlAdyenException;
 use Adyen\Payment\Helper\PaymentMethods;
 use Adyen\Payment\Logger\AdyenLogger;
@@ -22,8 +21,6 @@ use Magento\Framework\GraphQl\Config\Element\Field;
 use Magento\Framework\GraphQl\Exception\GraphQlAuthorizationException;
 use Magento\Framework\GraphQl\Exception\GraphQlInputException;
 use Magento\Framework\GraphQl\Exception\GraphQlNoSuchEntityException;
-use Magento\Framework\GraphQl\Query\Resolver\ContextInterface;
-use Magento\Framework\GraphQl\Query\Resolver\Value;
 use Magento\Framework\GraphQl\Query\ResolverInterface;
 use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
 use Magento\Framework\Serialize\Serializer\Json;
@@ -31,34 +28,11 @@ use Magento\QuoteGraphQl\Model\Cart\GetCartForUser;
 
 class GetAdyenPaymentMethods implements ResolverInterface
 {
-    /**
-     * @var GetCartForUser
-     */
-    protected $getCartForUser;
+    protected GetCartForUser $getCartForUser;
+    protected PaymentMethods $paymentMethodsHelper;
+    protected Json $jsonSerializer;
+    protected AdyenLogger $adyenLogger;
 
-    /**
-     * @var PaymentMethods
-     */
-    protected $paymentMethodsHelper;
-
-    /**
-     * @var Json
-     */
-    protected $jsonSerializer;
-
-    /**
-     * @var AdyenLogger
-     */
-    protected $adyenLogger;
-
-
-    /**
-     * GetAdyenPaymentMethods constructor.
-     * @param GetCartForUser $getCartForUser
-     * @param PaymentMethods $paymentMethodsHelper
-     * @param Json $jsonSerializer
-     * @param AdyenLogger $adyenLogger
-     */
     public function __construct(
         GetCartForUser $getCartForUser,
         PaymentMethods $paymentMethodsHelper,
@@ -71,21 +45,6 @@ class GetAdyenPaymentMethods implements ResolverInterface
         $this->adyenLogger = $adyenLogger;
     }
 
-
-    /**
-     * @inheritdoc
-     *
-     * @param Field $field
-     * @param ContextInterface $context
-     * @param ResolveInfo $info
-     * @param array|null $value
-     * @param array|null $args
-     * @return array|Value|mixed
-     * @throws GraphQlAdyenException
-     * @throws GraphQlAuthorizationException
-     * @throws GraphQlInputException
-     * @throws GraphQlNoSuchEntityException
-     */
     public function resolve(
         Field $field,
         $context,
@@ -98,6 +57,7 @@ class GetAdyenPaymentMethods implements ResolverInterface
         }
         $maskedCartId = $args['cart_id'];
         $shopperLocale = $args['shopper_locale'] ?? null;
+        $country = $args['country'] ?? null;
 
         $currentUserId = $context->getUserId();
         $storeId = (int)$context->getExtensionAttributes()->getStore()->getId();
@@ -107,6 +67,7 @@ class GetAdyenPaymentMethods implements ResolverInterface
 
             $adyenPaymentMethodsResponse = $this->paymentMethodsHelper->getPaymentMethods(
                 intval($cart->getId()),
+                $country,
                 $shopperLocale
             );
 
@@ -122,11 +83,7 @@ class GetAdyenPaymentMethods implements ResolverInterface
         }
     }
 
-    /**
-     * @param $adyenPaymentMethodsResponse
-     * @return mixed
-     */
-    public function preparePaymentMethodGraphQlResponse($adyenPaymentMethodsResponse)
+    public function preparePaymentMethodGraphQlResponse(string $adyenPaymentMethodsResponse): array
     {
         $adyenPaymentMethodsResponse = $this->jsonSerializer->unserialize($adyenPaymentMethodsResponse);
 

--- a/etc/schema.graphqls
+++ b/etc/schema.graphqls
@@ -7,6 +7,7 @@ type Query {
     adyenPaymentMethods (
         cart_id: String! @doc(description: "Cart ID.")
         shopper_locale: String @doc(description: "Language and country code combination separated by underscore (_), e.g. en_US")
+        country: String @doc(description: "Country code to be used in paymentMethods call, e.g. US")
     ) : AdyenPaymentMethods @resolver(class: "Adyen\\Payment\\Model\\Resolver\\GetAdyenPaymentMethods")
 }
 

--- a/view/frontend/web/js/model/adyen-payment-service.js
+++ b/view/frontend/web/js/model/adyen-payment-service.js
@@ -35,19 +35,18 @@ define(
                 // url for guest users
                 var serviceUrl = urlBuilder.createUrl(
                     '/guest-carts/:cartId/retrieve-adyen-payment-methods', {
-                        cartId: quote.getQuoteId(),
+                        cartId: quote.getQuoteId()
                     });
 
                 // url for logged in users
                 if (customer.isLoggedIn()) {
-                    serviceUrl = urlBuilder.createUrl(
-                        '/carts/mine/retrieve-adyen-payment-methods', {});
+                    serviceUrl = urlBuilder.createUrl('/carts/mine/retrieve-adyen-payment-methods', {});
                 }
 
                 // Construct payload for the retrieve payment methods request
                 var payload = {
                     cartId: quote.getQuoteId(),
-                    form_key: $.mage.cookies.get('form_key')
+                    country: quote.billingAddress().countryId
                 };
 
                 return storage.post(

--- a/view/frontend/web/js/view/payment/adyen-methods.js
+++ b/view/frontend/web/js/view/payment/adyen-methods.js
@@ -118,12 +118,14 @@ define(
                     });
                 };
                 quote.billingAddress.subscribe(function(address) {
-                    // In case the country hasn't changed don't retrieve new payment methods
-                    if (billingAddressCountry === quote.billingAddress().countryId) {
-                        return;
+                    if (!!quote.billingAddress()) {
+                        // In case the country hasn't changed don't retrieve new payment methods
+                        if (billingAddressCountry === quote.billingAddress().countryId) {
+                            return;
+                        }
+                        billingAddressCountry = quote.billingAddress().countryId;
+                        retrievePaymentMethods();
                     }
-                    billingAddressCountry = quote.billingAddress().countryId;
-                    retrievePaymentMethods();
                 });
                 //Retrieve payment methods to ensure the amount is updated, when applying the discount code
                 setCouponCodeAction.registerSuccessCallback(function () {


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
`paymentMethods` endpoint expects country parameter to fetch correct payment methods. For a logged-in user, default billing address' country code is being used. However, when shopper changes the billing address on checkout page, correct country code was missing due to wrong arguments being passed to payment method endpoints.

- AdyenPaymentMethodManagementInterface and implementation's argument updated.
- GuestAdyenPaymentMethodManagementInterface and implementation's argument updated.
- Frontend JS implementation fixed.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- Trying different billing address combinations with guest and logged-in user