### PR TITLE
fix: Notification model `getUpdatedAt` method uses `created_at` date

### DIFF
--- a/Model/Notification.php
+++ b/Model/Notification.php
@@ -272,7 +272,7 @@ class Notification extends AbstractModel implements NotificationInterface
 
     public function getUpdatedAt(): ?string
     {
-        $updatedAt = $this->getData(self::CREATED_AT);
+        $updatedAt = $this->getData(self::UPDATED_AT);
 
         if ($updatedAt instanceOf Datetime) {
             return $updatedAt->format('Y-m-d H:i:s');


### PR DESCRIPTION
**Description**
Notification model `getUpdatedAt` method uses `created_at` date instead of `updated_at`.
This Pull Request is fixing the issue with setting proper property of Notification model.

Fixes #2416 
