### PR TITLE
[ECP-8670] Giftcard order amount is wrong

### DIFF
--- a/view/frontend/web/js/helper/currencyHelper.js
+++ b/view/frontend/web/js/helper/currencyHelper.js
@@ -1,0 +1,53 @@
+/**
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2023 Adyen NV (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+define([], function () {
+    'use strict';
+
+    return {
+        decimalNumbers: function (currency) {
+            let format;
+            switch (currency) {
+                case "CVE":
+                case "DJF":
+                case "GNF":
+                case "IDR":
+                case "JPY":
+                case "KMF":
+                case "KRW":
+                case "PYG":
+                case "RWF":
+                case "UGX":
+                case "VND":
+                case "VUV":
+                case "XAF":
+                case "XOF":
+                case "XPF":
+                    format = 0;
+                    break;
+                case "BHD":
+                case "IQD":
+                case "JOD":
+                case "KWD":
+                case "LYD":
+                case "OMR":
+                case "TND":
+                    format = 3;
+                    break;
+                default:
+                    format = 2;
+            }
+            return format;
+        },
+        formatAmount: function (amount, currency) {
+            let decimals = this.decimalNumbers(currency);
+            return parseInt(amount.toFixed(decimals).replace('.', ''));
+        }
+    };
+});


### PR DESCRIPTION
**Description**
The issue this PR addresses is that the pay button of the giftcard shows wrong amount (no shipping cost) if the full amount is covered by the giftcard. As the shipping address selection isn't included at the point we are obtaining and sending the quote amount to the frontend when initiating the giftcard component, this PR adds the obtaining of the shipping costs to the balance check event listener. 

**Tested scenarios**
- make sure the shipping costs are included in the amount redeemed by the giftcard and rendered correctly in the pay button
