### PR TITLE
[ECP-8858] Set order status back to pre_payment_authorised after partial captures

### DIFF
--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -298,6 +298,14 @@ class Order extends AbstractHelper
                     'merchantReference' => $notification->getMerchantReference()
                 ]);
             }
+        } else {
+            /*
+             * Set order status back to pre_payment_authorized if the order state is payment_review.
+             * Otherwise, capture-cancel-refund is not possible.
+             */
+            if ($order->getState() === MagentoOrder::STATE_PAYMENT_REVIEW) {
+                $this->setPrePaymentAuthorized($order);
+            }
         }
 
         return $order;

--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -304,7 +304,7 @@ class Order extends AbstractHelper
              * Otherwise, capture-cancel-refund is not possible.
              */
             if ($order->getState() === MagentoOrder::STATE_PAYMENT_REVIEW) {
-                $this->setPrePaymentAuthorized($order);
+                $order = $this->setPrePaymentAuthorized($order);
             }
         }
 


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Capture process changes the order status into `Payment Review`. After processing `Capture` webhook, if the full amount has been finalised, order status will be updated to `Processing`. However, if this `Capture` webhook belongs to a partial capture, order status will be stuck at `Payment Review`, which blocks any further payment action. Order can not be captured, cancelled or refunded while it is on `Payment Review` status. 

This PR updates the order status after partial capture back to `pre_payment_authorized`.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- Partial capture and processing capture webhook
- Processing partial payment authorisation webhook