### PR TITLE
[ECP-8676] Auto-reconfiguring issue if Webhook does not exist in Adyen

### DIFF
--- a/Helper/ManagementHelper.php
+++ b/Helper/ManagementHelper.php
@@ -37,7 +37,7 @@ class ManagementHelper
      * @var Config
      */
     private $configHelper;
-    
+
     /**
      * @var EncryptorInterface
      */
@@ -172,35 +172,46 @@ class ManagementHelper
         $storeId = $this->storeManager->getStore()->getId();
         $webhookId = $this->configHelper->getWebhookId($storeId);
         $savedMerchantAccount = $this->configHelper->getMerchantAccount($storeId);
+        // Try to reuse saved webhookId if merchant account is the same.
+        if (!empty($webhookId) && $merchantId === $savedMerchantAccount) {
+            try {
+                $response = $managementApiService->merchantWebhooks->update($merchantId, $webhookId, $params);
+            } catch (AdyenException $exception){
+                $this->adyenLogger->error($exception->getMessage());
+            }
+        }
 
-        try {
-            // reuse saved webhookId if merchant account is the same.
-            if (!empty($webhookId) && $merchantId === $savedMerchantAccount) {
-                $managementApiService->merchantWebhooks->update($merchantId, $webhookId, $params);
-            } else {
+        // If update request fails, meas that webhook has been removed. Create new webhook.
+        if (!isset($response) || empty($webhookId)) {
+            try {
                 $params['type'] = 'standard';
                 $response = $managementApiService->merchantWebhooks->create($merchantId, $params);
                 // save webhook_id to configuration
                 $webhookId = $response['id'];
                 $this->configHelper->setConfigData($webhookId, 'webhook_id', Config::XML_ADYEN_ABSTRACT_PREFIX);
+            } catch (\Exception $exception) {
+                $this->adyenLogger->error($exception->getMessage());
             }
-
-            // generate hmac key and save
-            $response = $managementApiService->merchantWebhooks->generateHmac($merchantId, $webhookId);
-            $hmacKey = $response['hmacKey'];
-            $hmac = $this->encryptor->encrypt($hmacKey);
-            $mode = $demoMode ? 'test' : 'live';
-            $this->configHelper->setConfigData($hmac, 'notification_hmac_key_' . $mode, Config::XML_ADYEN_ABSTRACT_PREFIX);
-        } catch (\Exception $exception) {
-            $this->adyenLogger->error($exception->getMessage());
-
-            if (!$demoMode) {
-                throw $exception;
-            }
-
-            $this->messageManager->addErrorMessage(__("Credentials saved but webhook and HMAC key couldn't be generated! Please check the error logs."));
         }
 
+        if (!empty($webhookId)) {
+            try {
+                // generate hmac key and save
+                $response = $managementApiService->merchantWebhooks->generateHmac($merchantId, $webhookId);
+                $hmacKey = $response['hmacKey'];
+                $hmac = $this->encryptor->encrypt($hmacKey);
+                $mode = $demoMode ? 'test' : 'live';
+                $this->configHelper->setConfigData($hmac, 'notification_hmac_key_' . $mode, Config::XML_ADYEN_ABSTRACT_PREFIX);
+            } catch (\Exception $exception) {
+                $this->adyenLogger->error($exception->getMessage());
+
+                if (!$demoMode) {
+                    throw $exception;
+                }
+
+                $this->messageManager->addErrorMessage(__("Credentials saved but webhook and HMAC key couldn't be generated! Please check the error logs."));
+            }
+        }
         return $webhookId;
     }
 
@@ -246,7 +257,7 @@ class ManagementHelper
 
             $this->adyenLogger->info(
                 sprintf( 'response from webhook test %s',
-                json_encode($response))
+                    json_encode($response))
             );
 
             return $response;


### PR DESCRIPTION
**Description**
Currently, auto-reconfiguration of the plugin will not be successful if a webhook was already created in this way, and deleted in Adyen CA.
This scenario causes both the update and HMAC Key generation API requests, since the webhook with ID equals to the saved webhookID in Magento will not exist in Adyen.

This fix adds a check after update request. If it failed (no response), or the saved webhookId is empty, a new webhook should be created.

**Tested scenarios**
1. Create initial webhook for merchant account X (clean install and config)
2. Update created webhook (1.) by reconfiguring the plugin
3. Delete Webhook in Adyen and reconfigure the plugin to create new webhook automatically
4. Change merchant account and reconfigure plugin (creates new webhook on merchant account Y)
