### PR TITLE
[ECP-8758] Update collection condition before removal of giftcard state data

### DIFF
--- a/Helper/StateData.php
+++ b/Helper/StateData.php
@@ -18,6 +18,7 @@ use Adyen\Payment\Model\ResourceModel\StateData as StateDataResourceModel;
 use Adyen\Payment\Model\ResourceModel\StateData\Collection as StateDataCollection;
 use Adyen\Payment\Model\StateDataFactory;
 use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
 
 class StateData
 {
@@ -97,22 +98,31 @@ class StateData
         $this->stateDataResourceModel->save($stateDataObj);
     }
 
+    /**
+     * @throws NoSuchEntityException
+     */
     public function removeStateData(int $stateDataId, ?int $quoteId = null): bool
     {
-        $stateDataObj = $this->stateDataFactory->create();
-        $stateDataObj->setEntityId($stateDataId);
+        $stateDataCollection = $this->stateDataCollection->addFieldToFilter('entity_id', $stateDataId);
 
         if (isset($quoteId)) {
-            $stateDataObj->setQuoteId($quoteId);
+            $stateDataCollection->addFieldToFilter('quote_id', $quoteId);
         }
 
-        try {
-            $this->stateDataResourceModel->delete($stateDataObj);
-        } catch (\Exception $e) {
-            $this->adyenLogger->error('An error occurred while deleting state data: ' . $e->getMessage());
-            return false;
-        }
+        $stateDataCollection->getSelect();
+        $stateDataObj = $stateDataCollection->getFirstItem();
 
-        return true;
+        if (empty($stateDataObj->getData())) {
+            throw new NoSuchEntityException();
+        } else {
+            try {
+                $this->stateDataResourceModel->delete($stateDataObj);
+            } catch (\Exception $e) {
+                $this->adyenLogger->error('An error occurred while deleting state data: ' . $e->getMessage());
+                return false;
+            }
+
+            return true;
+        }
     }
 }

