### PR TITLE
Prevent to pass float when int expected

### DIFF
--- a/Helper/RateLimiter.php
+++ b/Helper/RateLimiter.php
@@ -112,6 +112,6 @@ class RateLimiter
     private function calculateNotificationCacheLifetime($numberOfAttempts)
     {
 
-        return max(self::INITIAL_COOLDOWN_PERIOD, pow(self::POWER, $numberOfAttempts));
+        return min(PHP_INT_MAX, max(self::INITIAL_COOLDOWN_PERIOD, pow(self::POWER, $numberOfAttempts)));
     }
 }


### PR DESCRIPTION
**Description**

When you have at least 63 consecutive calls, the lifetime exceeds the PHP max int limit and is converted as a float.
This fix prevent this case and use the PHP max int available value.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

Fixes  <!-- #-prefixed github issue number -->
