### PR TITLE
[ECP-8694-2] Fix 3DS payment challenge on multishipping success page

### DIFF
--- a/view/frontend/templates/checkout/multishipping/success.phtml
+++ b/view/frontend/templates/checkout/multishipping/success.phtml
@@ -147,7 +147,7 @@ $paymentResponseEntities = $block->getPaymentResponseEntities();
                 let orderId = $(paymentSelected).data('order-id');
                 fullScreenLoader.stopLoader();
                 let popupModal = showModal();
-                adyenPaymentService.paymentDetails(request, orderId).done(function (responseJSON) {
+                adyenPaymentService.paymentDetails(request, orderId, true).done(function (responseJSON) {
                     handleAdyenResult(responseJSON, $(paymentSelected).data('order-id'));
                 }).fail(function (response) {
                     errorProcessor.process(response, self.messageContainer);

--- a/view/frontend/web/js/model/adyen-payment-service.js
+++ b/view/frontend/web/js/model/adyen-payment-service.js
@@ -93,14 +93,14 @@ define(
                 );
             },
 
-            paymentDetails: function(data, orderId) {
+            paymentDetails: function(data, orderId, isMultishipping = false) {
                 let serviceUrl;
                 let payload = {
                     'payload': JSON.stringify(data),
                     'orderId': orderId
                 };
 
-                if (customer.isLoggedIn()) {
+                if (customer.isLoggedIn() || isMultishipping) {
                     serviceUrl = urlBuilder.createUrl(
                         '/adyen/carts/mine/payments-details',
                         {}


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
On the success page, `customer.isLoggedIn()` returns undefined. Due to this inconvenience, plugin tries to make a call to guest endpoints for `paymentsDetails` call. Extra argument was added to solve and override this behaviour to use correct endpoints since multishipping payments are always for logged-in shoppers.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- Multishipping 3DS2 payment