### PR TITLE
New GettingStarted Fieldset class to dynamically add support form URL

### DIFF
--- a/Model/Config/Adminhtml/GettingStarted.php
+++ b/Model/Config/Adminhtml/GettingStarted.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Adyen Payment Module
+ *
+ * Copyright (c) 2022 Adyen N.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\Payment\Model\Config\Adminhtml;
+
+use Magento\Backend\Block\Context;
+use Magento\Backend\Model\Auth\Session;
+use Magento\Config\Block\System\Config\Form\Fieldset;
+use Magento\Framework\UrlInterface;
+use Magento\Framework\View\Helper\Js;
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+
+class GettingStarted extends Fieldset
+{
+
+    private UrlInterface $urlBuilder;
+
+    public function __construct(
+        Context             $context,
+        Session             $authSession,
+        Js                  $jsHelper,
+        UrlInterface        $urlBuilder,
+        array               $data = [],
+        ?SecureHtmlRenderer $secureRenderer = null
+    )
+    {
+        $this->urlBuilder = $urlBuilder;
+        parent::__construct($context, $authSession, $jsHelper, $data, $secureRenderer);
+    }
+
+    protected function _getHeaderCommentHtml($element): string
+    {
+        $supportFormUrl = $this->urlBuilder->getUrl('adyen/support/configurationsettings');
+        $text = '
+        <ul class="adyen-list">
+            <li>Adyen Adobe Commerce plugin integration demo in GitHub <a href="https://github.com/adyen-examples/adyen-magento-plugin-demo" target="_blank">integration demo in GitHub</a></li>
+            <li><a target="_blank" href="https://docs.adyen.com/plugins/adobe-commerce">Documentation for setting up the module</a></li>
+            <li>Adyen Customer Area for <a target="_blank" href="https://ca-test.adyen.com">TEST</a> and Adyen Customer Area for <a target="_blank" href="https://ca-live.adyen.com">LIVE</a></li>
+            <li>If you have any further question, reach out to our support team by filling out the <a target="_parent" href="' . $supportFormUrl . '">support form</a></li>
+        </ul>
+        ';
+        $element->setData("comment", $text);
+        return parent::_getHeaderCommentHtml($element);
+    }
+}

--- a/etc/adminhtml/system/adyen_getting_started.xml
+++ b/etc/adminhtml/system/adyen_getting_started.xml
@@ -13,15 +13,7 @@
 <include xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_include.xsd">
     <group id="adyen_getting_started" translate="label" type="text" sortOrder="100" showInDefault="1" showInWebsite="1" showInStore="1">
         <label><![CDATA[Documentation & Support]]></label>
-        <frontend_model>Magento\Config\Block\System\Config\Form\Fieldset</frontend_model>
-        <comment><![CDATA[
-                            <ul class="adyen-list">
-                                <li>Adyen Adobe Commerce plugin integration demo in GitHub <a href="https://github.com/adyen-examples/adyen-magento-plugin-demo" target="_blank">integration demo in GitHub</a></li>
-                                <li><a target="_blank" href="https://docs.adyen.com/plugins/adobe-commerce">Documentation for setting up the module</a></li>
-                                <li>Adyen Customer Area for <a target="_blank" href="https://ca-test.adyen.com">TEST</a> and Adyen Customer Area for <a target="_blank" href="https://ca-live.adyen.com">LIVE</a></li>
-                                <li>If you have any further question, reach out to our support team by filling out the <a target="_blank" href="https://ca-test.adyen.com/ca/ca/contactUs/support.shtml?topic=magento&form=magento">support form</a></li>
-                            </ul>
-                            ]]></comment>
+        <frontend_model>Adyen\Payment\Model\Config\Adminhtml\GettingStarted</frontend_model>
         <field id="version" translate="label" type="label" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="0">
             <label>Extension version</label>
             <frontend_model>\Adyen\Payment\Block\Adminhtml\System\Config\Field\Version</frontend_model>


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
The Getting Started section has a text with a link to the adyen.com help form. But we have a brand new and shiny support form in the plugin.

The text is normally added in XML, so a frontend model is used to generate and add the URL dynamically.

**Tested scenarios**
Link to support form redirects to the support form in the plugin


