### PR TITLE
[ECP-8632] Define Amazon Pay sub-variants for manual capture

### DIFF
--- a/.github/docker-compose.e2e.yml
+++ b/.github/docker-compose.e2e.yml
@@ -20,6 +20,8 @@ services:
       - ADYEN_MERCHANT
       - GOOGLE_USERNAME
       - GOOGLE_PASSWORD
+      - WEBHOOK_USERNAME
+      - WEBHOOK_PASSWORD
 
     volumes:
       - ../../scripts/e2e.sh:/e2e.sh

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -65,6 +65,8 @@ jobs:
           ADYEN_API_KEY: ${{secrets.ADYEN_API_KEY}}
           ADYEN_CLIENT_KEY: ${{secrets.ADYEN_CLIENT_KEY}}
           ADYEN_MERCHANT: ${{secrets.ADYEN_MERCHANT}}
+          WEBHOOK_USERNAME: ${{secrets.WEBHOOK_USERNAME}}
+          WEBHOOK_PASSWORD: ${{secrets.WEBHOOK_PASSWORD}}
 
       - name: Archive test result artifacts
         if: always()

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -18,8 +18,8 @@ jobs:
       labels: ubuntu-latest-8-cores
     timeout-minutes: 20
     env:
-      PHP_VERSION: "8.2"
-      MAGENTO_VERSION: "2.4.6-p2"
+      PHP_VERSION: "8.1"
+      MAGENTO_VERSION: "2.4.5"
       ADMIN_USERNAME: ${{secrets.MAGENTO_ADMIN_USERNAME}}
       ADMIN_PASSWORD: ${{secrets.MAGENTO_ADMIN_PASSWORD}}
     steps:

--- a/.github/workflows/templates/docker-compose.yml
+++ b/.github/workflows/templates/docker-compose.yml
@@ -78,6 +78,8 @@ services:
       - ADYEN_MERCHANT
       - GOOGLE_USERNAME
       - GOOGLE_PASSWORD
+      - WEBHOOK_USERNAME
+      - WEBHOOK_PASSWORD
     volumes:
       - ../../scripts/e2e.sh:/e2e.sh
       - ../../scripts/e2e-all.sh:/e2e-all.sh

--- a/.github/workflows/test-repo-e2e-release.yml
+++ b/.github/workflows/test-repo-e2e-release.yml
@@ -13,8 +13,8 @@ jobs:
       labels: ubuntu-latest-8-cores
     timeout-minutes: 20
     env:
-      PHP_VERSION: "8.2"
-      MAGENTO_VERSION: "2.4.6-p2"
+      PHP_VERSION: "8.1"
+      MAGENTO_VERSION: "2.4.5"
       ADMIN_USERNAME: ${{secrets.MAGENTO_ADMIN_USERNAME}}
       ADMIN_PASSWORD: ${{secrets.MAGENTO_ADMIN_PASSWORD}}
     steps:

--- a/.github/workflows/test-repo-e2e-release.yml
+++ b/.github/workflows/test-repo-e2e-release.yml
@@ -66,6 +66,8 @@ jobs:
           ADYEN_MERCHANT: ${{secrets.ADYEN_MERCHANT}}
           GOOGLE_USERNAME: ${{secrets.GOOGLE_USERNAME}}
           GOOGLE_PASSWORD: ${{secrets.GOOGLE_PASSWORD}}
+          WEBHOOK_USERNAME: ${{secrets.WEBHOOK_USERNAME}}
+          WEBHOOK_PASSWORD: ${{secrets.WEBHOOK_PASSWORD}}
 
       - name: Archive test result artifacts
         if: always()

--- a/.github/workflows/test-repo-e2e.yml
+++ b/.github/workflows/test-repo-e2e.yml
@@ -25,8 +25,8 @@ jobs:
       labels: ubuntu-latest-8-cores
     timeout-minutes: 20
     env:
-      PHP_VERSION: "8.2"
-      MAGENTO_VERSION: "2.4.6-p2"
+      PHP_VERSION: "8.1"
+      MAGENTO_VERSION: "2.4.5"
       ADMIN_USERNAME: ${{secrets.MAGENTO_ADMIN_USERNAME}}
       ADMIN_PASSWORD: ${{secrets.MAGENTO_ADMIN_PASSWORD}}
     steps:

--- a/.github/workflows/test-repo-e2e.yml
+++ b/.github/workflows/test-repo-e2e.yml
@@ -78,6 +78,8 @@ jobs:
           ADYEN_MERCHANT: ${{secrets.ADYEN_MERCHANT}}
           GOOGLE_USERNAME: ${{secrets.GOOGLE_USERNAME}}
           GOOGLE_PASSWORD: ${{secrets.GOOGLE_PASSWORD}}
+          WEBHOOK_USERNAME: ${{secrets.WEBHOOK_USERNAME}}
+          WEBHOOK_PASSWORD: ${{secrets.WEBHOOK_PASSWORD}}
 
       - name: Archive test result artifacts
         if: always()

--- a/Helper/Util/PaymentMethodUtil.php
+++ b/Helper/Util/PaymentMethodUtil.php
@@ -61,7 +61,14 @@ class PaymentMethodUtil
         'walley_b2b',
         'mc_clicktopay',
         'visa_clicktopay',
