### PR TITLE
[ECP-8690] Enable MFTF tests for V8 releases

### DIFF
--- a/.github/workflows/mftf-test.yml
+++ b/.github/workflows/mftf-test.yml
@@ -2,7 +2,7 @@ name: Functional Tests
 on:
   workflow_dispatch:
   pull_request:
-    branches: [main, develop-8]
+    branches: [main-8]
 
 jobs:
   build:

--- a/.github/workflows/mftf-test.yml
+++ b/.github/workflows/mftf-test.yml
@@ -2,7 +2,7 @@ name: Functional Tests
 on:
   workflow_dispatch:
   pull_request:
-    branches: [main]
+    branches: [main, develop-8]
 
 jobs:
   build:


### PR DESCRIPTION
**Description**
MFTF test pipeline only runs against main branch. However, we are maintaining 2 major versions at the same time currently. This PR updates the target branch to main-8 to trigger this workflow for V8 releases.

**Tested scenarios**
- test triggering MFTF tests first on develop-8 branch and then include main-8 branch
