### PR TITLE
[ECP-8778] Create new state for adyen_authorized status

### DIFF
--- a/Model/Config/Source/PreAuthorized.php
+++ b/Model/Config/Source/PreAuthorized.php
@@ -18,10 +18,13 @@ use Magento\Sales\Model\Order;
  */
 class PreAuthorized extends \Magento\Sales\Model\Config\Source\Order\Status
 {
+    const STATE_ADYEN_AUTHORIZED = 'adyen_authorized';
+
     /**
      * @var string[]
      */
     protected $_stateStatuses = [
-        Order::STATE_NEW
+        Order::STATE_NEW,
+        self::STATE_ADYEN_AUTHORIZED
     ];
 }

--- a/Setup/Patch/Data/CreateStatusAuthorized.php
+++ b/Setup/Patch/Data/CreateStatusAuthorized.php
@@ -12,12 +12,16 @@ declare(strict_types=1);
 namespace Adyen\Payment\Setup\Patch\Data;
 
 use Adyen\Payment\Helper\DataPatch;
+use Magento\Framework\Exception\AlreadyExistsException;
 use Magento\Framework\Setup\ModuleDataSetupInterface;
 use Magento\Framework\Setup\Patch\DataPatchInterface;
 use Magento\Framework\Setup\Patch\PatchVersionInterface;
 use Magento\Framework\App\Config\ReinitableConfigInterface;
 use Magento\Framework\App\Config\Storage\WriterInterface;
 use Magento\Sales\Model\Order;
