### PR TITLE
Fix 301 Return value while running command console

### DIFF
--- a/Console/Command/EnablePaymentMethodsCommand.php
+++ b/Console/Command/EnablePaymentMethodsCommand.php
@@ -32,7 +32,7 @@ class EnablePaymentMethodsCommand extends Command
     /**
      * @throws \Exception
      */
-    protected function execute(InputInterface $input, OutputInterface $output): void
+    protected function execute(InputInterface $input, OutputInterface $output)
     {
         $output->writeln('Starting enabling payment methods.');
         $availablePaymentMethods = $this->paymentMethods->getAdyenPaymentMethods();
@@ -45,5 +45,6 @@ class EnablePaymentMethodsCommand extends Command
         }
 
         $output->writeln('Completed enabling payment methods.');
+        return Command::SUCCESS;
     }
 }

--- a/Console/Command/WebhookProcessorCommand.php
+++ b/Console/Command/WebhookProcessorCommand.php
@@ -32,7 +32,12 @@ class WebhookProcessorCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $output->writeln('Starting webhook processor.');
-        $this->webhookProcessor->execute();
+        try {
+            $this->webhookProcessor->execute();
+        } catch (\Exception $e) {
+            return Command::FAILURE;
+        }
         $output->writeln('Completed webhook processor execution.');
+        return Command::SUCCESS;
     }
 }


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
- Possibly fix for https://github.com/Adyen/adyen-magento2/issues/2349
- According to `Symfony\Component\Console\Command\Command::execute` must return int 0 if everything went fine, or an exit code. Instead void or null.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- Run `adyen:enablepaymentmethods:run` or `adyen:webhook:run` without any of exception error related to `301 Return value` `must be of the type int, "null" returned`
- Unit tests are passing

Fixes https://github.com/Adyen/adyen-magento2/issues/2349
