### PR TITLE
[ECP-8599] Create a handler for ORDER_OPENED webhook and upgrade PHP Webhook Module version

### DIFF
--- a/Helper/Webhook/OrderOpenedWebhookHandler.php
+++ b/Helper/Webhook/OrderOpenedWebhookHandler.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ *
+ * Adyen Payment Module
+ *
+ * Copyright (c) 2023 Adyen N.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\Payment\Helper\Webhook;
+
+use Adyen\Payment\Logger\AdyenLogger;
+use Adyen\Payment\Model\Notification;
+use Magento\Sales\Model\Order;
+
+class OrderOpenedWebhookHandler implements WebhookHandlerInterface
+{
+    private AdyenLogger $adyenLogger;
+
+    public function __construct(
+        AdyenLogger $adyenLogger
+    ) {
+        $this->adyenLogger = $adyenLogger;
+    }
+
+    public function handleWebhook(Order $order, Notification $notification, string $transitionState): Order
+    {
+        if ($notification->isSuccessful()) {
+            $order->addCommentToStatusHistory(__("Adyen order has been successfully created for partial payments."));
+        } else {
+            $this->adyenLogger->addAdyenNotification(__("An error occurred while creating partial payment order!"), [
+                'pspReference' => $notification->getPspreference(),
+                'merchantReference' => $notification->getMerchantReference()
+            ]);
+        }
+
+        return $order;
+    }
+}

--- a/Helper/Webhook/WebhookHandlerFactory.php
+++ b/Helper/Webhook/WebhookHandlerFactory.php
@@ -216,6 +216,8 @@ class WebhookHandlerFactory
                     self::$serializer,
                     self::$orderHelper
                 );
+            case Notification::ORDER_OPENED:
+                return new OrderOpenedWebhookHandler(self::$adyenLogger);
             case Notification::ORDER_CLOSED:
                 return new OrderClosedWebhookHandler(
                     self::$adyenOrderPayment,

--- a/Model/Notification.php
+++ b/Model/Notification.php
@@ -40,6 +40,7 @@ class Notification extends AbstractModel implements NotificationInterface
     const MANUAL_REVIEW_REJECT = 'MANUAL_REVIEW_REJECT';
     const RECURRING_CONTRACT = "RECURRING_CONTRACT";
     const REPORT_AVAILABLE = "REPORT_AVAILABLE";
+    const ORDER_OPENED = 'ORDER_OPENED';
     const ORDER_CLOSED = "ORDER_CLOSED";
     const OFFER_CLOSED = "OFFER_CLOSED";
     const MAX_ERROR_COUNT = 5;

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   "require": {
     "php": ">=8.1",
     "adyen/php-api-library": "^14.0.1",
-    "adyen/php-webhook-module": "^0.7.0",
+    "adyen/php-webhook-module": "^0.8.0",
     "magento/framework": ">=101.0.8 <102 || >=102.0.1",
     "magento/module-vault": "101.*",
     "magento/module-multishipping": ">=100.3.7",


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Related webhook handler for `ORDER_OPENED` event has been created and Adyen PHP Webhook Module version upgraded.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- Giftcard orders webhook processing