### PR TITLE
[ECP-8650] Fix "Installment not valid" for Elo Credit Cards V8

### DIFF
--- a/etc/config.xml
+++ b/etc/config.xml
@@ -36,7 +36,7 @@
                 <title>Credit Card</title>
                 <allowspecific>0</allowspecific>
                 <sort_order>2</sort_order>
-                <cctypes>AE,VI,MC,DI</cctypes>
+                <cctypes>AE,VI,MC,DI,ELO</cctypes>
                 <useccv>1</useccv>
                 <has_holder_name>1</has_holder_name>
                 <holder_name_required>0</holder_name_required>


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
Elo payment method was missing in the available CC Types configuration and due to that it was not appear as has installment payment

**Fixes**  <!-- #-prefixed github issue number -->
ECP-8650
