### PR TITLE
[ECP-8627] - Null ccType on Pay by Link payments causes type issue

### DIFF
--- a/Helper/Webhook/OfferClosedWebhookHandler.php
+++ b/Helper/Webhook/OfferClosedWebhookHandler.php
@@ -58,6 +58,10 @@ class OfferClosedWebhookHandler implements WebhookHandlerInterface
      */
     public function handleWebhook(MagentoOrder $order, Notification $notification, string $transitionState): MagentoOrder
     {
+        //Do not process OfferClosed for Pay by Link payments
+        if($order->getPayment()->getMethod() == 'adyen_pay_by_link')
+            return $order;
+
         $capturedAdyenOrderPayments = $this->orderPaymentResourceModel->getLinkedAdyenOrderPayments(
             $order->getPayment()->getEntityId()
         );


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
If a payment has been completed with Pay by Link, ccType field couldn't be filled and it causes following error message while processing the OFFER_CLOSED notification.

OFFER_CLOSED notification is no more processed for Pay by Link payments
<!-- Please provide a description of the changes proposed in the Pull Request -->

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

Fixes  <!-- #-prefixed github issue number -->
https://github.com/Adyen/adyen-magento2/issues/2166