### PR TITLE
Added factory classes as dependencies for CLI Command

### DIFF
--- a/Console/Command/EnablePaymentMethodsCommand.php
+++ b/Console/Command/EnablePaymentMethodsCommand.php
@@ -2,24 +2,24 @@
 
 namespace Adyen\Payment\Console\Command;
 
-use Adyen\Payment\Helper\PaymentMethods;
-use Adyen\Payment\Helper\Config;
+use Adyen\Payment\Helper\PaymentMethodsFactory;
+use Adyen\Payment\Helper\ConfigFactory;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class EnablePaymentMethodsCommand extends Command
 {
-    private PaymentMethods $paymentMethods;
+    private PaymentMethodsFactory $paymentMethodsFactory;
 
-    private Config $configHelper;
+    private ConfigFactory $configHelperFactory;
 
     public function __construct(
-        PaymentMethods $paymentMethods,
-        Config $configHelper
+        PaymentMethodsFactory $paymentMethodsFactory,
+        ConfigFactory $configHelperFactory
     ) {
-        $this->paymentMethods = $paymentMethods;
-        $this->configHelper = $configHelper;
+        $this->paymentMethodsFactory = $paymentMethodsFactory;
+        $this->configHelperFactory = $configHelperFactory;
         parent::__construct();
     }
 
@@ -35,12 +35,14 @@ class EnablePaymentMethodsCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output): void
     {
         $output->writeln('Starting enabling payment methods.');
-        $availablePaymentMethods = $this->paymentMethods->getAdyenPaymentMethods();
+        $paymentMethods = $this->paymentMethodsFactory->create();
+        $availablePaymentMethods = $paymentMethods->getAdyenPaymentMethods();
+        $configHelper = $this->configHelperFactory->create();
 
         foreach ($availablePaymentMethods as $paymentMethod) {
             $value = '1';
             $field = 'active';
-            $this->configHelper->setConfigData($value, $field, $paymentMethod);
+            $configHelper->setConfigData($value, $field, $paymentMethod);
             $output->writeln("Enabled payment method: {$paymentMethod}");
         }
 


### PR DESCRIPTION
**Description**
During installation of Magento from a scratch, there is an exception thrown:
```
[Progress: 4 / 1931]
Installing database schema:

In WebsiteRepository.php line 159:

  [DomainException]
  The default website isn't defined. Set the website and try again.
``` 

It is caused by CLI Command class dependencies that uses ScopeConfig.
In order to fix the issue, there should be used Factory classes as CLI dependencies.

Closes #2388 
