### PR TITLE
[ECP-8727] Fix the condition to fetch expired PBL orders

### DIFF
--- a/Cron/Providers/PayByLinkExpiredPaymentOrdersProvider.php
+++ b/Cron/Providers/PayByLinkExpiredPaymentOrdersProvider.php
@@ -125,15 +125,16 @@ class PayByLinkExpiredPaymentOrdersProvider implements OrdersProviderInterface
             ->setValue(Order::STATE_NEW)
             ->create();
 
-        $orderIdFilter = $this->filterBuilder->setField('state')
+        $orderIdFilter = $this->filterBuilder->setField('entity_id')
             ->setConditionType('in')
             ->setValue($expiredOrderIds)
             ->create();
 
-        $filterGroup = $this->filterGroupBuilder->setFilters([$stateFilter, $orderIdFilter])->create();
+        $stateFilterGroup = $this->filterGroupBuilder->setFilters([$stateFilter])->create();
+        $orderIdFilterGroup = $this->filterGroupBuilder->setFilters([$orderIdFilter])->create();
 
         $searchCriteria = $this->searchCriteriaBuilder
-            ->setFilterGroups([$filterGroup])
+            ->setFilterGroups([$stateFilterGroup, $orderIdFilterGroup])
             ->setSortOrders([$sortOrder])
             ->setPageSize(500)
             ->create();
@@ -149,22 +150,23 @@ class PayByLinkExpiredPaymentOrdersProvider implements OrdersProviderInterface
     {
         $sortOrder = new SortOrder();
         $sortOrder->setField('parent_id')->setDirection('DESC');
-        $payPerLinkFilters = [
-            $this->filterBuilder->setField('method')
-                ->setConditionType('eq')
-                ->setValue(PaymentMethods::ADYEN_PAY_BY_LINK)
-                ->create(),
-            $this->filterBuilder->setField('adyen_psp_reference')
-                ->setConditionType('null')
-                ->create()
-        ];
 
-        $filterGroup = $this->filterGroupBuilder->setFilters($payPerLinkFilters)->create();
+        $paymentMethodFilter = $this->filterBuilder->setField('method')
+            ->setConditionType('eq')
+            ->setValue(PaymentMethods::ADYEN_PAY_BY_LINK)
+            ->create();
+
+        $pspreferenceFilter = $this->filterBuilder->setField('adyen_psp_reference')
+            ->setConditionType('null')
+            ->create();
+
+        $paymentMethodFilterGroup = $this->filterGroupBuilder->setFilters([$paymentMethodFilter])->create();
+        $pspreferenceFilterGroup = $this->filterGroupBuilder->setFilters([$pspreferenceFilter])->create();
 
         $searchCriteria = $this->searchCriteriaBuilder
-            ->setFilterGroups([$filterGroup])
+            ->setFilterGroups([$paymentMethodFilterGroup, $pspreferenceFilterGroup])
             ->setSortOrders([$sortOrder])
-            ->setPageSize(1000)
+            ->setPageSize(500)
             ->create();
 
         return $this->orderPaymentRepository->getList($searchCriteria)->getItems();


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
A bug was found on order cancellation cron designed for expired Adyen Pay by Link payment method after implementing #2313 and #2318. This bug causes cancellation of all orders in `new` state.

This PR fixes the condition and provides only expired Adyen Pay by Link orders to `CancelOrders` cron job.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- Cancelling only expired Adyen Pay by Link payments