### PR TITLE
Remove cart dependency when creating open invoice

### DIFF
--- a/Helper/ChargedCurrency.php
+++ b/Helper/ChargedCurrency.php
@@ -109,6 +109,32 @@ class ChargedCurrency
         );
     }
 
+    public function getOrderItemAmountCurrency(\Magento\Sales\Model\Order\Item $item)
+    {
+        $chargedCurrency = $this->config->getChargedCurrency($item->getStoreId());
+        if ($chargedCurrency == self::BASE) {
+            return new AdyenAmountCurrency(
+                $item->getBasePrice(),
+                $item->getOrder()->getBaseCurrencyCode(),
+                $item->getBaseDiscountAmount(),
+                $item->getBasePriceInclTax() - $item->getBasePrice(),
+                null,
+                $item->getBasePriceInclTax()
+            );
+        }
+        $amount = $item->getRowTotal()/$item->getQtyOrdered();
+        $amountIncludingTax = $item->getRowTotalInclTax()/$item->getQtyOrdered();
+        return new AdyenAmountCurrency(
+            $amount,
+            $item->getOrder()->getQuoteCurrencyCode(),
+            $item->getDiscountAmount(),
+            $amountIncludingTax - $amount,
+            null,
+            $amountIncludingTax
+        );
+    }
+
+
     /**
      * @param Invoice\Item $item
      * @return AdyenAmountCurrency
@@ -246,6 +272,29 @@ class ChargedCurrency
             $quote->getShippingAddress()->getShippingTaxAmount(),
             null,
             $quote->getShippingAddress()->getShippingInclTax()
+        );
+    }
+
+    public function getOrderShippingAmountCurrency(Order $order): AdyenAmountCurrency
+    {
+        $chargedCurrency = $this->config->getChargedCurrency($order->getStoreId());
+        if ($chargedCurrency == self::BASE) {
+            return new AdyenAmountCurrency(
+                $order->getBaseShippingAmount(),
+                $order->getBaseCurrencyCode(),
+                $order->getBaseShippingDiscountAmount(),
+                $order->getBaseShippingTaxAmount(),
+                null,
+                $order->getBaseShippingInclTax()
+            );
+        }
+        return new AdyenAmountCurrency(
+            $order->getShippingAmount(),
+            $order->getOrderCurrencyCode(),
+            $order->getShippingDiscountAmount(),
+            $order->getShippingTaxAmount(),
+            null,
+            $order->getShippingInclTax()
         );
     }
 

--- a/Helper/ChargedCurrency.php
+++ b/Helper/ChargedCurrency.php
@@ -126,7 +126,7 @@ class ChargedCurrency
         $amountIncludingTax = $item->getRowTotalInclTax()/$item->getQtyOrdered();
         return new AdyenAmountCurrency(
             $amount,
-            $item->getOrder()->getQuoteCurrencyCode(),
+            $item->getOrder()->getOrderCurrencyCode(),
             $item->getDiscountAmount(),
             $amountIncludingTax - $amount,
             null,

--- a/Helper/OpenInvoice.php
+++ b/Helper/OpenInvoice.php
@@ -61,6 +61,7 @@ class OpenInvoice
 
         /** @var MagentoOrder\Item $item */
         foreach ($order->getAllVisibleItems() as $item) {
+            $item->setOrder($order);
             $numberOfItems = (int)$item->getQtyOrdered();
 
             $itemAmountCurrency = $this->chargedCurrency->getOrderItemAmountCurrency($item);


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
Remove dependencies on product and quote when creating an open invoice. The shared functionality is used when converting a quote to an onder, but also when creating a creditmemo from an invoice. When either a quote or a product has been deleted of an invoice that needs a refund, the original code fails. This fix resolves the failures when these dependencies are no longer met.

**Tested scenarios**
Create an invoice for an open invoice payment method (e.g.Klarna). Remove the quote corresponding to the invoice. Creditmemo the invoice.

<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->