### PR TITLE
[ECP-8772] Use transactionLimit on balance response if exists

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/adyen-giftcard-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-giftcard-method.js
@@ -205,16 +205,21 @@ define(
 
             handleBalanceResult: function (balanceResponse, stateData, resolve) {
                 let self = this;
+
+                let consumableBalance = balanceResponse.transactionLimit ?
+                    balanceResponse.transactionLimit :
+                    balanceResponse.balance;
+
                 let orderAmount = currencyHelper.formatAmount(
                     quote.totals().grand_total,
                     window.checkoutConfig.payment.adyen.giftcard.currency
                 );
 
-                if(this.totalGiftcardBalance() === 0 && balanceResponse.balance.value >= orderAmount) {
+                if(this.totalGiftcardBalance() === 0 && consumableBalance.value >= orderAmount) {
                     resolve(balanceResponse);
                 } else if (orderAmount > this.totalGiftcardBalance()) {
                     stateData.giftcard = {
-                        balance: balanceResponse.balance,
+                        balance: consumableBalance,
                         title: this.selectedGiftcard().key
                     }
                     adyenPaymentService.saveStateData(stateData).done(function () {


### PR DESCRIPTION
**Description**
If the giftcard balance is higher than a certain amount (50 EUR in EU), `/paymentMethods/balance` endpoint returns an additional parameter `transactionLimit`. This object contains amount and currency and indicates the max. amount that can be used from this giftcard on a single checkout. This PR introduces a change if `transactionLimit` exists on balance check API response, we use this value as the balance.

**Tested scenarios**
- test a payment with a giftcard that has a higher balance than 50EUR
- test a payment with a giftcard that has a balance of 50EUR
- test a payment with a giftcard that has a lower balance than 50EUR
