### PR TITLE
[ECP- 8591] Anomaly in Payment Method Transition: Persistence of cc_type Value Despite Payment Method Change

### DIFF
--- a/Observer/AdyenBoletoDataAssignObserver.php
+++ b/Observer/AdyenBoletoDataAssignObserver.php
@@ -3,7 +3,7 @@
  *
  * Adyen Payment module (https://www.adyen.com/)
  *
- * Copyright (c) 2015 Adyen BV (https://www.adyen.com/)
+ * Copyright (c) 2023 Adyen BV (https://www.adyen.com/)
  * See LICENSE.txt for license details.
  *
  * Author: Adyen <magento@adyen.com>
@@ -23,34 +23,21 @@ class AdyenBoletoDataAssignObserver extends AbstractDataAssignObserver
     const FIRSTNAME = 'firstname';
     const LASTNAME = 'lastname';
 
-    /**
-     * @var array
-     */
-    protected $additionalInformationList = [
+    protected array $additionalInformationList = [
         self::SOCIAL_SECURITY_NUMBER,
         self::BOLETO_TYPE,
         self::FIRSTNAME,
         self::LASTNAME
     ];
 
-    /**
     private Config $configHelper;
 
-    /**
-     * AdyenBoletoDataAssignObserver constructor.
-     *
-     * @param Config $configHelper
-     */
     public function __construct(
         Config $configHelper
     ) {
         $this->configHelper = $configHelper;
     }
 
-    /**
-     * @param Observer $observer
-     * @return void
-     */
     public function execute(Observer $observer)
     {
         $data = $this->readDataArgument($observer);

--- a/Observer/AdyenBoletoDataAssignObserver.php
+++ b/Observer/AdyenBoletoDataAssignObserver.php
@@ -11,6 +11,7 @@
 
 namespace Adyen\Payment\Observer;
 
+use Adyen\Payment\Helper\Config;
 use Magento\Framework\Event\Observer;
 use Magento\Payment\Observer\AbstractDataAssignObserver;
 use Magento\Quote\Api\Data\PaymentInterface;
@@ -33,17 +34,17 @@ class AdyenBoletoDataAssignObserver extends AbstractDataAssignObserver
     ];
 
     /**
-     * @var \Adyen\Payment\Helper\Config
+     * @var Config
      */
     private $configHelper;
 
     /**
      * AdyenBoletoDataAssignObserver constructor.
      *
-     * @param \Adyen\Payment\Helper\Config $configHelper
+     * @param Config $configHelper
      */
     public function __construct(
-        \Adyen\Payment\Helper\Config $configHelper
+        Config $configHelper
     ) {
         $this->configHelper = $configHelper;
     }
@@ -62,6 +63,9 @@ class AdyenBoletoDataAssignObserver extends AbstractDataAssignObserver
         }
 
         $paymentInfo = $this->readPaymentModelArgument($observer);
+
+        // Remove cc_type information from the previous payment
+        $paymentInfo->unsAdditionalInformation('cc_type');
 
         // Remove remaining brand_code information from the previous payment
         $paymentInfo->unsAdditionalInformation('brand_code');

--- a/Observer/AdyenBoletoDataAssignObserver.php
+++ b/Observer/AdyenBoletoDataAssignObserver.php
@@ -34,9 +34,7 @@ class AdyenBoletoDataAssignObserver extends AbstractDataAssignObserver
     ];
 
     /**
-     * @var Config
-     */
-    private $configHelper;
+    private Config $configHelper;
 
     /**
      * AdyenBoletoDataAssignObserver constructor.

--- a/Observer/AdyenCcDataAssignObserver.php
+++ b/Observer/AdyenCcDataAssignObserver.php
@@ -98,6 +98,9 @@ class AdyenCcDataAssignObserver extends AbstractDataAssignObserver
         // Remove remaining brand_code information from the previous payment
         $paymentInfo->unsAdditionalInformation('brand_code');
 
+        // Remove cc_type information from the previous payment
+        $paymentInfo->unsAdditionalInformation('cc_type');
+
         // Get additional data array
         $additionalData = $data->getData(PaymentInterface::KEY_ADDITIONAL_DATA);
         if (!is_array($additionalData)) {

--- a/Observer/AdyenMotoDataAssignObserver.php
+++ b/Observer/AdyenMotoDataAssignObserver.php
@@ -91,6 +91,9 @@ class AdyenMotoDataAssignObserver extends AbstractDataAssignObserver
             return;
         }
 
+        // Remove cc_type information from the previous payment
+        $paymentInfo->unsAdditionalInformation('cc_type');
+
         // Get a validated additional data array
         $additionalData = DataArrayValidator::getArrayOnlyWithApprovedKeys(
             $additionalData,

--- a/Observer/AdyenPayByLinkDataAssignObserver.php
+++ b/Observer/AdyenPayByLinkDataAssignObserver.php
@@ -39,6 +39,9 @@ class AdyenPayByLinkDataAssignObserver extends AbstractDataAssignObserver
         $data = $this->readDataArgument($observer);
         $paymentInfo = $this->readPaymentModelArgument($observer);
 
+        // Remove cc_type information from the previous payment
+        $paymentInfo->unsAdditionalInformation('cc_type');
+        
         // Get additional data array
         $additionalData = $data->getData(PaymentInterface::KEY_ADDITIONAL_DATA);
         if (!is_array($additionalData)) {

--- a/Observer/AdyenPaymentMethodDataAssignObserver.php
+++ b/Observer/AdyenPaymentMethodDataAssignObserver.php
@@ -68,6 +68,9 @@ class AdyenPaymentMethodDataAssignObserver extends AbstractDataAssignObserver
         $data = $this->readDataArgument($observer);
         $paymentInfo = $this->readPaymentModelArgument($observer);
 
+        // Remove cc_type information from the previous payment
+        $paymentInfo->unsAdditionalInformation('cc_type');
+
         // Get additional data array
         $additionalData = $data->getData(PaymentInterface::KEY_ADDITIONAL_DATA);
         if (!is_array($additionalData)) {

--- a/Observer/AdyenPosCloudDataAssignObserver.php
+++ b/Observer/AdyenPosCloudDataAssignObserver.php
@@ -38,6 +38,9 @@ class AdyenPosCloudDataAssignObserver extends AbstractDataAssignObserver
 
         $paymentInfo = $this->readPaymentModelArgument($observer);
 
+        // Remove cc_type information from the previous payment
+        $paymentInfo->unsAdditionalInformation('cc_type');
+
         foreach ($this->additionalInformationList as $additionalInformationKey) {
             if (array_key_exists($additionalInformationKey, $additionalData)) {
                 $paymentInfo->setAdditionalInformation(


### PR DESCRIPTION


<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
After canceling a 3DS CC payment and choosing any other giftcard, the cc_type field has retained the value. This PR unsets it for all other payment methods.

Unset the cc_type value for the related observers
<!-- Please provide a description of the changes proposed in the Pull Request -->

**Tested scenarios**
Tried changing the payment method and checking the respective fields in DB, it holds correct value as expected.
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

Fixes  <!-- #-prefixed github issue number -->
