### PR TITLE
[ECP-8609] Update Stored Payment Methods List in order to have all tokens shown.

### DIFF
--- a/Plugin/CustomerFilterVaultTokens.php
+++ b/Plugin/CustomerFilterVaultTokens.php
@@ -14,39 +14,46 @@ namespace Adyen\Payment\Plugin;
 use Adyen\Payment\Helper\Vault;
 use Magento\Store\Model\StoreManagerInterface;
 use Magento\Vault\Model\CustomerTokenManagement;
+use Magento\Framework\App\Request\Http;
 
 class CustomerFilterVaultTokens
 {
     private Vault $vaultHelper;
     private StoreManagerInterface $storeManager;
+    private Http $request;
 
     public function __construct(
         Vault $vaultHelper,
-        StoreManagerInterface $storeManager
+        StoreManagerInterface $storeManager,
+        Http $request
     ) {
         $this->vaultHelper = $vaultHelper;
         $this->storeManager = $storeManager;
+        $this->request = $request;
     }
 
     /**
-     * Returns filtered list of payment tokens for current customer session
+     * Returns filtered list of payment tokens for current customer session for Checkout
      * Hide token if it is specifically set to SUBSCRIPTION or UNSCHEDULED_CARD_ON_FILE
      */
     public function afterGetCustomerSessionTokens(
         CustomerTokenManagement $customerTokenManagement,
         array $customerSessionTokens
     ): array {
-        foreach ($customerSessionTokens as $key => $token) {
-            if (strpos((string) $token->getPaymentMethodCode(), 'adyen_') === 0) {
-                $tokenDetails = json_decode((string) $token->getTokenDetails());
-                $storeId = $this->storeManager->getStore()->getId();
-                if ((property_exists($tokenDetails, Vault::TOKEN_TYPE) &&
-                    in_array($tokenDetails->tokenType, [
-                            Vault::SUBSCRIPTION,
-                            Vault::UNSCHEDULED_CARD_ON_FILE]
-                    )) || !$this->vaultHelper->getPaymentMethodRecurringActive($token->getPaymentMethodCode(), $storeId)
-                ) {
-                    unset($customerSessionTokens[$key]);
+        $controllerModule 	= $this->request->getControllerModule();
+        if($controllerModule == 'Magento_Checkout') {
+            foreach ($customerSessionTokens as $key => $token) {
+                if (strpos((string)$token->getPaymentMethodCode(), 'adyen_') === 0) {
+                    $tokenDetails = json_decode((string)$token->getTokenDetails());
+                    $storeId = $this->storeManager->getStore()->getId();
+                    if ((property_exists($tokenDetails, Vault::TOKEN_TYPE) &&
+                            in_array($tokenDetails->tokenType, [
+                                    Vault::SUBSCRIPTION,
+                                    Vault::UNSCHEDULED_CARD_ON_FILE]
+                            )) || !$this->vaultHelper->getPaymentMethodRecurringActive($token->getPaymentMethodCode(), $storeId)
+                    ) {
+                        unset($customerSessionTokens[$key]);
+                    }
                 }
             }
         }


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
Filtering out the Subscription and UCoF tokens for the Checkout page and show all stored token on shoppers Account page.
**Tested scenarios**
Shopper can delete all types (CoF, UCoF, Susbcriptions) stored token from the Account page and cannot use UCof & Subscriptions for the checkout
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

Fixes  <!-- #-prefixed github issue number -->
