### PR TITLE
[ECP-8580] filter token types for MIT orders

### DIFF
--- a/Block/Form/Oneclick.php
+++ b/Block/Form/Oneclick.php
@@ -13,6 +13,7 @@ namespace Adyen\Payment\Block\Form;
 
 use Adyen\Payment\Helper\ChargedCurrency;
 use Adyen\Payment\Helper\Data;
+use Adyen\Payment\Helper\Recurring;
 use Magento\Backend\Model\Session\Quote;
 use Magento\Framework\View\Element\Template\Context;
 use Magento\Payment\Block\Form;
@@ -63,6 +64,11 @@ class Oneclick extends Form
         $storeId = $this->_sessionQuote->getStoreId();
         $grandTotal = $this->chargedCurrency->getQuoteAmountCurrency($this->_sessionQuote->getQuote())->getAmount();
 
-        return $this->adyenHelper->getOneClickPaymentMethods($customerId, $storeId, $grandTotal);
+        return $this->adyenHelper->getOneClickPaymentMethods(
+            $customerId,
+            $storeId,
+            $grandTotal,
+            [Recurring::SUBSCRIPTION, Recurring::UNSCHEDULED_CARD_ON_FILE]
+        );
     }
 }

--- a/Gateway/Request/AdminOrderOneclickCheckoutDataBuilder.php
+++ b/Gateway/Request/AdminOrderOneclickCheckoutDataBuilder.php
@@ -12,6 +12,7 @@
 namespace Adyen\Payment\Gateway\Request;
 
 use Magento\Framework\App\RequestInterface;
+use Magento\Payment\Gateway\Http\ClientException;
 use Magento\Payment\Gateway\Request\BuilderInterface;
 
 class AdminOrderOneclickCheckoutDataBuilder implements BuilderInterface
@@ -37,10 +38,15 @@ class AdminOrderOneclickCheckoutDataBuilder implements BuilderInterface
      *
      * @param array $buildSubject
      * @return array
+     * @throws ClientException
      */
     public function build(array $buildSubject)
     {
         $paymentFormFields = $this->request->getParam('payment');
+
+        if (empty($paymentFormFields['recurring_detail_reference'])) {
+            throw new ClientException(__('Please select one of the stored payment methods to continue'));
+        }
 
         $requestBody = array(
             'paymentMethod' => array(

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -926,10 +926,10 @@ class Data extends AbstractHelper
      * @param $customerId
      * @param $storeId
      * @param $grandTotal
-     * @param $recurringType
+     * @param $recurringTypes
      * @return array
      */
-    public function getOneClickPaymentMethods($customerId, $storeId, $grandTotal, $subType=null)
+    public function getOneClickPaymentMethods($customerId, $storeId, $grandTotal, $recurringTypes = [])
     {
         $billingAgreements = [];
 
@@ -952,9 +952,33 @@ class Data extends AbstractHelper
             // check if contractType is supporting the selected contractType for OneClick payments
             $allowedContractTypes = $agreementData['contractTypes'];
 
-            // RecurringType::ONECLICK is kept in the if block to still display tokens that were created before changes in contract types
-            // even when $subType is not passed in /Block/Form/Oneclick.php, show all tokens with all contract types for admin orders
-            if (is_null($subType) || in_array(RecurringType::ONECLICK, $allowedContractTypes) || in_array($subType, $allowedContractTypes)) {
+            $fetchToken = false;
+
+            if (!empty($recurringTypes)) {
+                // Old contract types ONECLICK and RECURRING are added to support older tokens
+                if (in_array(Recurring::CARD_ON_FILE, $recurringTypes)) {
+                    $recurringTypes[] = RecurringType::ONECLICK;
+                }
+                if (
+                    !empty(
+                        array_intersect([Recurring::SUBSCRIPTION, Recurring::UNSCHEDULED_CARD_ON_FILE], $recurringTypes)
+                    )
+                ) {
+                    $recurringTypes[] = RecurringType::RECURRING;
+                }
+
+                // Fetch the token if it contains any or the specified $recurringTypes
+                foreach ($recurringTypes as $recurringType) {
+                    if (in_array($recurringType, $allowedContractTypes)) {
+                        $fetchToken = true;
+                    }
+                }
+            } else {
+                // Fetch all stored tokens if no recurring types are specified
+                $fetchToken = true;
+            }
+
+            if ($fetchToken) {
                 // check if AgreementLabel is set and if contract has an recurringType
                 if ($billingAgreement->getAgreementLabel()) {
                     // for Ideal use sepadirectdebit because it is

--- a/Model/Ui/AdyenOneclickConfigProvider.php
+++ b/Model/Ui/AdyenOneclickConfigProvider.php
@@ -195,7 +195,7 @@ class AdyenOneclickConfigProvider implements ConfigProviderInterface
                 $customerId,
                 $storeId,
                 $grandTotal,
-                Recurring::CARD_ON_FILE
+                [Recurring::CARD_ON_FILE]
             );
         }
         return $billingAgreements;


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Apply correct filter for Merchant initiated transaction orders:
Use tokens stored as `CardOnFile` only on frontend
FOr admin orders only show tokens stored as `UnscheduledCardOnFile` or `Subscription`

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- Tokens of multiple types stored for the same user by toggling configuration
- Only `CardOnFile` tokens show up for shopper in checkout
- Only `UnscheduledCardOnFile` or `Subscription` tokens show up when creating admin order

