### PR TITLE
[ECP-8771] Fix missing GraphQL fields for POS Cloud payments

### DIFF
--- a/Gateway/Request/PosCloudBuilder.php
+++ b/Gateway/Request/PosCloudBuilder.php
@@ -12,6 +12,7 @@
 
 namespace Adyen\Payment\Gateway\Request;
 
+use Adyen\Payment\Helper\PaymentMethods;
 use Magento\Payment\Gateway\Helper\SubjectReader;
 use Magento\Payment\Gateway\Request\BuilderInterface;
 
@@ -36,7 +37,8 @@ class PosCloudBuilder implements BuilderInterface
                 'terminalID' => $payment->getAdditionalInformation('terminal_id'),
                 'numberOfInstallments' => $payment->getAdditionalInformation('number_of_installments'),
                 'chainCalls' => $payment->getAdditionalInformation('chain_calls'),
-                'fundingSource' => $payment->getAdditionalInformation('funding_source')
+                'fundingSource' => $payment->getAdditionalInformation('funding_source') ?? PaymentMethods::FUNDING_SOURCE_CREDIT,
+                'order' => $payment->getOrder()
             ];
         } else {
             $body = [

--- a/etc/schema.graphqls
+++ b/etc/schema.graphqls
@@ -148,8 +148,10 @@ input AdyenAdditionalDataOneclick {
 }
 
 input AdyenAdditionalDataPosCloud {
+    terminal_id: String! @doc(description: "Terminal ID of selected terminal.")
     number_of_installments: Int @doc(description: "Number of installments for the payment.")
-    terminal_id: String @doc(description: "Terminal ID of selected terminal.")
+    chain_calls: Boolean @doc(description: "Indicates the chained call.")
+    funding_source: String @doc(description: "Funding source to be used for combo cards.")
 }
 
 type StoreConfig @doc(description: "The type contains information about a store config") {


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
GraphQL schema was missing `chain_call` and `funding_source` arguments for `AdyenAdditionalDataPosCloud` object. After adding those fields, `session` dependency of graphql payment for POS Cloud payment method was observer. Since, it is a blocker for headless payments, `TransactionPosCloudSync` class was decoupled from `session` object while fetching the `quote`. Instead, `order` object is being transferred from the request builder.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- Headless and headful POS Cloud payments