### PR TITLE
[ECP-8453v9] Null merchant reference causes failure on the webhook processing v9

### DIFF
--- a/Helper/Webhook.php
+++ b/Helper/Webhook.php
@@ -109,20 +109,7 @@ class Webhook
      */
     public function processNotification(Notification $notification): bool
     {
-        // set notification processing to true
-        $this->updateNotification($notification, true, false);
-        $this->logger
-            ->addAdyenNotification(
-                sprintf(
-                    "Processing %s notification %s",
-                    $notification->getEventCode(),
-                    $notification->getEntityId(),
-                ), [
-                    'merchantReference' => $notification->getMerchantReference(),
-                    'pspReference' => $notification->getPspreference()
-                ],
-            );
-
+        // check if merchant reference is set
         if (is_null($notification->getMerchantReference())) {
             $errorMessage = sprintf(
                 'Invalid merchant reference for notification with the event code %s',
@@ -136,6 +123,20 @@ class Webhook
 
             return false;
         }
+
+        // set notification processing to true
+        $this->updateNotification($notification, true, false);
+        $this->logger
+            ->addAdyenNotification(
+                sprintf(
+                    "Processing %s notification %s",
+                    $notification->getEventCode(),
+                    $notification->getEntityId(),
+                ), [
+                    'merchantReference' => $notification->getMerchantReference(),
+                    'pspReference' => $notification->getPspreference()
+                ],
+            );
 
         $order = $this->orderHelper->getOrderByIncrementId($notification->getMerchantReference());
         if (!$order) {


### PR DESCRIPTION
**Description**
Currently, [webhook](https://github.com/Adyen/adyen-magento2/blob/efe1f69b24d056ec370cea225970f44083dd036a/Helper/Webhook.php) helper throws an exception if the merchant reference is empty in the notification body and causes notification stays on Processing forever.

With this PR we are checking whether the merchant reference is set before executing the processing webhook logic.

**Tested scenarios**
- process the notification with the merchant reference
- process the notification without the merchant reference

Fixes  #2066
