### PR TITLE
[ECP-8675v8] Undefined array key "pspreference" in TransactionCapture 

### DIFF
--- a/Gateway/Http/Client/TransactionCapture.php
+++ b/Gateway/Http/Client/TransactionCapture.php
@@ -125,10 +125,14 @@ class TransactionCapture implements ClientInterface
                 $singleResponse = $this->copyParamsToResponse($singleResponse, $request);
                 $response[self::MULTIPLE_AUTHORIZATIONS][] = $singleResponse;
             } catch (AdyenException $e) {
+                $pspReference = isset($request[OrderPaymentInterface::PSPREFRENCE]) ?
+                    $request[OrderPaymentInterface::PSPREFRENCE] :
+                    'pspReference not set';
+
                 $message = sprintf(
                     'Exception occurred when attempting to capture multiple authorizations.
                     Authorization with pspReference %s: %s',
-                    $request[OrderPaymentInterface::PSPREFRENCE],
+                    $pspReference,
                     $e->getMessage()
                 );
 


### PR DESCRIPTION
**Description**
If capture response doesn't contain pspreference, catch block fails [here](https://github.com/Adyen/adyen-magento2/blob/3e9dc10be04b31fdb97d8661b29edc33396c5562/Gateway/Http/Client/TransactionCapture.php#L131C30-L131C51). This PR checks if the PSP reference is set and handles the exception message accordingly if it isn't.

**Tested scenarios**
- process the capture request without the PSP reference
