### PR TITLE
[ECP-8591] Anomaly in Payment Method Transition: Persistence of cc_type Value Despite Payment Method Change

### DIFF
--- a/Observer/AdyenBoletoDataAssignObserver.php
+++ b/Observer/AdyenBoletoDataAssignObserver.php
@@ -11,6 +11,7 @@
 
 namespace Adyen\Payment\Observer;
 
+use Adyen\Payment\Helper\Data;
 use Magento\Framework\Event\Observer;
 use Magento\Payment\Observer\AbstractDataAssignObserver;
 use Magento\Quote\Api\Data\PaymentInterface;
@@ -33,17 +34,17 @@ class AdyenBoletoDataAssignObserver extends AbstractDataAssignObserver
     ];
 
     /**
-     * @var \Adyen\Payment\Helper\Data
+     * @var Data
      */
     private $adyenHelper;
 
     /**
      * AdyenBoletoDataAssignObserver constructor.
      *
-     * @param \Adyen\Payment\Helper\Data $adyenHelper
+     * @param Data $adyenHelper
      */
     public function __construct(
-        \Adyen\Payment\Helper\Data $adyenHelper
+        Data $adyenHelper
     ) {
         $this->adyenHelper = $adyenHelper;
     }
@@ -65,6 +66,9 @@ class AdyenBoletoDataAssignObserver extends AbstractDataAssignObserver
 
         // Remove remaining brand_code information from the previous payment
         $paymentInfo->unsAdditionalInformation('brand_code');
