### PR TITLE
[ECP-8468] - Correctly update credit memo ID's in adyen_creditmemo

### DIFF
--- a/Observer/CreditmemoObserver.php
+++ b/Observer/CreditmemoObserver.php
@@ -104,8 +104,7 @@ class CreditmemoObserver implements ObserverInterface
         $payment = $order->getPayment();
 
         $adyenOrderPayments = $this->adyenPaymentResourceModel->getLinkedAdyenOrderPayments(
-            $payment->getEntityId(),
-            [OrderPaymentInterface::CAPTURE_STATUS_NO_CAPTURE, OrderPaymentInterface::CAPTURE_STATUS_PARTIAL_CAPTURE]
+            $payment->getEntityId()
         );
         foreach ($adyenOrderPayments as $adyenOrderPayment) {
             /** @var \Adyen\Payment\Model\Order\Payment $adyenOrderPaymentObject */


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->

This PR removes the validation for the cases where we have multiple partial captures aas auto captures and manual captures should also have a credit memo in the adyen_creditmemo table. 
**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

Fixes  <!-- #-prefixed github issue number -->
