### PR TITLE
Fix broken connected POS terminal list

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/adyen-pos-cloud-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-pos-cloud-method.js
@@ -114,13 +114,15 @@ define(
                 let connectedTerminals = [];
                 let connectedTerminalsList = adyenPaymentService.getConnectedTerminals();
 
-                for (let terminal of connectedTerminalsList()) {
-                    connectedTerminals.push(
-                        {
-                            key: terminal,
-                            value: terminal
-                        }
-                    );
+                if (!!connectedTerminalsList()) {
+                    for (let terminal of connectedTerminalsList()) {
+                        connectedTerminals.push(
+                            {
+                                key: terminal,
+                                value: terminal
+                            }
+                        );
+                    }
                 }
 
                 return connectedTerminals;


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
If the connected terminal list is empty, POS payment method template file fails to render. The value of the observable is checked before setting up the array.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- Empty terminal list
- POS payment