### PR TITLE
Fix return type of the methods of Notification class

### DIFF
--- a/Api/Data/NotificationInterface.php
+++ b/Api/Data/NotificationInterface.php
@@ -214,9 +214,9 @@ interface NotificationInterface
     public function setErrorMessage(string $errorMessage): NotificationInterface;
 
     /**
-     * @return DateTime|null
+     * @return string|null
      */
-    public function getCreatedAt(): ?DateTime;
+    public function getCreatedAt(): ?string;
 
     /**
      * @param DateTime $createdAt
@@ -225,9 +225,9 @@ interface NotificationInterface
     public function setCreatedAt(DateTime $createdAt): NotificationInterface;
 
     /**
-     * @return DateTime|null
+     * @return string|null
      */
-    public function getUpdatedAt(): ?DateTime;
+    public function getUpdatedAt(): ?string;
 
     /**
      * @param DateTime $timestamp

--- a/Model/Notification.php
+++ b/Model/Notification.php
@@ -253,7 +253,7 @@ class Notification extends AbstractModel implements NotificationInterface
         return $this->setData(self::ERROR_MESSAGE, $errorMessage);
     }
 
-    public function getCreatedAt(): DateTime
+    public function getCreatedAt(): string
     {
         return $this->getData(self::CREATED_AT);
     }
@@ -263,7 +263,7 @@ class Notification extends AbstractModel implements NotificationInterface
         return $this->setData(self::CREATED_AT, $createdAt);
     }
 
-    public function getUpdatedAt(): ?DateTime
+    public function getUpdatedAt(): ?string
     {
         return $this->getData(self::UPDATED_AT);
     }


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
`getCreatedAt()` and `getUpdatedAt()` methods' return type declarations fixed.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- Processing `ORDER_CLOSED` webhook