### PR TITLE
[ECP-8593] Remove redundant paymentMethods call from the frontend

### DIFF
--- a/Helper/PaymentMethodsFilter.php
+++ b/Helper/PaymentMethodsFilter.php
@@ -23,7 +23,7 @@ class PaymentMethodsFilter
     ];
 
     private PaymentMethods $paymentMethods;
-    protected CartRepositoryInterface $cartRepository;
+    private CartRepositoryInterface $cartRepository;
 
     public function __construct(
         PaymentMethods $paymentMethods,

--- a/Helper/PaymentMethodsFilter.php
+++ b/Helper/PaymentMethodsFilter.php
@@ -9,15 +9,11 @@
  * Author: Adyen <magento@adyen.com>
  */
 
-namespace Adyen\Payment\Plugin;
+namespace Adyen\Payment\Helper;
 
-use Adyen\Payment\Helper\PaymentMethods;
-use Adyen\Payment\Logger\AdyenLogger;
-use Exception;
-use Magento\Payment\Model\MethodList;
-use Magento\Quote\Api\Data\CartInterface;
+use Magento\Quote\Api\CartRepositoryInterface;
 
-class FilterSortPaymentMethods
+class PaymentMethodsFilter
 {
     const ADYEN_PREFIX = 'adyen_';
     const VAULT_SUFFIX = '_vault';
@@ -27,45 +23,39 @@ class FilterSortPaymentMethods
     ];
 
     private PaymentMethods $paymentMethods;
-    private AdyenLogger $adyenLogger;
-    private array $fetchPaymentMethodsResponse;
-    private array $magentoPaymentMethods;
+    protected CartRepositoryInterface $cartRepository;
 
     public function __construct(
         PaymentMethods $paymentMethods,
-        AdyenLogger $adyenLogger
+        CartRepositoryInterface $cartRepository
     ) {
         $this->paymentMethods = $paymentMethods;
-        $this->adyenLogger = $adyenLogger;
-        $this->fetchPaymentMethodsResponse = [];
+        $this->cartRepository = $cartRepository;
     }
 
-    public function afterGetAvailableMethods(
-        MethodList $methodListObject,
-        array $result,
-        CartInterface $quote = null
-    ): array {
-        if (!empty($result)) {
-            $this->magentoPaymentMethods = $result;
-        } else {
-            return $result;
-        }
-
-        $this->fetchPaymentMethods($quote);
-
-        if (!empty($this->fetchPaymentMethodsResponse)) {
-            $this->filterPaymentMethods();
-            $this->sortPaymentMethodsList();
-        }
-
-        return $this->magentoPaymentMethods;
-    }
-
-    private function filterPaymentMethods(): void
+    public function sortAndFilterPaymentMethods(array $magentoPaymentMethods, int $quoteId): array
     {
-        $adyenPaymentMethods = $this->getAdyenPaymentMethods();
+        $quote = $this->cartRepository->get($quoteId);
 
-        foreach ($this->magentoPaymentMethods as $key => $paymentMethod) {
+        $adyenPaymentMethodsResponse = $this->paymentMethods->getPaymentMethods(
+            $quote->getId(),
+            $quote->getBillingAddress()->getCountryId()
+        );
+
+        if (!empty($adyenPaymentMethodsResponse)) {
+            $adyenPaymentMethodsDecoded = json_decode($adyenPaymentMethodsResponse, true);
+            $adyenPaymentMethods = $adyenPaymentMethodsDecoded['paymentMethodsResponse']['paymentMethods'];
+
+            $magentoPaymentMethods = $this->filterPaymentMethods($magentoPaymentMethods, $adyenPaymentMethods);
+            $magentoPaymentMethods = $this->sortPaymentMethodsList($magentoPaymentMethods, $adyenPaymentMethods);
+        }
+
+        return [$magentoPaymentMethods, $adyenPaymentMethodsResponse];
+    }
+
+    private function filterPaymentMethods(array $magentoPaymentMethods, array $adyenPaymentMethods): array
+    {
+        foreach ($magentoPaymentMethods as $key => $paymentMethod) {
             $txVariant = $this->paymentMethodTypeReplace(
                 str_starts_with($paymentMethod->getCode(), self::ADYEN_PREFIX) ?
                     substr($paymentMethod->getCode(), strlen(self::ADYEN_PREFIX)) :
@@ -81,20 +71,20 @@ class FilterSortPaymentMethods
 
             if ($txVariant &&
                 !in_array($txVariant, array_column($adyenPaymentMethods, 'type'), true)) {
-                unset($this->magentoPaymentMethods[$key]);
+                unset($magentoPaymentMethods[$key]);
             }
         }
+
+        return $magentoPaymentMethods;
     }
 
-    private function sortPaymentMethodsList(): void
+    private function sortPaymentMethodsList(array $magentoPaymentMethods, array $adyenPaymentMethods): array
     {
-        usort($this->magentoPaymentMethods, function ($a, $b) {
-            $adyenPaymentMethods = $this->getAdyenPaymentMethods();
-
+        usort($magentoPaymentMethods, function ($a, $b) use ($adyenPaymentMethods) {
             $aTxVariant = $this->paymentMethodTypeReplace(
                 str_starts_with($a->getCode(), self::ADYEN_PREFIX) ?
-                substr($a->getCode(), strlen(self::ADYEN_PREFIX)) :
-                false
+                    substr($a->getCode(), strlen(self::ADYEN_PREFIX)) :
+                    false
             );
 
             $bTxVariant = $this->paymentMethodTypeReplace(
@@ -118,31 +108,8 @@ class FilterSortPaymentMethods
 
             return 0;
         });
-    }
 
-    private function fetchPaymentMethods(CartInterface $quote): void
-    {
-        try {
-            $paymentMethods = $this->paymentMethods->getPaymentMethods(
-                $quote->getId(),
-                $quote->getBillingAddress()->getCountryId()
-            );
-
-            $paymentMethodsArray = json_decode($paymentMethods, true);
-        } catch (Exception $e) {
-            $this->adyenLogger->error(
-                'There was an error while fetching payment methods: ' . $e->getMessage()
-            );
-        }
-
-        if (!empty($paymentMethodsArray)) {
-            $this->fetchPaymentMethodsResponse = $paymentMethodsArray;
-        }
-    }
-
-    private function getAdyenPaymentMethods(): ?array
-    {
-        return $this->fetchPaymentMethodsResponse['paymentMethodsResponse']['paymentMethods'] ?? null;
+        return $magentoPaymentMethods;
     }
 
     private function paymentMethodTypeReplace(string $type): string

--- a/Plugin/PaymentInformationManagement.php
+++ b/Plugin/PaymentInformationManagement.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2023 Adyen N.V. (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\Payment\Plugin;
+
+use Adyen\Payment\Helper\PaymentMethodsFilter;
+use Magento\Checkout\Api\Data\PaymentDetailsInterface;
+use Magento\Checkout\Model\PaymentDetailsFactory;
+use Magento\Checkout\Model\PaymentInformationManagement as MagentoPaymentInformationManagement;
+
+class PaymentInformationManagement
+{
+    protected PaymentMethodsFilter $paymentMethodsFilter;
+
+    public function __construct(
+        PaymentMethodsFilter $paymentMethodsFilter
+    ) {
+        $this->paymentMethodsFilter = $paymentMethodsFilter;
+    }
+
+    public function afterGetPaymentInformation(
+        MagentoPaymentInformationManagement $magentoPaymentInformationManagement,
+        PaymentDetailsInterface $result,
+        int $cartId
+    ): PaymentDetailsInterface {
+        $magentoPaymentMethods = $result->getPaymentMethods();
+
+        list($magentoPaymentMethods, $adyenPaymentMethodsResponse) =
+            $this->paymentMethodsFilter->sortAndFilterPaymentMethods($magentoPaymentMethods, $cartId);
+
+        $result->setPaymentMethods($magentoPaymentMethods);
+
+        $extensionAttributes = $result->getExtensionAttributes();
+        $extensionAttributes->setAdyenPaymentMethodsResponse($adyenPaymentMethodsResponse);
+        $result->setExtensionAttributes($extensionAttributes);
+
+        return $result;
+    }
+}

--- a/Plugin/ShippingInformationManagement.php
+++ b/Plugin/ShippingInformationManagement.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2023 Adyen N.V. (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\Payment\Plugin;
+
+use Adyen\Payment\Helper\PaymentMethodsFilter;
+use Magento\Checkout\Api\Data\PaymentDetailsInterface;
+use Magento\Checkout\Api\Data\ShippingInformationInterface;
+use Magento\Checkout\Model\PaymentDetailsFactory;
+use Magento\Checkout\Model\ShippingInformationManagement as MagentoShippingInformationManagement;
+
+class ShippingInformationManagement
+{
+    protected PaymentMethodsFilter $paymentMethodsFilter;
+
+    public function __construct(
+        PaymentMethodsFilter $paymentMethodsFilter
+    ) {
+        $this->paymentMethodsFilter = $paymentMethodsFilter;
+    }
+
+    public function afterSaveAddressInformation(
+        MagentoShippingInformationManagement $shippingInformationManagement,
+        PaymentDetailsInterface $result,
+        int $cartId,
+        ShippingInformationInterface $addressInformation
+    ): PaymentDetailsInterface {
+        $magentoPaymentMethods = $result->getPaymentMethods();
+
+        list($magentoPaymentMethods, $adyenPaymentMethodsResponse) =
+            $this->paymentMethodsFilter->sortAndFilterPaymentMethods($magentoPaymentMethods, $cartId);
+
+        $result->setPaymentMethods($magentoPaymentMethods);
+
+        $extensionAttributes = $result->getExtensionAttributes();
+        $extensionAttributes->setAdyenPaymentMethodsResponse($adyenPaymentMethodsResponse);
+        $result->setExtensionAttributes($extensionAttributes);
+
+        return $result;
+    }
+}

--- a/Test/Unit/Helper/PaymentMethodsFilterTest.php
+++ b/Test/Unit/Helper/PaymentMethodsFilterTest.php
@@ -1,0 +1,216 @@
+<?php
+/**
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2023 Adyen N.V. (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\Payment\Test\Unit\Helper;
+
+use Adyen\Payment\Helper\PaymentMethods;
+use Adyen\Payment\Helper\PaymentMethodsFilter;
+use Adyen\Payment\Test\Unit\AbstractAdyenTestCase;
+use Magento\Payment\Model\Method\Adapter;
+use Magento\Quote\Api\CartRepositoryInterface;
+use Magento\Quote\Api\Data\CartInterface;
+use Magento\Sales\Model\Order\Address;
+
+class PaymentMethodsFilterTest extends AbstractAdyenTestCase
+{
+    const PAYMENT_METHODS = [
+        'adyen_alma',
+        'adyen_paypal',
+        'adyen_sepadirectdebit',
+        'unknown',
+        'adyen_clearpay',
+        'adyen_ideal',
+        'adyen_amazonpay',
+        'undefined',
+        'adyen_klarna_account'
+    ];
+
+    const PAYMENT_METHODS_SORTED = [
+        'adyen_sepadirectdebit',
+        'adyen_alma',
+        'adyen_paypal',
+        'adyen_clearpay',
+        'adyen_klarna_account',
+        'unknown',
+        'undefined'
+    ];
+
+    const PAYMENT_METHODS_RESPONSE = <<<JSON
+        {
+          "paymentMethodsResponse": {
+            "paymentMethods": [
+              {
+                "name": "SEPA Direct Debit",
+                "type": "sepadirectdebit"
+              },
+              {
+                "name": "Alma",
+                "type": "alma"
+              },
+              {
+                "configuration": {
+                  "merchantId": "xxxxx",
+                  "intent": "authorize"
+                },
+                "name": "PayPal",
+                "type": "paypal"
+              },
+              {
+                "name": "Clearpay",
+                "type": "clearpay"
+              },
+              {
+                "name": "Pay over time with Klarna.",
+                "type": "klarna_account"
+              }
+            ]
+          },
+          "paymentMethodsExtraDetails": {
+            "sepadirectdebit": {
+              "icon": {
+                "url": "https://192.168.58.20/static/version1695118335/frontend/Magento/luma/en_US/Adyen_Payment/images/logos/sepadirectdebit.svg",
+                "width": 77,
+                "height": 50
+              },
+              "isOpenInvoice": false,
+              "configuration": {
+                "amount": {
+                  "value": 5900,
+                  "currency": "EUR"
+                },
+                "currency": "EUR"
+              }
+            },
+            "alma": {
+              "icon": {
+                "url": "https://192.168.58.20/static/version1695118335/frontend/Magento/luma/en_US/Adyen_Payment/images/logos/alma.svg",
+                "width": 77,
+                "height": 50
+              },
+              "isOpenInvoice": false,
+              "configuration": {
+                "amount": {
+                  "value": 5900,
+                  "currency": "EUR"
+                },
+                "currency": "EUR"
+              }
+            },
+            "paypal": {
+              "icon": {
+                "url": "https://192.168.58.20/static/version1695118335/frontend/Magento/luma/en_US/Adyen_Payment/images/logos/paypal.svg",
+                "width": 77,
+                "height": 50
+              },
+              "isOpenInvoice": false,
+              "configuration": {
+                "amount": {
+                  "value": 5900,
+                  "currency": "EUR"
+                },
+                "currency": "EUR"
+              }
+            },
+            "clearpay": {
+              "icon": {
+                "url": "https://192.168.58.20/static/version1695118335/frontend/Magento/luma/en_US/Adyen_Payment/images/logos/clearpay.svg",
+                "width": 77,
+                "height": 50
+              },
+              "isOpenInvoice": true,
+              "configuration": {
+                "amount": {
+                  "value": 5900,
+                  "currency": "EUR"
+                },
+                "currency": "EUR"
+              }
+            },
+            "klarna_account": {
+              "icon": {
+                "url": "https://192.168.58.20/static/version1695118335/frontend/Magento/luma/en_US/Adyen_Payment/images/logos/klarna_account.svg",
+                "width": 77,
+                "height": 50
+              },
+              "isOpenInvoice": true,
+              "configuration": {
+                "amount": {
+                  "value": 5900,
+                  "currency": "EUR"
+                },
+                "currency": "EUR"
+              }
+            }
+          }
+        }
+    JSON;
+
+    private array $magentoPaymentMethods;
+
+    public function __construct(?string $name = null, array $data = [], $dataName = '')
+    {
+        parent::__construct($name, $data, $dataName);
+
+        foreach (self::PAYMENT_METHODS as $paymentMethod) {
+            $this->magentoPaymentMethods[] = $this->createConfiguredMock(Adapter::class, [
+                'getCode' => $paymentMethod
+            ]);
+        }
+    }
+
+    public function testSortAndFilterPaymentMethods()
+    {
+        $quoteMock = $this->createConfiguredMock(CartInterface::class, [
+            'getId' => 1,
+            'getBillingAddress' => $this->createConfiguredMock(Address::class, [
+                'getCountryId' => 1
+            ])
+        ]);
+
+        $cartRepositoryInterfaceMock = $this->createConfiguredMock(CartRepositoryInterface::class, [
+            'get' => $quoteMock
+        ]);
+
+        $paymentMethodsHelperMock = $this->createConfiguredMock(PaymentMethods::class, [
+            'getPaymentMethods' => self::PAYMENT_METHODS_RESPONSE
+        ]);
+
+        $paymentMethodsFilterHelper = $this->createPaymentMethodsFilterHelper(
+            $paymentMethodsHelperMock,
+            $cartRepositoryInterfaceMock
+        );
+
+        $sortedMagentoPaymentMethods =
+            $paymentMethodsFilterHelper->sortAndFilterPaymentMethods($this->magentoPaymentMethods, 1)[0];
+
+        $assertArray = [];
+        foreach ($sortedMagentoPaymentMethods as $paymentMethod) {
+            $assertArray[] = $paymentMethod->getCode();
+        };
+
+        $this->assertEquals(self::PAYMENT_METHODS_SORTED, $assertArray);
+    }
+
+    protected function createPaymentMethodsFilterHelper(
+        $paymentMethodsHelperMock = null,
+        $cartRepositoryInterfaceMock = null
+    ) {
+        if (is_null($paymentMethodsHelperMock)) {
+            $paymentMethodsHelperMock = $this->createMock(PaymentMethods::class);
+        }
+
+        if (is_null($cartRepositoryInterfaceMock)) {
+            $cartRepositoryInterfaceMock = $this->createMock(CartRepositoryInterface::class);
+        }
+
+        return new PaymentMethodsFilter($paymentMethodsHelperMock, $cartRepositoryInterfaceMock);
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1578,9 +1578,13 @@
     <type name="Magento\Vault\Model\CustomerTokenManagement">
         <plugin name="FilterVaultTokens" type="Adyen\Payment\Plugin\CustomerFilterVaultTokens" sortOrder="10" />
     </type>
-    <type name="Magento\Payment\Model\MethodList">
-        <plugin name="FilterSortCheckoutPaymentMethods" type="Adyen\Payment\Plugin\FilterSortPaymentMethods" sortOrder="10" />
+    <type name="Magento\Checkout\Model\PaymentInformationManagement">
+        <plugin name="CustomPaymentInformationManagement" type="Adyen\Payment\Plugin\PaymentInformationManagement" sortOrder="10" />
     </type>
+    <type name="Magento\Checkout\Model\ShippingInformationManagement">
+        <plugin name="CustomShippingInformationManagement" type="Adyen\Payment\Plugin\ShippingInformationManagement" sortOrder="10" />
+    </type>
+
     <virtualType name="AdyenCancelOrders" type="Adyen\Payment\Cron\CancelOrders">
         <arguments>
             <argument name="providers" xsi:type="array">

--- a/etc/extension_attributes.xml
+++ b/etc/extension_attributes.xml
@@ -1,0 +1,18 @@
+<!--
+/**
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2015 Adyen BV (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+-->
+
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:Api/etc/extension_attributes.xsd">
+    <extension_attributes for="Magento\Checkout\Api\Data\PaymentDetailsInterface">
+        <attribute code="adyen_payment_methods_response" type="string" />
+    </extension_attributes>
+</config>

--- a/view/frontend/requirejs-config.js
+++ b/view/frontend/requirejs-config.js
@@ -13,6 +13,9 @@ var config = {
             'Magento_Checkout/js/action/set-shipping-information': {
               'Adyen_Payment/js/model/set-shipping-information-mixin': true
             },
+            'Magento_Checkout/js/action/get-payment-information': {
+                'Adyen_Payment/js/model/get-payment-information-mixin': true
+            },
             'Magento_Multishipping/js/payment': {
                 'Adyen_Payment/js/view/checkout/multishipping/payment-mixin': true
              },

--- a/view/frontend/web/js/model/get-payment-information-mixin.js
+++ b/view/frontend/web/js/model/get-payment-information-mixin.js
@@ -17,8 +17,8 @@ define([
 ) {
     'use strict';
 
-    return function (shippingInformationAction) {
-        return wrapper.wrap(shippingInformationAction, function (originalAction) {
+    return function (paymentInformationAction) {
+        return wrapper.wrap(paymentInformationAction, function (originalAction) {
             return originalAction().then(function (result) {
                 let adyenPaymentMethodsResponse = result.extension_attributes.adyen_payment_methods_response;
 

--- a/view/frontend/web/js/view/payment/adyen-methods.js
+++ b/view/frontend/web/js/view/payment/adyen-methods.js
@@ -12,23 +12,11 @@
 define(
     [
         'uiComponent',
-        'Magento_Checkout/js/model/payment/renderer-list',
-        'Adyen_Payment/js/model/adyen-payment-service',
-        'Adyen_Payment/js/model/adyen-configuration',
-        'Magento_Checkout/js/model/quote',
-        'Magento_Checkout/js/model/full-screen-loader',
-        'Magento_SalesRule/js/action/set-coupon-code',
-        'Magento_SalesRule/js/action/cancel-coupon'
+        'Magento_Checkout/js/model/payment/renderer-list'
     ],
     function (
         Component,
-        rendererList,
-        adyenPaymentService,
-        adyenConfiguration,
-        quote,
-        fullScreenLoader,
-        setCouponCodeAction,
-        cancelCouponAction
+        rendererList
     ) {
         'use strict';
 

--- a/view/frontend/web/js/view/payment/adyen-methods.js
+++ b/view/frontend/web/js/view/payment/adyen-methods.js
@@ -56,42 +56,6 @@ define(
         return Component.extend({
             initialize: function () {
                 this._super();
-
-                var billingAddressCountry = "";
-                var retrievePaymentMethods = function (){
-                    fullScreenLoader.startLoader();
-                    // Retrieve adyen payment methods
-                    adyenPaymentService.retrievePaymentMethods().done(function(paymentMethods) {
-                        try {
-                            paymentMethods = JSON.parse(paymentMethods);
-                        } catch(error) {
-                            console.log(error);
-                            paymentMethods = null;
-                        }
-                        adyenPaymentService.setPaymentMethods(paymentMethods);
-                        fullScreenLoader.stopLoader();
-                    }).fail(function() {
-                        console.log('Fetching the payment methods failed!');
-                    });
-                };
-                quote.billingAddress.subscribe(function(address) {
-                    if (!!quote.billingAddress()) {
-                        // In case the country hasn't changed don't retrieve new payment methods
-                        if (billingAddressCountry === quote.billingAddress().countryId) {
-                            return;
-                        }
-                        billingAddressCountry = quote.billingAddress().countryId;
-                        retrievePaymentMethods();
-                    }
-                });
-                //Retrieve payment methods to ensure the amount is updated, when applying the discount code
-                setCouponCodeAction.registerSuccessCallback(function () {
-                    retrievePaymentMethods();
-                });
-                //Retrieve payment methods to ensure the amount is updated, when canceling the discount code
-                cancelCouponAction.registerSuccessCallback(function () {
-                    retrievePaymentMethods();
-                });
             }
         });
     }

--- a/view/frontend/web/js/view/payment/method-renderer/adyen-pm-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-pm-method.js
@@ -107,7 +107,6 @@ define(
                                     : undefined,
                                 method: this.getTxVariant()
                             });
-                            this.renderCheckoutComponent();
                         }
                     }
                 }

--- a/view/frontend/web/template/payment/pm-form.html
+++ b/view/frontend/web/template/payment/pm-form.html
@@ -64,7 +64,7 @@
                 <!--/ko-->
 
                 <fieldset class="fieldset" data-bind='attr: {id: "payment_fieldset_" + getCode()}'>
-                    <div class="checkout-component-dock" data-bind="attr: { id: adyenPaymentMethod().method + 'Container'}"></div>
+                    <div class="checkout-component-dock" afterRender="renderCheckoutComponent()" data-bind="attr: { id: adyenPaymentMethod().method + 'Container'}"></div>
                 </fieldset>
 
                 <!-- ko if: showPlaceOrderButton() -->


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
After implementing #2180, `/paymentMethods` call through `/retrieve-adyen-payment-methods` on the frontend became redundant since a call has been made in the backend already to change sorting order of the payment methods and filtering them out.

In this PR, an extension attribute was created for `adyen_payment_methods_response` to store `/paymentMethods` call response. `payment-information` and `shipping-information` endpoints now extending that extension attribute to pass Adyen `/paymentMethods` call response to frontend.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- Logged-in user payment tests
- Guest user payment tests