### PR TITLE
[ECP-8716] Fix broken multi-store implementation

### DIFF
--- a/Gateway/Http/Client/TransactionCancel.php
+++ b/Gateway/Http/Client/TransactionCancel.php
@@ -59,12 +59,10 @@ class TransactionCancel implements ClientInterface
         $request = $transferObject->getBody();
         $headers = $transferObject->getHeaders();
 
-        $client = $this->adyenHelper->initializeAdyenClient();
+        $client = $this->adyenHelper->initializeAdyenClient($transferObject->getClientConfig()['storeId']);
         $service = $this->adyenHelper->createAdyenCheckoutService($client);
 
-
         $response = [];
-
 
         foreach ($request as $requests) {
 
@@ -88,5 +86,4 @@ class TransactionCancel implements ClientInterface
 
         return $response;
     }
-
 }

--- a/Gateway/Http/Client/TransactionCapture.php
+++ b/Gateway/Http/Client/TransactionCapture.php
@@ -76,7 +76,7 @@ class TransactionCapture implements ClientInterface
         $request = $transferObject->getBody();
         $headers = $transferObject->getHeaders();
 
-        $client = $this->adyenHelper->initializeAdyenClient();
+        $client = $this->adyenHelper->initializeAdyenClient($transferObject->getClientConfig()['storeId']);
         $service = $this->adyenHelper->createAdyenCheckoutService($client);
 
 

--- a/Gateway/Http/Client/TransactionMotoPayment.php
+++ b/Gateway/Http/Client/TransactionMotoPayment.php
@@ -12,6 +12,7 @@
 namespace Adyen\Payment\Gateway\Http\Client;
 
 use Adyen\Client;
+use Adyen\Payment\Helper\Idempotency;
 use Adyen\Payment\Model\PaymentResponse;
 use Adyen\Payment\Model\PaymentResponseFactory;
 use Magento\Payment\Gateway\Http\ClientInterface;
