### PR TITLE
[ECP-8738] Support Apple Pay donations via Adyen Giving

### DIFF
--- a/Helper/Requests.php
+++ b/Helper/Requests.php
@@ -26,6 +26,7 @@ class Requests extends AbstractHelper
         'storedPaymentMethods' => 'scheme',
         'googlepay' => 'scheme',
         'paywithgoogle' => 'scheme',
+        'applepay' => 'scheme'
     ];
     const SHOPPER_INTERACTION_CONTAUTH = 'ContAuth';
 


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Allow usage of card scheme rail for donation tokens to complete Apple Pay donations.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- Apple Pay donations