### PR TITLE
Add `magento/module-quote-graph-ql` as composer dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     "magento/framework": ">=103.0.4",
     "magento/module-vault": ">=101.2.4",
     "magento/module-multishipping": ">=100.4.4",
+    "magento/module-quote-graph-ql": "*",
     "ext-json": "*"
   },
   "require-dev": {


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
- Possibly fix https://github.com/Adyen/adyen-magento2/issues/1466
- Since package `adyen/module-payment` officially supported graphql but did not separated as `adyen/module-payment-graphql` for example, the fix provided composer dependencies for anyone using `replace` with graphql modules.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- For Anyone using `replace` on composer.json with `magento/module-quote-graph-ql` would be unable to install module through `composer require` unless the removal of graphql modules from `replace` area.

Fixes https://github.com/Adyen/adyen-magento2/issues/1466