+use Magento\Sales\Model\Order\StatusFactory;
+use Magento\Sales\Model\ResourceModel\Order\StatusFactory as StatusResourceFactory;
+use Magento\Sales\Model\ResourceModel\Order\Status as StatusResource;
 
 class CreateStatusAuthorized implements DataPatchInterface, PatchVersionInterface
 {
@@ -25,6 +29,8 @@ class CreateStatusAuthorized implements DataPatchInterface, PatchVersionInterfac
     private WriterInterface $configWriter;
     private ReinitableConfigInterface $reinitableConfig;
     private DataPatch $dataPatchHelper;
+    private StatusFactory $statusFactory;
+    private StatusResourceFactory $statusResourceFactory;
 
     const ADYEN_AUTHORIZED_STATUS = 'adyen_authorized';
     const ADYEN_AUTHORIZED_STATUS_LABEL = 'Authorized';
@@ -33,43 +39,41 @@ class CreateStatusAuthorized implements DataPatchInterface, PatchVersionInterfac
         ModuleDataSetupInterface $moduleDataSetup,
         WriterInterface $configWriter,
         ReinitableConfigInterface $reinitableConfig,
-        DataPatch $dataPatchHelper
+        DataPatch $dataPatchHelper,
+        StatusFactory $statusFactory,
+        StatusResourceFactory $statusResourceFactory
     ) {
         $this->moduleDataSetup = $moduleDataSetup;
         $this->configWriter = $configWriter;
         $this->reinitableConfig = $reinitableConfig;
         $this->dataPatchHelper = $dataPatchHelper;
+        $this->statusFactory = $statusFactory;
+        $this->statusResourceFactory = $statusResourceFactory;
     }
 
     public function apply()
     {
+        /** @var StatusResource $statusResource */
+        $statusResource = $this->statusResourceFactory->create();
+
+        $status = $this->statusFactory->create();
+        $status->setData([
+            'status' => self::ADYEN_AUTHORIZED_STATUS,
+            'label' => self::ADYEN_AUTHORIZED_STATUS_LABEL,
+        ]);
+
+        try {
+            $statusResource->save($status);
+        } catch (AlreadyExistsException $exception) {
+            return;
+        }
+
+        $status->assignState(self::ADYEN_AUTHORIZED_STATUS, true, true);
+
         $setup = $this->moduleDataSetup;
-
-        $orderStateAssignmentTable = $this->moduleDataSetup->getTable('sales_order_status_state');
-        $orderStatusTable = $this->moduleDataSetup->getTable('sales_order_status');
-
-        $status = [
-            [
-                'status' => self::ADYEN_AUTHORIZED_STATUS,
-                'label' => self::ADYEN_AUTHORIZED_STATUS_LABEL
-            ]
-        ];
-
-        $this->moduleDataSetup->getConnection()->insertOnDuplicate($orderStatusTable, $status);
-
-        $stateAssignment = [
-            [
-                'status' => self::ADYEN_AUTHORIZED_STATUS,
-                'state' => Order::STATE_NEW,
-                'is_default' => 0,
-                'visible_on_front' => 1
-            ]
-        ];
-
-        $this->moduleDataSetup->getConnection()->insertOnDuplicate($orderStateAssignmentTable, $stateAssignment);
-
         $path = 'payment/adyen_abstract/payment_pre_authorized';
 
+        // Processing status was assigned mistakenly. It shouldn't be used on payment_pre_authorized.
         $config = $this->dataPatchHelper->findConfig($setup, $path, Order::STATE_PROCESSING);
         if (isset($config)) {
             $this->configWriter->save(

--- a/Test/Unit/Setup/Patch/Data/CreateStatusAuthorizedTest.php
+++ b/Test/Unit/Setup/Patch/Data/CreateStatusAuthorizedTest.php
@@ -18,6 +18,10 @@ use Magento\Framework\App\Config\ReinitableConfigInterface;
 use Magento\Framework\App\Config\Storage\WriterInterface;
 use Magento\Framework\DB\Adapter\AdapterInterface;
 use Magento\Framework\Setup\ModuleDataSetupInterface;
+use Magento\Sales\Model\Order\Status;
+use Magento\Sales\Model\Order\StatusFactory;
+use Magento\Sales\Model\ResourceModel\Order\Status as StatusResource;
+use Magento\Sales\Model\ResourceModel\Order\StatusFactory as StatusResourceFactory;
 
 class CreateStatusAuthorizedTest extends AbstractAdyenTestCase
 {
@@ -66,12 +70,19 @@ class CreateStatusAuthorizedTest extends AbstractAdyenTestCase
         $dataPatchHelperMock = $this->createConfiguredMock(DataPatch::class, [
             'findConfig' => null
         ]);
+        $statusFactoryMock = $this->createGeneratedMock(StatusFactory::class);
+        $statusFactoryMock->method('create')->willReturn($this->createMock(Status::class));
+        $statusResourceFactoryMock = $this->createGeneratedMock(StatusResourceFactory::class);
+        $statusResourceFactoryMock->method('create')
+            ->willReturn($this->createMock(StatusResource::class));
 
         return new CreateStatusAuthorized(
             $moduleDataSetupMock,
             $configWriteMock,
             $reinitableConfigMock,
-            $dataPatchHelperMock
+            $dataPatchHelperMock,
+            $statusFactoryMock,
+            $statusResourceFactoryMock
         );
     }
 }

--- a/Test/Unit/Setup/Patch/Data/CreateStatusAuthorizedTest.php
+++ b/Test/Unit/Setup/Patch/Data/CreateStatusAuthorizedTest.php
@@ -70,7 +70,7 @@ class CreateStatusAuthorizedTest extends AbstractAdyenTestCase
         $dataPatchHelperMock = $this->createConfiguredMock(DataPatch::class, [
             'findConfig' => null
         ]);
-        $statusFactoryMock = $this->createGeneratedMock(StatusFactory::class);
+        $statusFactoryMock = $this->createGeneratedMock(StatusFactory::class, ['create']);
         $statusFactoryMock->method('create')->willReturn($this->createMock(Status::class));
         $statusResourceFactoryMock = $this->createGeneratedMock(StatusResourceFactory::class);
         $statusResourceFactoryMock->method('create')

--- a/Test/Unit/Setup/Patch/Data/CreateStatusAuthorizedTest.php
+++ b/Test/Unit/Setup/Patch/Data/CreateStatusAuthorizedTest.php
@@ -72,7 +72,7 @@ class CreateStatusAuthorizedTest extends AbstractAdyenTestCase
         ]);
         $statusFactoryMock = $this->createGeneratedMock(StatusFactory::class, ['create']);
         $statusFactoryMock->method('create')->willReturn($this->createMock(Status::class));
-        $statusResourceFactoryMock = $this->createGeneratedMock(StatusResourceFactory::class);
+        $statusResourceFactoryMock = $this->createGeneratedMock(StatusResourceFactory::class, ['create']);
         $statusResourceFactoryMock->method('create')
             ->willReturn($this->createMock(StatusResource::class));
 


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
A merchant can select he order status for order creation on the configuration page. Since, `adyen_authorized` has been assigned to state `new` after implementing #2316, merchant can select Authorized status for order creation, which is not always true.

In order to tackle this issue, a new state was generated and `adyen_authorized` status was assigned to this new state.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- Running migration script
- Manual capture payments
