### PR TITLE
[ECP-8616] Remove unused ACL resources defined for headless endpoints

### DIFF
--- a/etc/acl.xml
+++ b/etc/acl.xml
@@ -6,13 +6,7 @@
                 <resource id="Magento_Backend::system">
                     <resource id="Adyen_Payment::adyen" title="Adyen" translate="title" sortOrder="10">
                         <resource id="Adyen_Payment::notifications_overview" title="Notifications Overview" translate="title" sortOrder="10"/>
-                        <resource id="Adyen_Payment::guestPaymentMethods" title="Get payment methods for guest shoppers" sortOrder="20" />
-                        <resource id="Adyen_Payment::paymentMethods" title="Get payment methods for logged-in shoppers" sortOrder="30" />
-                        <resource id="Adyen_Payment::paymentDetails" title="Submit details for a payment" sortOrder="40" />
-                        <resource id="Adyen_Payment::stateData" title="Send state data in a separate request" sortOrder="50" />
-                        <resource id="Adyen_Payment::paymentStatus" title="Get order payment status" sortOrder="50" />
-                        <resource id="Adyen_Payment::donations" title="Submit Adyen Giving request" translate="title" sortOrder="60"/>
-                        <resource id="Adyen_Payment::support" title="Support" translate="title" sortOrder="70"/>
+                        <resource id="Adyen_Payment::support" title="Adyen Support Form" translate="title" sortOrder="20"/>
                     </resource>
                 </resource>
             </resource>

--- a/etc/webapi.xml
+++ b/etc/webapi.xml
@@ -120,7 +120,7 @@
     <route url="/V1/adyen/donations" method="POST">
         <service class="Adyen\Payment\Api\AdyenDonationsInterface" method="donate"/>
         <resources>
-            <resource ref="Adyen_Payment::donations"/>
+            <resource ref="anonymous"/>
         </resources>
     </route>
 


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Following ACL resources were removed because those endpoints now use `self` or `anonymous` resources depending on the type of the request.

- Adyen_Payment::guestPaymentMethods
- Adyen_Payment::paymentMethods
- Adyen_Payment::paymentDetails
- Adyen_Payment::stateData
- Adyen_Payment::paymentStatus
- Adyen_Payment::donations