### PR TITLE
[ECP-8652] Fix broken Amazon Pay payment

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/adyen-hpp-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-hpp-method.js
@@ -523,7 +523,12 @@ define(
                     selectedAlternativePaymentMethodType();
                 var validate = $(form).validation() &&
                     $(form).validation('isValid');
-                return validate && additionalValidators.validate() && this.isPlaceOrderActionAllowed();
+
+                if (['googlepay', 'paywithgoogle'].includes(selectedAlternativePaymentMethodType())) {
+                    return validate && additionalValidators.validate() && this.isPlaceOrderActionAllowed();
+                }
+
+                return validate && additionalValidators.validate();
             },
             isButtonActive: function() {
                 return this.getCode() == this.isChecked() &&


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
The fix introduced in PR #2198 breaks the payment flow of Amazon Pay and validation fails while mounting the third component. Previous fix is isolated for Google Pay only in this PR.
