### PR TITLE
Update webrestrictions.xml

### DIFF
--- a/etc/webrestrictions.xml
+++ b/etc/webrestrictions.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_WebsiteRestriction:etc/webrestrictions.xsd">
-    <action path="adyen_process_json" type="generic" />
+    <action path="adyen_webhook_index" type="generic" />
 </config>


### PR DESCRIPTION
**Description**
In the 9.0.1 version the webhook controller path has been changed but that change was not reflected in module webrestriction.xml file making it impossible for Magento to accept incoming webhook messages when website restriction mode is turned on in the settings. This fix corrects that file, so Magento is able to accept those messages again.
