### PR TITLE
[ECP-8732] Fix MOTO captures

### DIFF
--- a/Gateway/Http/Client/TransactionMotoCapture.php
+++ b/Gateway/Http/Client/TransactionMotoCapture.php
@@ -16,8 +16,8 @@ use Adyen\Client;
 use Adyen\Payment\Api\Data\OrderPaymentInterface;
 use Adyen\Payment\Helper\Data;
 use Adyen\Payment\Helper\Requests;
+use Adyen\Payment\Helper\Idempotency;
 use Adyen\Payment\Logger\AdyenLogger;
-use Adyen\Service\Modification;
 use Magento\Payment\Gateway\Http\ClientInterface;
 use Magento\Payment\Gateway\Http\TransferInterface;
 
@@ -29,7 +29,7 @@ class TransactionMotoCapture implements ClientInterface
     const MULTIPLE_AUTHORIZATIONS = 'multiple_authorizations';
     const FORMATTED_CAPTURE_AMOUNT = 'formatted_capture_amount';
     const CAPTURE_AMOUNT = 'capture_amount';
-    const ORIGINAL_REFERENCE = 'original_reference';
+    const ORIGINAL_REFERENCE = 'paymentPspReference';
     const CAPTURE_RECEIVED = '[capture-received]';
 
     /**
@@ -43,9 +43,15 @@ class TransactionMotoCapture implements ClientInterface
     private $adyenLogger;
 
     /**
+     * @var Idempotency
+     */
+    private $idempotencyHelper;
+
+    /**
      * PaymentRequest constructor.
      * @param Data $adyenHelper
      * @param AdyenLogger $adyenLogger
+     * @param Idempotency $idempotencyHelper
      */
     public function __construct(
         Data $adyenHelper,
@@ -63,6 +69,7 @@ class TransactionMotoCapture implements ClientInterface
     public function placeRequest(TransferInterface $transferObject)
     {
         $request = $transferObject->getBody();
+        $headers = $transferObject->getHeaders();
         $clientConfig = $transferObject->getClientConfig();
 
         $client = $this->adyenHelper->initializeAdyenClient(
@@ -70,16 +77,23 @@ class TransactionMotoCapture implements ClientInterface
             null,
             $request['merchantAccount']
         );
-        $service = new Modification($client);
+        $service = $this->adyenHelper->createAdyenCheckoutService($client);
+
+        $idempotencyKey = $this->idempotencyHelper->generateIdempotencyKey(
+            $request,
+            $headers['idempotencyExtraData'] ?? null
+        );
+
+        $requestOptions['idempotencyKey'] = $idempotencyKey;
 
         if (array_key_exists(self::MULTIPLE_AUTHORIZATIONS, $request)) {
-            return $this->placeMultipleCaptureRequests($service, $request);
+            return $this->placeMultipleCaptureRequests($service, $request, $requestOptions);
         }
 
-        $this->adyenHelper
-            ->logRequest($request, Client::API_PAYMENT_VERSION, '/pal/servlet/Payment/{version}/capture');
+        $this->adyenHelper->logRequest($request, Client::API_CHECKOUT_VERSION, '/captures');
+
         try {
-            $response = $service->capture($request);
+            $response = $service->captures($request, $requestOptions);
             $response = $this->copyParamsToResponse($response, $request);
         } catch (AdyenException $e) {
             $response['error'] = $e->getMessage();
@@ -90,22 +104,22 @@ class TransactionMotoCapture implements ClientInterface
     }
 
     /**
-     * @param Modification $service
+     * @param $service
      * @param $requestContainer
      * @return array
      */
-    private function placeMultipleCaptureRequests(Modification $service, $requestContainer)
+    private function placeMultipleCaptureRequests($service, $requestContainer, $requestOptions)
     {
         $response = [];
         foreach ($requestContainer[self::MULTIPLE_AUTHORIZATIONS] as $request) {
             try {
                 // Copy merchant account from parent array to every request array
                 $request[Requests::MERCHANT_ACCOUNT] = $requestContainer[Requests::MERCHANT_ACCOUNT];
-                $singleResponse = $service->capture($request);
-                $singleResponse[self::FORMATTED_CAPTURE_AMOUNT] = $request['modificationAmount']['currency'] . ' ' .
+                $singleResponse = $service->capture($request, $requestOptions);
+                $singleResponse[self::FORMATTED_CAPTURE_AMOUNT] = $request['amount']['currency'] . ' ' .
                 $this->adyenHelper->originalAmount(
-                    $request['modificationAmount']['value'],
-                    $request['modificationAmount']['currency']
+                    $request['amount']['value'],
+                    $request['amount']['currency']
                 );
                 $singleResponse = $this->copyParamsToResponse($singleResponse, $request);
                 $response[self::MULTIPLE_AUTHORIZATIONS][] = $singleResponse;
@@ -134,8 +148,8 @@ class TransactionMotoCapture implements ClientInterface
      */
     private function copyParamsToResponse(array $response, array $request): array
     {
-        $response[self::CAPTURE_AMOUNT] = $request['modificationAmount']['value'];
-        $response[self::ORIGINAL_REFERENCE] = $request['originalReference'];
+        $response[self::CAPTURE_AMOUNT] = $request['amount']['value'];
+        $response[self::ORIGINAL_REFERENCE] = $request[self::ORIGINAL_REFERENCE];
 
         return $response;
     }

--- a/Gateway/Http/Client/TransactionMotoRefund.php
+++ b/Gateway/Http/Client/TransactionMotoRefund.php
@@ -12,6 +12,9 @@
 namespace Adyen\Payment\Gateway\Http\Client;
 
 use Adyen\Client;
+use Adyen\Payment\Helper\Data;
+use Adyen\Payment\Helper\Idempotency;
+use Magento\Payment\Gateway\Http\TransferInterface;
 use Magento\Payment\Gateway\Http\ClientInterface;
 
 /**
@@ -20,27 +23,36 @@ use Magento\Payment\Gateway\Http\ClientInterface;
 class TransactionMotoRefund implements TransactionRefundInterface
 {
     /**
-     * @var \Adyen\Payment\Helper\Data
+     * @var Data
      */
     private $adyenHelper;
 
     /**
+     * @var Idempotency
+     */
+    private $idempotencyHelper;
+
+    /**
      * PaymentRequest constructor.
-     * @param \Adyen\Payment\Helper\Data $adyenHelper
+     * @param Data $adyenHelper
      */
     public function __construct(
-        \Adyen\Payment\Helper\Data $adyenHelper
+        Data $adyenHelper,
+        Idempotency $idempotencyHelper
     ) {
         $this->adyenHelper = $adyenHelper;
+        $this->idempotencyHelper = $idempotencyHelper;
     }
 
     /**
-     * @param \Magento\Payment\Gateway\Http\TransferInterface $transferObject
+     * @param TransferInterface $transferObject
      * @return null
      */
-    public function placeRequest(\Magento\Payment\Gateway\Http\TransferInterface $transferObject)
+    public function placeRequest(TransferInterface $transferObject)
     {
         $requests = $transferObject->getBody();
+        $headers = $transferObject->getHeaders();
+
         $clientConfig = $transferObject->getClientConfig();
 
         $responses = [];
@@ -55,10 +67,18 @@ class TransactionMotoRefund implements TransactionRefundInterface
             );
 
             $service = $this->adyenHelper->createAdyenCheckoutService($client);
+
+            $idempotencyKey = $this->idempotencyHelper->generateIdempotencyKey(
+                $request,
+                $headers['idempotencyExtraData'] ?? null
+            );
+
+            $requestOptions['idempotencyKey'] = $idempotencyKey;
+
             $this->adyenHelper
                 ->logRequest($request, Client::API_CHECKOUT_VERSION, '/refunds');
             try {
-                $response = $service->refunds($request);
+                $response = $service->refunds($request, $requestOptions);
 
                 // Add amount original reference and amount information to response
                 $response[self::REFUND_AMOUNT] = $request['amount']['value'];


### PR DESCRIPTION
**Description**
TransactionMotoCapture is still using v51 /capture endpoint. Therefore, the manual invoicing of the MOTO orders in admin panel is not possible. The goal of this PR is to migrate to Checkout API v70 with the /capture endpoint for MOTO captures.
This PR also adds the utilisation of idempotency key, if exists to both TransactionMotoCapture and TransactionMotoRefund clients.

**Tested scenarios**
- immediate capture payments with MOTO through the admin panel
- manual creation of invoices and manual refunding of MOTO payments through admin panel

