### PR TITLE
Invert logic to capture invoice when "on shipment" is set

### DIFF
--- a/Observer/BeforeShipmentObserver.php
+++ b/Observer/BeforeShipmentObserver.php
@@ -87,7 +87,7 @@ class BeforeShipmentObserver extends AbstractDataAssignObserver
             $order->getStoreId()
         );
 
-        if (strcmp((string) $openInvoiceCapture, self::ONSHIPMENT_CAPTURE_OPENINVOICE) === 0)
+        if (strcmp((string) $openInvoiceCapture, self::ONSHIPMENT_CAPTURE_OPENINVOICE) !== 0)
         {
             $this->logger->info(
                 "Capture on shipment not configured for order id {$order->getId()}",


### PR DESCRIPTION
**Description**
When the capture mode for open invoices is set to "on shipment" no invoices are created/captured, whereas when the capture mode is set to "manual" or "immediately", invoices are created upon creating a shipment. The logic should be inverted.