### PR TITLE
createAdyenCheckoutService() with no client param

### DIFF
--- a/Gateway/Http/Client/TransactionPayment.php
+++ b/Gateway/Http/Client/TransactionPayment.php
@@ -91,8 +91,7 @@ class TransactionPayment implements ClientInterface
             return $request;
         }
 
-        $client = $this->adyenHelper->initializeAdyenClient();
-        $service = $this->adyenHelper->createAdyenCheckoutService($client);
+        $service = $this->adyenHelper->createAdyenCheckoutService();
 
         $idempotencyKey = $this->idempotencyHelper->generateIdempotencyKey(
             $request,

--- a/Gateway/Http/Client/TransactionPaymentLinks.php
+++ b/Gateway/Http/Client/TransactionPaymentLinks.php
@@ -61,8 +61,7 @@ class TransactionPaymentLinks implements ClientInterface
             return $request;
         }
 
-        $client = $this->adyenHelper->initializeAdyenClient();
-        $service = $this->adyenHelper->createAdyenCheckoutService($client);
+        $service = $this->adyenHelper->createAdyenCheckoutService();
 
         $idempotencyKey = $this->idempotencyHelper->generateIdempotencyKey(
             $request,

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -13,6 +13,7 @@ namespace Adyen\Payment\Helper;
 
 use Adyen\AdyenException;
 use Adyen\Client;
+use Adyen\Service\Checkout;
 use Adyen\Payment\Logger\AdyenLogger;
 use Adyen\Payment\Model\RecurringType;
 use Adyen\Payment\Model\ResourceModel\Billing\Agreement\CollectionFactory as BillingCollectionFactory;
@@ -1682,12 +1683,16 @@ class Data extends AbstractHelper
     }
 
     /**
-     * @param $client
-     * @return \Adyen\Service\Checkout
+     * @throws AdyenException
+     * @throws NoSuchEntityException
      */
-    public function createAdyenCheckoutService($client)
+    public function createAdyenCheckoutService(Client $client = null): Checkout
     {
-        return new \Adyen\Service\Checkout($client);
+        if (!$client) {
+            $client = $this->initializeAdyenClient();
+        }
+
+        return new Checkout($client);
     }
 
     /**


### PR DESCRIPTION


**Description**

In the code base, we are initializing client just to create CK service, and we see those two lines coupled

```php
$client = $this->adyenHelper->initializeAdyenClient();
$service = $this->adyenHelper->createAdyenCheckoutService($client);
```
This pr to fix this anti pattern by making the client input optional to the CK service
