### PR TITLE
Cast input argument to string for isWalletTxVariant

### DIFF
--- a/Helper/PaymentMethods.php
+++ b/Helper/PaymentMethods.php
@@ -632,7 +632,7 @@ class PaymentMethods extends AbstractHelper
         $notificationPaymentMethod = $notification->getPaymentMethod();
 
         // Returns if the payment method is wallet like wechatpayWeb, amazonpay, applepay, paywithgoogle
-        $isWalletPaymentMethod = $this->isWalletTxVariant($orderPaymentMethod);
+        $isWalletPaymentMethod = $this->isWalletTxVariant((string) $orderPaymentMethod);
         $isCardPaymentMethod = $order->getPayment()->getMethod() === 'adyen_cc' || $order->getPayment()->getMethod() === 'adyen_oneclick';
 
         // If it is a wallet method OR a card OR the methods match exactly, return true


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
Fix for bug: "Cron Job adyen_payment_process_notification has an error: Adyen\Payment\Helper\PaymentMethods::isWalletTxVariant(): Argument #1 ($notificationPaymentMethod) must be of type string, null given, called in vendor/adyen/module-payment/Helper/PaymentMethods.php on line 635"

**Tested scenarios**
Run cron "adyen_payment_process_notification" after patch.
