### PR TITLE
[ECP-8634] Fix the refund order of partial payments

### DIFF
--- a/Controller/Process/Json.php
+++ b/Controller/Process/Json.php
@@ -341,7 +341,15 @@ class Json extends Action
 
         // do this to set both fields in the correct timezone
         $date = new DateTime();
-        $notification->setCreatedAt($date);
+        if (isset($requestItem['eventDate'])) {
+            $eventDate = DateTime::createFromFormat(DATE_ATOM, $requestItem['eventDate']);
+            // Change webhook's timezone to server's timezone
+            if ($eventDate) {
+                $formattedEventDate = $eventDate->setTimezone($date->getTimezone());
+            }
+        }
+
+        $notification->setCreatedAt($formattedEventDate ?? $date);
         $notification->setUpdatedAt($date);
     }
 

--- a/Gateway/Request/RefundDataBuilder.php
+++ b/Gateway/Request/RefundDataBuilder.php
@@ -112,7 +112,7 @@ class RefundDataBuilder implements BuilderInterface
             ->addFieldToFilter('payment_id', $payment->getId());
 
         // partial refund if multiple payments check refund strategy
-        if ($orderPaymentCollection->getSize() > self::REFUND_STRATEGY_ASCENDING_ORDER) {
+        if ($orderPaymentCollection->getSize() > 1) {
             $refundStrategy = $this->adyenHelper->getAdyenAbstractConfigData(
                 'partial_payments_refund_strategy',
                 $storeId

--- a/Helper/AdyenOrderPayment.php
+++ b/Helper/AdyenOrderPayment.php
@@ -18,6 +18,7 @@ use Adyen\Payment\Model\Order\Payment;
 use Adyen\Payment\Model\Order\PaymentFactory;
 use Adyen\Payment\Model\ResourceModel\Order\Payment as OrderPaymentResourceModel;
 use Adyen\Payment\Model\ResourceModel\Order\Payment\CollectionFactory as AdyenOrderPaymentCollection;
+use DateTime;
 use Magento\Framework\App\Helper\AbstractHelper;
 use Magento\Framework\App\Helper\Context;
 use Magento\Framework\Exception\AlreadyExistsException;
@@ -210,7 +211,9 @@ class AdyenOrderPayment extends AbstractHelper
         $pspReference = $notification->getPspreference();
 
         try {
-            $date = new \DateTime();
+            $date = new DateTime();
+            $eventDate = DateTime::createFromFormat('Y-m-d H:i:s', $notification->getCreatedAt());
+
             $adyenOrderPayment = $this->adyenOrderPaymentFactory->create();
             $adyenOrderPayment->setPspreference($pspReference);
             $adyenOrderPayment->setMerchantReference($merchantReference);
@@ -219,7 +222,7 @@ class AdyenOrderPayment extends AbstractHelper
             $adyenOrderPayment->setCaptureStatus($captureStatus);
             $adyenOrderPayment->setAmount($amount);
             $adyenOrderPayment->setTotalRefunded(0);
-            $adyenOrderPayment->setCreatedAt($date);
+            $adyenOrderPayment->setCreatedAt($eventDate);
             $adyenOrderPayment->setUpdatedAt($date);
             $this->orderPaymentResourceModel->save($adyenOrderPayment);
         } catch (\Exception $e) {
@@ -249,7 +252,7 @@ class AdyenOrderPayment extends AbstractHelper
     {
         $amountRefunded = $adyenOrderPayment->getTotalRefunded() +
             $this->adyenDataHelper->originalAmount($notification->getAmountValue(), $notification->getAmountCurrency());
-        $adyenOrderPayment->setUpdatedAt(new \DateTime());
+        $adyenOrderPayment->setUpdatedAt(new DateTime());
         $adyenOrderPayment->setTotalRefunded($amountRefunded);
         $adyenOrderPayment->save();
 
@@ -266,7 +269,7 @@ class AdyenOrderPayment extends AbstractHelper
     public function refundFullyAdyenOrderPayment(OrderPaymentInterface $adyenOrderPayment): OrderPaymentInterface
     {
         $amountRefunded = $adyenOrderPayment->getAmount();
-        $adyenOrderPayment->setUpdatedAt(new \DateTime());
+        $adyenOrderPayment->setUpdatedAt(new DateTime());
         $adyenOrderPayment->setTotalRefunded($amountRefunded);
         $adyenOrderPayment->save();
 

--- a/Model/ResourceModel/Order/Payment/Collection.php
+++ b/Model/ResourceModel/Order/Payment/Collection.php
@@ -83,7 +83,7 @@ class Collection extends \Magento\Framework\Model\ResourceModel\Db\Collection\Ab
     public function addPaymentFilterDescending($paymentId)
     {
         $this->addFieldToFilter('payment_id', $paymentId);
-        $this->getSelect()->order(['created_at DESC', 'entity_id DESC']);
+        $this->getSelect()->order(['created_at DESC']);
         return $this;
     }
 }


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Refund strategy of the partial payments now uses the `eventDate` of the authorisation webhook.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- Refund test for different strategies