### PR TITLE
Harden webhook processing against exceptions during invoice mail sending

### DIFF
--- a/Helper/Invoice.php
+++ b/Helper/Invoice.php
@@ -213,7 +213,7 @@ class Invoice extends AbstractHelper
             );
 
             if ($invoiceAutoMail) {
-                $this->invoiceSender->send($invoice);
+                $this->sendInvoiceMail($invoice);
             }
 
             return $invoice;
@@ -437,7 +437,7 @@ class Invoice extends AbstractHelper
         );
         $transactionSave->save();
 
-        $this->invoiceSender->send($invoice);
+        $this->sendInvoiceMail($invoice);
 
         //Send Invoice mail to customer
         $invoiceAutoMail = (bool)$this->scopeConfig->isSetFlag(
@@ -447,7 +447,7 @@ class Invoice extends AbstractHelper
         );
 
         if ($invoiceAutoMail) {
-            $this->invoiceSender->send($invoice);
+            $this->sendInvoiceMail($invoice);
             $order->addStatusHistoryComment(
                 __('Notified customer about invoice creation #%1.', $invoice->getId())
             );
@@ -477,5 +477,17 @@ class Invoice extends AbstractHelper
         ));
 
         return $adyenInvoice;
+    }
+
+    public function sendInvoiceMail(InvoiceModel $invoice)
+    {
+        try {
+            $this->invoiceSender->send($invoice);
+        } catch (Exception $exception) {
+            $this->adyenLogger->addAdyenWarning(
+                "Exception in Send Mail in Magento. This is an issue in the the core of Magento" .
+                $exception->getMessage()
+            );
+        }
     }
 }

--- a/Test/Unit/Helper/InvoiceTest.php
+++ b/Test/Unit/Helper/InvoiceTest.php
@@ -364,6 +364,35 @@ class InvoiceTest extends AbstractAdyenTestCase
         $this->assertInstanceOf(AdyenInvoice::class, $adyenInvoice);
     }
 
+    public function testSendInvoiceMailCatchesException()
+    {
+        $invoiceSenderMock = $this->createMock(InvoiceSender::class);
+        $invoiceModelMock = $this->createMock(InvoiceModel::class);
+
+        $invoiceSenderMock
+            ->expects($this->once())
+            ->method('send')
+            ->willThrowException(new \Exception('Test Exception Message'));
+
+        $invoiceHelper = $this->createInvoiceHelper(
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            $invoiceSenderMock
+        );
+
+        $invoiceHelper->sendInvoiceMail($invoiceModelMock);
+    }
+
     /**
      * @param $contextMock
      * @param $adyenLoggerMock


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
If an exception is thrown while the invoice mail is sent when an AUTHORISATION webhook notification is being processed, the order status will never be updated.

The cron will first process the webhook, then send the invoice mail and lastly save the updated order. Exceptions during sending of the invoice mail will interrupt this flow. The webhook will be marked as successfully processed, but the order stays in status "Payment review".

This change applies the same try-catch logic to the invoice sender that is already present in the order confirmation sender:
\Adyen\Payment\Helper\Order::sendOrderMail

**Tested scenarios**
\Adyen\Payment\Test\Unit\Helper\InvoiceTest::testSendInvoiceMailCatchesException makes sure that exceptions thrown inside of \Magento\Sales\Model\Order\Email\Sender\InvoiceSender::send are caught inside \Adyen\Payment\Helper\Invoice::sendInvoiceMail.

Fixes  #2022 