### PR TITLE
[ECP-8853] Issues/2407 multiple adyen creditmemos linked to same magento creditcmemo

### DIFF
--- a/Helper/Creditmemo.php
+++ b/Helper/Creditmemo.php
@@ -144,6 +144,7 @@ class Creditmemo extends AbstractHelper
                 if ($currAdyenCreditmemo->getAmount() == $magentoCreditmemo->getGrandTotal()) {
                     $currAdyenCreditmemo->setCreditmemoId($magentoCreditmemo->getEntityId());
                     $this->adyenCreditmemoResourceModel->save($currAdyenCreditmemo);
+                    break;
                 }
 
             }

--- a/Helper/Creditmemo.php
+++ b/Helper/Creditmemo.php
@@ -136,8 +136,16 @@ class Creditmemo extends AbstractHelper
                     $adyenCreditmemo[CreditmemoInterface::ENTITY_ID],
                     CreditmemoInterface::ENTITY_ID
                 );
-                $currAdyenCreditmemo->setCreditmemoId($magentoCreditmemo->getEntityId());
-                $this->adyenCreditmemoResourceModel->save($currAdyenCreditmemo);
+
+                if ($currAdyenCreditmemo->getCreditmemoId() !== null) {
+                    continue;
+                }
+
+                if ($currAdyenCreditmemo->getAmount() == $magentoCreditmemo->getGrandTotal()) {
+                    $currAdyenCreditmemo->setCreditmemoId($magentoCreditmemo->getEntityId());
+                    $this->adyenCreditmemoResourceModel->save($currAdyenCreditmemo);
+                }
+
             }
         }
     }

--- a/Observer/BeforeShipmentObserver.php
+++ b/Observer/BeforeShipmentObserver.php
@@ -87,7 +87,7 @@ class BeforeShipmentObserver extends AbstractDataAssignObserver
             $order->getStoreId()
         );
 
-        if (strcmp((string) $openInvoiceCapture, self::ONSHIPMENT_CAPTURE_OPENINVOICE) === 0)
+        if (strcmp((string) $openInvoiceCapture, self::ONSHIPMENT_CAPTURE_OPENINVOICE) !== 0)
         {
             $this->logger->info(
                 "Capture on shipment not configured for order id {$order->getId()}",


### PR DESCRIPTION
**Description**
This PR prevents that multiple Adyen credit memos are linked to the same Magento credit memo.

**Tested scenarios**
Create an invoice from a order with an online capture.
Create a first online credit memo from the invoice, not refunding the entire amount.
Create a second online credit memo from the invoice, refunding the remaining amount.
Inspect the database table adyen_creditmemo column creditmemo_id: The corresponding Adyen credit memos are linked to different Magento credit memo.

Fixes  #2407 
