### PR TITLE
Remove duplicated PM items from .xml

### DIFF
--- a/view/frontend/layout/checkout_index_index.xml
+++ b/view/frontend/layout/checkout_index_index.xml
@@ -62,12 +62,6 @@
                                                                         <item name="adyen_amazonpay" xsi:type="array">
                                                                             <item name="isBillingAddressRequired" xsi:type="boolean">true</item>
                                                                         </item>
-                                                                        <item name="adyen_boleto" xsi:type="array">
-                                                                            <item name="isBillingAddressRequired" xsi:type="boolean">true</item>
-                                                                        </item>
-                                                                        <item name="adyen_pos_cloud" xsi:type="array">
-                                                                            <item name="isBillingAddressRequired" xsi:type="boolean">true</item>
-                                                                        </item>
                                                                         <item name="adyen_giftcard" xsi:type="array">
                                                                             <item name="isBillingAddressRequired" xsi:type="boolean">true</item>
                                                                         </item>


### PR DESCRIPTION
**Description**
WIth the latest merging to rc-v9 branch, we have duplicated some payment method items in checkout_index_index.xml file, more specifically:
- ayden_pos_cloud
- adyen_boleto
The outcome of this is that Magento UI breaks when a shopper tries to reach the checkout page.

This PR removes the redundant duplications.

**Tested scenarios**
- make sure you can complete the payment with CC and the above two methods
