### PR TITLE
Remove Magento_Paypal dependency from the plugin

### DIFF
--- a/etc/module.xml
+++ b/etc/module.xml
@@ -17,7 +17,6 @@
             <module name="Magento_Sales"/>
             <module name="Magento_Quote"/>
             <module name="Magento_Checkout"/>
-            <module name="Magento_Paypal"/>
             <module name="Magento_AdminNotification"/>
             <module name="Magento_Vault"/>
             <module name="Magento_Multishipping"/>


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
After deprecating the usage of billing agreement table, `Magento_Paypal` dependency can be removed from the plugin safely.