--- a/Test/Unit/Helper/StateDataTest.php
+++ b/Test/Unit/Helper/StateDataTest.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2023 Adyen N.V. (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\Payment\Test\Unit\Helper;
+
+use Adyen\Payment\Helper\StateData;
+use Adyen\Payment\Helper\Util\CheckoutStateDataValidator;
+use Adyen\Payment\Logger\AdyenLogger;
+use Adyen\Payment\Model\ResourceModel\StateData as StateDataResourceModel;
+use Adyen\Payment\Model\ResourceModel\StateData\Collection as StateDataCollection;
+use Adyen\Payment\Test\Unit\AbstractAdyenTestCase;
+use Adyen\Payment\Model\StateDataFactory;
+
+class StateDataTest extends AbstractAdyenTestCase
+{
+    public function testRemoveStateData($stateDataId = 1, $quoteId = 1)
+    {
+
+    }
+
+    protected function buildStateDataHelper(
+        $stateDataCollectionMock = null,
+        $stateDataFactoryMock = null,
+        $stateDataResourceModelMock = null,
+        $checkoutStateDataValidatorMock = null,
+        $adyenLoggerMock = null
+    ) {
+        if (is_null($stateDataCollectionMock)) {
+            $stateDataCollectionMock = $this->createMock(StateDataCollection::class);
+        }
+
+        if (is_null($stateDataFactoryMock)) {
+            $stateDataFactoryMock = $this->createGeneratedMock(StateDataFactory::class);
+        }
+
+        if (is_null($stateDataResourceModelMock)) {
+            $stateDataResourceModelMock = $this->createMock(StateDataResourceModel::class);
+        }
+
+        if (is_null($checkoutStateDataValidatorMock)) {
+            $checkoutStateDataValidatorMock = $this->createMock(CheckoutStateDataValidator::class);
+        }
+
+        if (is_null($adyenLoggerMock)) {
+            $adyenLoggerMock = $this->createMock(AdyenLogger::class);
+        }
+
+        return new StateData(
+            $stateDataCollectionMock,
+            $stateDataFactoryMock,
+            $stateDataResourceModelMock,
+            $checkoutStateDataValidatorMock,
+            $adyenLoggerMock
+        );
+    }
+}

--- a/Test/Unit/Model/Api/GuestAdyenStateDataTest.php
+++ b/Test/Unit/Model/Api/GuestAdyenStateDataTest.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2023 Adyen N.V. (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\Payment\Test\Unit\Model\Api;
+
+use Adyen\Payment\Helper\StateData;
+use Adyen\Payment\Model\Api\GuestAdyenStateData;
+use Adyen\Payment\Test\Unit\AbstractAdyenTestCase;
+use Magento\Framework\Exception\InputException;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Magento\Quote\Model\QuoteIdMask;
+use Magento\Quote\Model\QuoteIdMaskFactory;
+
+class GuestAdyenStateDataTest extends AbstractAdyenTestCase
+{
+    private $objectManager;
+    private $stateDataHelperMock;
+    private $quoteIdMaskFactoryMock;
+    private $quoteIdMaskMock;
+    private $guestAdyenStateDataModel;
+
+    protected function setUp(): void
+    {
+        $this->objectManager = new ObjectManager($this);
+
+        $this->quoteIdMaskFactoryMock = $this->createGeneratedMock(QuoteIdMaskFactory::class, [
+            'create'
+        ]);
+        $this->stateDataHelperMock = $this->createMock(StateData::class);
+
+        $this->quoteIdMaskMock = $this->createGeneratedMock(QuoteIdMask::class, ['load', 'getQuoteId']);
+        $this->quoteIdMaskMock->method('load')->willReturn($this->quoteIdMaskMock);
+        $this->quoteIdMaskMock->method('getQuoteId')->willReturn(1);
+
+        $this->guestAdyenStateDataModel = $this->objectManager->getObject(GuestAdyenStateData::class, [
+            'quoteIdMaskFactory' => $this->quoteIdMaskFactoryMock,
+            'stateDataHelper' => $this->stateDataHelperMock
+        ]);
+    }
+
+    public function testSaveSuccessful()
+    {
+        $stateData = '{"stateData":"dummyData"}';
+        $cartId = 'ABC123456789';
+
+        $this->quoteIdMaskFactoryMock->method('create')->willReturn($this->quoteIdMaskMock);
+        $this->stateDataHelperMock->expects($this->once())->method('saveStateData');
+
+        $this->guestAdyenStateDataModel->save($stateData, $cartId);
+    }
+
+    public function testRemoveSuccessful()
+    {
+        $stateDataId = 1;
+        $cartId = 'ABC123456789';
+
+        $this->quoteIdMaskFactoryMock->method('create')->willReturn($this->quoteIdMaskMock);
+        $this->stateDataHelperMock->expects($this->once())->method('removeStateData');
+
+        $this->guestAdyenStateDataModel->remove($stateDataId, $cartId);
+    }
+
+    public function testSaveException()
+    {
+        $this->expectException(InputException::class);
+
+        $stateData = '{"stateData":"dummyData"}';
+        $cartId = '';
+
+        $quoteIdMaskMock = $this->createGeneratedMock(QuoteIdMask::class, ['load', 'getQuoteId']);
+        $quoteIdMaskMock->method('load')->willReturn($quoteIdMaskMock);
+        $quoteIdMaskMock->method('getQuoteId')->willReturn(null);
+
+        $this->quoteIdMaskFactoryMock->method('create')->willReturn($quoteIdMaskMock);
+
+        $this->guestAdyenStateDataModel->save($stateData, $cartId);
+    }
+}

--- a/view/frontend/web/js/view/payment/method-renderer/adyen-giftcard-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-giftcard-method.js
@@ -20,6 +20,7 @@ define(
         'Adyen_Payment/js/model/adyen-configuration',
         'Adyen_Payment/js/adyen',
         'Magento_Customer/js/customer-data',
+        'Magento_Checkout/js/model/error-processor',
         'mage/translate'
     ],
     function(
@@ -34,6 +35,7 @@ define(
         adyenConfiguration,
         adyenCheckout,
         customerData,
+        errorProcessor,
         $t
     ) {
         'use strict';
@@ -192,6 +194,11 @@ define(
                 adyenPaymentService.removeStateData(data.stateDataId).done(function () {
                     self.fetchRedeemedGiftcards();
                     fullScreenLoader.stopLoader();
+                }).fail(function(response) {
+                    fullScreenLoader.stopLoader();
+                    self.fetchRedeemedGiftcards();
+
+                    errorProcessor.process(response, this.currentMessageContainer);
                 });
             },
 


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Removal condition of state data was refactored and correct exception messages were implemented.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- Removing guest use state data 
- Removing logged-in user state data
- Removing state data of another user.