+
+        // Remove cc_type information from the previous payment
+        $paymentInfo->unsAdditionalInformation('cc_type');
 
         if (!empty($additionalData[self::BOLETO_TYPE])) {
             $paymentInfo->setCcType($additionalData[self::BOLETO_TYPE]);

--- a/Observer/AdyenCcDataAssignObserver.php
+++ b/Observer/AdyenCcDataAssignObserver.php
@@ -98,6 +98,9 @@ class AdyenCcDataAssignObserver extends AbstractDataAssignObserver
         // Remove remaining brand_code information from the previous payment
         $paymentInfo->unsAdditionalInformation('brand_code');
 
+        // Remove cc_type information from the previous payment
+        $paymentInfo->unsAdditionalInformation('cc_type');
+
         // Get additional data array
         $additionalData = $data->getData(PaymentInterface::KEY_ADDITIONAL_DATA);
         if (!is_array($additionalData)) {

--- a/Observer/AdyenHppDataAssignObserver.php
+++ b/Observer/AdyenHppDataAssignObserver.php
@@ -92,6 +92,9 @@ class AdyenHppDataAssignObserver extends AbstractDataAssignObserver
         $data = $this->readDataArgument($observer);
         $paymentInfo = $this->readPaymentModelArgument($observer);
 
+        // Remove cc_type information from the previous payment
+        $paymentInfo->unsAdditionalInformation('cc_type');
+
         // Get additional data array
         $additionalData = $data->getData(PaymentInterface::KEY_ADDITIONAL_DATA);
         if (!is_array($additionalData)) {

--- a/Observer/AdyenMotoDataAssignObserver.php
+++ b/Observer/AdyenMotoDataAssignObserver.php
@@ -85,6 +85,9 @@ class AdyenMotoDataAssignObserver extends AbstractDataAssignObserver
         $data = $this->readDataArgument($observer);
         $paymentInfo = $this->readPaymentModelArgument($observer);
 
+        // Remove cc_type information from the previous payment
+        $paymentInfo->unsAdditionalInformation('cc_type');
+
         // Get additional data array
         $additionalData = $data->getData(PaymentInterface::KEY_ADDITIONAL_DATA);
         if (!is_array($additionalData)) {

--- a/Observer/AdyenOneclickDataAssignObserver.php
+++ b/Observer/AdyenOneclickDataAssignObserver.php
@@ -15,9 +15,12 @@ use Adyen\Payment\Helper\Data;
 use Adyen\Payment\Helper\StateData;
 use Adyen\Payment\Helper\Util\CheckoutStateDataValidator;
 use Adyen\Payment\Helper\Util\DataArrayValidator;
+use Adyen\Payment\Model\RecurringType;
 use Adyen\Payment\Model\ResourceModel\StateData\Collection;
+use Magento\Backend\App\Area\FrontNameResolver;
 use Magento\Framework\App\State;
 use Magento\Framework\Event\Observer;
+use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Model\Context;
 use Magento\Payment\Observer\AbstractDataAssignObserver;
 use Magento\Quote\Api\Data\PaymentInterface;
@@ -101,6 +104,9 @@ class AdyenOneclickDataAssignObserver extends AbstractDataAssignObserver
         // Remove remaining brand_code information from the previous payment
         $paymentInfo->unsAdditionalInformation('brand_code');
 
+        // Remove cc_type information from the previous payment
+        $paymentInfo->unsAdditionalInformation('cc_type');
+
         // Get additional data array
         $additionalData = $data->getData(PaymentInterface::KEY_ADDITIONAL_DATA);
         if (!is_array($additionalData)) {
@@ -141,7 +147,7 @@ class AdyenOneclickDataAssignObserver extends AbstractDataAssignObserver
 
         // set customerInteraction
         $recurringContractType = $this->getRecurringPaymentType();
-        if ($recurringContractType == \Adyen\Payment\Model\RecurringType::ONECLICK) {
+        if ($recurringContractType == RecurringType::ONECLICK) {
             $paymentInfo->setAdditionalInformation('customer_interaction', true);
         } else {
             $paymentInfo->setAdditionalInformation('customer_interaction', false);
@@ -152,13 +158,13 @@ class AdyenOneclickDataAssignObserver extends AbstractDataAssignObserver
      * For admin use RECURRING contract for front-end get it from configuration
      *
      * @return mixed|string
-     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws LocalizedException
      */
     public function getRecurringPaymentType()
     {
         // For admin always use Recurring
-        if ($this->appState->getAreaCode() === \Magento\Backend\App\Area\FrontNameResolver::AREA_CODE) {
-            return \Adyen\Payment\Model\RecurringType::RECURRING;
+        if ($this->appState->getAreaCode() === FrontNameResolver::AREA_CODE) {
+            return RecurringType::RECURRING;
         } else {
             return $this->adyenHelper->getAdyenOneclickConfigData('recurring_payment_type');
         }

--- a/Observer/AdyenPayByLinkDataAssignObserver.php
+++ b/Observer/AdyenPayByLinkDataAssignObserver.php
@@ -39,6 +39,9 @@ class AdyenPayByLinkDataAssignObserver extends AbstractDataAssignObserver
         $data = $this->readDataArgument($observer);
         $paymentInfo = $this->readPaymentModelArgument($observer);
 
+        // Remove cc_type information from the previous payment
+        $paymentInfo->unsAdditionalInformation('cc_type');
+
         // Get additional data array
         $additionalData = $data->getData(PaymentInterface::KEY_ADDITIONAL_DATA);
         if (!is_array($additionalData)) {

--- a/Observer/AdyenPosCloudDataAssignObserver.php
+++ b/Observer/AdyenPosCloudDataAssignObserver.php
@@ -47,6 +47,9 @@ class AdyenPosCloudDataAssignObserver extends AbstractDataAssignObserver
 
         $paymentInfo = $this->readPaymentModelArgument($observer);
 
+        // Remove cc_type information from the previous payment
+        $paymentInfo->unsAdditionalInformation('cc_type');
+
         foreach ($this->additionalInformationList as $additionalInformationKey) {
             if (!empty($additionalData[$additionalInformationKey])) {
                 $paymentInfo->setAdditionalInformation(


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
After canceling a 3DS CC payment and choosing any other giftcard, the cc_type field has retained the value. This PR unsets it for all other payment methods.
<!-- Please provide a description of the changes proposed in the Pull Request -->
Unset the cc_type value for the related observers
**Tested scenarios**
<!-- Description of tested scenarios -->
Tried changing the payment method and checking the respective fields in DB, it holds correct value as expected.
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

Fixes  <!-- #-prefixed github issue number -->
