### PR TITLE
[ECP-8807] Handle POS payment resultCode

### DIFF
--- a/Gateway/Response/PaymentPosCloudHandler.php
+++ b/Gateway/Response/PaymentPosCloudHandler.php
@@ -45,6 +45,9 @@ class PaymentPosCloudHandler implements HandlerInterface
         // do not send order confirmation mail
         $payment->getOrder()->setCanSendNewEmailFlag(false);
 
+        if (!empty($paymentResponse) && isset($paymentResponse['Response']['Result'])) {
+            $payment->setAdditionalInformation('resultCode', $paymentResponse['Response']['Result']);
+        }
 
         if (!empty($paymentResponse['Response']['AdditionalResponse']))
         {

--- a/Helper/PaymentResponseHandler.php
+++ b/Helper/PaymentResponseHandler.php
@@ -33,6 +33,7 @@ class PaymentResponseHandler
     const CANCELLED = 'Cancelled';
     const ADYEN_TOKENIZATION = 'Adyen Tokenization';
     const VAULT = 'Magento Vault';
+    const POS_SUCCESS = 'Success';
 
     /**
      * @var AdyenLogger
@@ -89,6 +90,7 @@ class PaymentResponseHandler
             case self::AUTHORISED:
             case self::REFUSED:
             case self::ERROR:
+            case self::POS_SUCCESS:
                 return [
                     "isFinal" => true,
                     "resultCode" => $resultCode


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
POS payment's `Result` is now being stored as `resultCode` in `additional_information` field of the payment object. This prevents the misleading error message on GraphQL `adyen_payment_status` object although there is no error.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- GraphQL POS payment