@@ -41,6 +42,11 @@ class TransactionMotoPayment implements ClientInterface
     private $paymentResponseResourceModel;
 
     /**
+     * @var Idempotency
+     */
+    private $idempotencyHelper;
+
+    /**
      * TransactionPayment constructor.
      * @param \Adyen\Payment\Helper\Data $adyenHelper
      * @param ApplicationInfo $applicationInfo
@@ -49,12 +55,14 @@ class TransactionMotoPayment implements ClientInterface
         \Adyen\Payment\Helper\Data $adyenHelper,
         \Adyen\Payment\Model\ApplicationInfo $applicationInfo,
         PaymentResponseFactory $paymentResponseFactory,
-        \Adyen\Payment\Model\ResourceModel\PaymentResponse $paymentResponseResourceModel
+        \Adyen\Payment\Model\ResourceModel\PaymentResponse $paymentResponseResourceModel,
+        IdempotencyHelper $idempotencyHelper
     ) {
         $this->adyenHelper = $adyenHelper;
         $this->applicationInfo = $applicationInfo;
         $this->paymentResponseFactory = $paymentResponseFactory;
         $this->paymentResponseResourceModel = $paymentResponseResourceModel;
+        $this->idempotencyHelper = $idempotencyHelper;
     }
 
     /**
@@ -65,6 +73,7 @@ class TransactionMotoPayment implements ClientInterface
     public function placeRequest(\Magento\Payment\Gateway\Http\TransferInterface $transferObject)
     {
         $request = $transferObject->getBody();
+        $headers = $transferObject->getHeaders();
         $clientConfig = $transferObject->getClientConfig();
 
         // If the payments call is already done return the request
@@ -79,6 +88,13 @@ class TransactionMotoPayment implements ClientInterface
             $request['merchantAccount']
         );
         $service = $this->adyenHelper->createAdyenCheckoutService($client);
+
+        $idempotencyKey = $this->idempotencyHelper->generateIdempotencyKey(
+            $request,
+            $headers['idempotencyExtraData'] ?? null
+        );
+
+        $requestOptions['idempotencyKey'] = $idempotencyKey;
 
         $requestOptions = [];
 

--- a/Gateway/Http/Client/TransactionMotoPayment.php
+++ b/Gateway/Http/Client/TransactionMotoPayment.php
@@ -56,7 +56,7 @@ class TransactionMotoPayment implements ClientInterface
         \Adyen\Payment\Model\ApplicationInfo $applicationInfo,
         PaymentResponseFactory $paymentResponseFactory,
         \Adyen\Payment\Model\ResourceModel\PaymentResponse $paymentResponseResourceModel,
-        IdempotencyHelper $idempotencyHelper
+        Idempotency $idempotencyHelper
     ) {
         $this->adyenHelper = $adyenHelper;
         $this->applicationInfo = $applicationInfo;

--- a/Gateway/Http/Client/TransactionPayment.php
+++ b/Gateway/Http/Client/TransactionPayment.php
@@ -91,7 +91,8 @@ class TransactionPayment implements ClientInterface
             return $request;
         }
 
-        $service = $this->adyenHelper->createAdyenCheckoutService();
+        $client = $this->adyenHelper->initializeAdyenClient($transferObject->getClientConfig()['storeId']);
+        $service = $this->adyenHelper->createAdyenCheckoutService($client);
 
         $idempotencyKey = $this->idempotencyHelper->generateIdempotencyKey(
             $request,

--- a/Gateway/Http/Client/TransactionPaymentLinks.php
+++ b/Gateway/Http/Client/TransactionPaymentLinks.php
@@ -61,7 +61,8 @@ class TransactionPaymentLinks implements ClientInterface
             return $request;
         }
 
-        $service = $this->adyenHelper->createAdyenCheckoutService();
+        $client = $this->adyenHelper->initializeAdyenClient($transferObject->getClientConfig()['storeId']);
+        $service = $this->adyenHelper->createAdyenCheckoutService($client);
 
         $idempotencyKey = $this->idempotencyHelper->generateIdempotencyKey(
             $request,

--- a/Gateway/Http/Client/TransactionRefund.php
+++ b/Gateway/Http/Client/TransactionRefund.php
@@ -61,7 +61,7 @@ class TransactionRefund implements TransactionRefundInterface
 
         foreach ($requests as $request) {
 
-            $client = $this->adyenHelper->initializeAdyenClient();
+            $client = $this->adyenHelper->initializeAdyenClient($transferObject->getClientConfig()['storeId']);
             $service = $this->adyenHelper->createAdyenCheckoutService($client);
 
             $idempotencyKey = $this->idempotencyHelper->generateIdempotencyKey(

--- a/Gateway/Request/MerchantAccountDataBuilder.php
+++ b/Gateway/Request/MerchantAccountDataBuilder.php
@@ -45,6 +45,7 @@ class MerchantAccountDataBuilder implements BuilderInterface
         $method = $payment->getMethod();
 
         $request['body'] = $this->adyenRequestsHelper->buildMerchantAccountData($method, $storeId, []);
+        $request['clientConfig']['storeId'] = $storeId;
 
         return $request;
     }

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -240,7 +240,7 @@ class Data extends AbstractHelper
         Locale $localeHelper,
         OrderManagementInterface $orderManagement,
         HistoryFactory $orderStatusHistoryFactory,
-        ConfigHelper $configHelper
+        ConfigHelper $configHelper,
     ) {
         parent::__construct($context);
         $this->_encryptor = $encryptor;

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -240,7 +240,7 @@ class Data extends AbstractHelper
         Locale $localeHelper,
         OrderManagementInterface $orderManagement,
         HistoryFactory $orderStatusHistoryFactory,
-        ConfigHelper $configHelper,
+        ConfigHelper $configHelper
     ) {
         parent::__construct($context);
         $this->_encryptor = $encryptor;


### PR DESCRIPTION
**Description**
The issues this PR is addressing are:
- fixing the multi-store implementation for all the transaction clients (all the payment modifications for payment links, MOTO and default payments)
- adding the usage of idempotency keys in all the transaction clients
- adding the storeId when instantiating those clients
- adding the storeId to the merchant account data builder

**Tested scenarios**
- create, capture, refund and cancel MOTO transaction, pay by link transaction and "normal payment"

Fixes  <!-- #-prefixed github issue number -->
https://github.com/Adyen/adyen-magento2/issues/2289