-        'ach'
+        'ach',
+        'visa_amazonpay',
+        'mc_amazonpay',
+        'amex_amazonpay',
+        'discover_amazonpay',
+        'maestro_amazonpay',
+        'elo_amazonpay',
+        'jcb_amazonpay'
     ];
 
     const OPEN_INVOICE_PAYMENT_METHODS = [

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,5 @@
 sonar.organization=adyen
 sonar.projectKey=Adyen_adyen-magento2
-sonar.sources=.
 sonar.tests=Test/
 sonar.exclusions=vendor/**/*, or Test/**/*
 sonar.php.coverage.reportPaths=build/clover.xml

--- a/view/adminhtml/templates/config/webhook_test.phtml
+++ b/view/adminhtml/templates/config/webhook_test.phtml
@@ -29,7 +29,7 @@
                         } else {
                             resultText = response.responseJSON.statusCode;
                             if(resultText==='Success'){
-                                progressSpan.find('.test-').show();
+                                progressSpan.find('.test-configured').show();
                             }
                         }
                         jQuery('#adyen_webhook_test_message').text(resultText);
@@ -48,7 +48,7 @@
 
         });
 </script>
-<?php if ($block->isWebhookId()) : ?>
+<?php if ($block->isWebhookIdConfigured()) : ?>
     <?php echo $block->getButtonHtml() ?>
     <span class="adyen_webhook_test_config" id="webhook_progress">
         <img class="test-processing" hidden="hidden" alt="Configuring" style="margin:0 5px" src="<?php echo $block->getViewFileUrl('images/process_spinner.gif') ?>"/>

--- a/view/adminhtml/templates/config/webhook_test.phtml
+++ b/view/adminhtml/templates/config/webhook_test.phtml
@@ -15,28 +15,28 @@
                     loaderArea:     false,
                     asynchronous:   true,
                     onCreate: function() {
-                        progressSpan.find('.configured').hide();
-                        progressSpan.find('.processing').show();
+                        progressSpan.find('.test-configured').hide();
+                        progressSpan.find('.test-processing').show();
                         jQuery('#adyen_webhook_test_message').text('');
                         jQuery("#adyen_webhook_test").prop('disabled', true);
                     },
                     onSuccess: function (response) {
                         //add html response
-                        progressSpan.find('.processing').hide();
+                        progressSpan.find('.test-processing').hide();
                         let resultText = '';
                         if (response.responseJSON === null) {
                             resultText = "No response";
                         } else {
                             resultText = response.responseJSON.statusCode;
                             if(resultText==='Success'){
-                                progressSpan.find('.configured').show();
+                                progressSpan.find('.test-').show();
                             }
                         }
                         jQuery('#adyen_webhook_test_message').text(resultText);
                     },
                     onFailure: function(response)
                     {
-                        progressSpan.find('.processing').hide();
+                        progressSpan.find('.test-processing').hide();
                         jQuery('#adyen_webhook_test_message').text("Failed").show();
                     },
                     onComplete: function()
@@ -48,11 +48,11 @@
 
         });
 </script>
-<?php if ($block->isWebhookIdConfigured()) : ?>
+<?php if ($block->isWebhookId()) : ?>
     <?php echo $block->getButtonHtml() ?>
     <span class="adyen_webhook_test_config" id="webhook_progress">
-        <img class="processing" hidden="hidden" alt="Configuring" style="margin:0 5px" src="<?php echo $block->getViewFileUrl('images/process_spinner.gif') ?>"/>
-        <img class="configured" hidden="hidden" alt="Configured" style="margin:-3px 5px" src="<?php echo $block->getViewFileUrl('images/rule_component_apply.gif') ?>"/>
+        <img class="test-processing" hidden="hidden" alt="Configuring" style="margin:0 5px" src="<?php echo $block->getViewFileUrl('images/process_spinner.gif') ?>"/>
+        <img class="test-configured" hidden="hidden" alt="Configured" style="margin:-3px 5px" src="<?php echo $block->getViewFileUrl('images/rule_component_apply.gif') ?>"/>
         <span id="adyen_webhook_test_message"></span>
         <div id="adyen_webhook_test_errors" class="message-system-inner">
             <div class="message message-warning"></div>

--- a/view/adminhtml/templates/config/webhook_test.phtml
+++ b/view/adminhtml/templates/config/webhook_test.phtml
@@ -5,7 +5,6 @@
         ],
         function(jQuery)
         {
-            jQuery('#adyen_webhook_test_errors').hide();
             let progressSpan = jQuery('#webhook_progress');
             jQuery('#adyen_webhook_test').click(function () {
 
@@ -54,9 +53,6 @@
         <img class="test-processing" hidden="hidden" alt="Configuring" style="margin:0 5px" src="<?php echo $block->getViewFileUrl('images/process_spinner.gif') ?>"/>
         <img class="test-configured" hidden="hidden" alt="Configured" style="margin:-3px 5px" src="<?php echo $block->getViewFileUrl('images/rule_component_apply.gif') ?>"/>
         <span id="adyen_webhook_test_message"></span>
-        <div id="adyen_webhook_test_errors" class="message-system-inner">
-            <div class="message message-warning"></div>
-        </div>
     </span>
     <p class="note">
         <span><?php echo __('Sends sample notifications to test if the webhook is set up correctly.'); ?></span>


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Following Amazon Pay sub-variants were added to manual capture payment method list.
- visa_amazonpay
- mc_amazonpay
- amex_amazonpay
- discover_amazonpay
- maestro_amazonpay
- elo_amazonpay
- jcb_amazonpa

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- Amazon Pay manual capture