### PR TITLE
Fix sonarcloud regix backtracking

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/adyen-pm-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-pm-method.js
@@ -391,12 +391,13 @@ define(
 
                 function getStreetAndHouseNumberWithRegex(addressString) {
                     // Match addresses where the street name comes first, e.g. John-Paul's Ave. 1 B
-                    let streetFirstRegex = /(?<streetName>[a-zA-Z0-9.'\- ]+)\s+(?<houseNumber>\d{1,10}((\s)?\w{1,3})?)$/;
-                    // Match addresses where the house number comes first, e.g. 10 D John-Paul's Ave.
-                    let numberFirstRegex = /^(?<houseNumber>\d{1,10}((\s)?\w{1,3})?)\s+(?<streetName>[a-zA-Z0-9.'\- ]+)/;
+                    const streetFirstRegex = /^(?<streetName>[a-zA-Z0-9.'\- ]{1,100})\s+(?<houseNumber>\d{1,10}((\s)?\w{1,3})?)$/;
 
-                    let streetFirstAddress = addressString.match(streetFirstRegex);
-                    let numberFirstAddress = addressString.match(numberFirstRegex);
+                    // Match addresses where the house number comes first, e.g. 10 D John-Paul's Ave.
+                    const numberFirstRegex = /^(?<houseNumber>\d{1,10}((\s)?\w{1,3})?)\s+(?<streetName>[a-zA-Z0-9.'\- ]{1,100})$/;
+
+                    const streetFirstAddress = addressString.match(streetFirstRegex);
+                    const numberFirstAddress = addressString.match(numberFirstRegex);
 
                     if (streetFirstAddress) {
                         return streetFirstAddress.groups;


### PR DESCRIPTION
**Description**
Fix sonarcloud regix backtracking in view/frontend/web/js/view/payment/method-renderer/adyen-pm-method.js


Fixes  <!-- #-prefixed github issue number -->
Fix: Make sure the regex used here, which is vulnerable to super-linear runtime due to backtracking, cannot lead to denial of service.