### PR TITLE
[ECP-8853] [v8] Multiple Adyen credit memos linked to same Magento credit memo

### DIFF
--- a/Helper/Creditmemo.php
+++ b/Helper/Creditmemo.php
@@ -136,8 +136,16 @@ class Creditmemo extends AbstractHelper
                     $adyenCreditmemo[CreditmemoInterface::ENTITY_ID],
                     CreditmemoInterface::ENTITY_ID
                 );
-                $currAdyenCreditmemo->setCreditmemoId($magentoCreditmemo->getEntityId());
-                $this->adyenCreditmemoResourceModel->save($currAdyenCreditmemo);
+
+                if ($currAdyenCreditmemo->getCreditmemoId() !== null) {
+                    continue;
+                }
+
+                if ($currAdyenCreditmemo->getAmount() == $magentoCreditmemo->getGrandTotal()) {
+                    $currAdyenCreditmemo->setCreditmemoId($magentoCreditmemo->getEntityId());
+                    $this->adyenCreditmemoResourceModel->save($currAdyenCreditmemo);
+                    break;
+                }
             }
         }
     }


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Describe the bug
When an order has multiple Magento credit memos, all related Adyen credit memos are linked to the same/last Magento 2 creditmemo. To our understanding, every refund's PSP reference can only be linked to a single Magento credit memo.

To Reproduce
Steps to reproduce the behavior:

Create an invoice from a order with an online capture.
Create a first online credit memo from the invoice, not refunding the entire amount.
Create a second online credit memo from the invoice, refunding the remaining amount.
Inspect the database table adyen_creditmemo column creditmemo_id: The corresponding Adyen credit memos are linked to the same Magento credit memo.
Expected behavior
The Adyen credit memo should be linked to the corresponding Magento credit memo.



**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

Fixes  #2407
