### PR TITLE
[ECP-8679] Cancel invoices before order cancellation

### DIFF
--- a/Helper/Webhook/CancellationWebhookHandler.php
+++ b/Helper/Webhook/CancellationWebhookHandler.php
@@ -3,7 +3,7 @@
  *
  * Adyen Payment Module
  *
- * Copyright (c) 2022 Adyen N.V.
+ * Copyright (c) 2023 Adyen N.V.
  * This file is open source and available under the MIT license.
  * See the LICENSE file for more info.
  *
@@ -13,26 +13,60 @@
 namespace Adyen\Payment\Helper\Webhook;
 
 use Adyen\Payment\Helper\Order;
+use Adyen\Payment\Logger\AdyenLogger;
 use Adyen\Payment\Model\Notification;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Sales\Model\Order as MagentoOrder;
 
 class CancellationWebhookHandler implements WebhookHandlerInterface
 {
-    /** @var Order */
-    private $orderHelper;
+    private Order $orderHelper;
+    private AdyenLogger $adyenLogger;
 
     public function __construct(
-        Order $orderHelper
+        Order $orderHelper,
+        AdyenLogger $adyenLogger
     ) {
         $this->orderHelper = $orderHelper;
+        $this->adyenLogger = $adyenLogger;
     }
 
     /**
      * @throws LocalizedException
      */
-    public function handleWebhook(MagentoOrder $order, Notification $notification, string $transitionState): MagentoOrder
-    {
-        return $this->orderHelper->holdCancelOrder($order, true);
+    public function handleWebhook(
+        MagentoOrder $order,
+        Notification $notification,
+        string $transitionState
+    ): MagentoOrder {
+        /** @var MagentoOrder\Invoice $invoice */
+        $invoices = $order->getInvoiceCollection();
+
+        $allInvoicesCanCancel = true;
+        foreach ($invoices as $invoice)  {
+            if (!$invoice->canCancel()) {
+                $allInvoicesCanCancel = false;
+                break;
+            }
+        }
+
+        if ($allInvoicesCanCancel) {
+            foreach ($invoices as $invoice) {
+                $invoice->cancel();
+                $invoice->save();
+            }
+
+            $order = $this->orderHelper->holdCancelOrder($order, true);
+        } else {
+            $this->adyenLogger->addAdyenNotification(
+                "Order can not be cancelled because invoice has been paid.",
+                [
+                    'pspReference' => $notification->getPspreference(),
+                    'merchantReference' => $notification->getMerchantReference()
+                ]
+            );
+        }
+
+        return $order;
     }
 }


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
If there is an invoice linked to the order, order can't be cancelled with void. Cancel all the invoices before order cancellation.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- Manual capture order cancellation