### PR TITLE
[ECP-8893] Allow usage of storedPaymentMethodId on headless payment requests

### DIFF
--- a/Gateway/Request/RecurringDataBuilder.php
+++ b/Gateway/Request/RecurringDataBuilder.php
@@ -51,8 +51,6 @@ class RecurringDataBuilder implements BuilderInterface
             $body = $this->adyenRequestsHelper->buildCardRecurringData($storeId, $payment);
         } elseif ($this->paymentMethodsHelper->isAlternativePaymentMethod($method)) {
             $body = $this->vaultHelper->buildPaymentMethodRecurringData($payment, $storeId);
-        } elseif ($method === PaymentMethods::ADYEN_ONE_CLICK) {
-            $body = $this->adyenRequestsHelper->buildAdyenTokenizedPaymentRecurringData($storeId, $payment);
         } elseif ($method !== PaymentMethods::ADYEN_PAY_BY_LINK) {
             $this->adyenLogger->addAdyenWarning(
                 sprintf('Unknown payment method: %s', $payment->getMethod()),

--- a/Gateway/Request/ShopperInteractionDataBuilder.php
+++ b/Gateway/Request/ShopperInteractionDataBuilder.php
@@ -11,6 +11,7 @@
 
 namespace Adyen\Payment\Gateway\Request;
 
+use Adyen\Payment\Helper\StateData;
 use Adyen\Payment\Model\Ui\Adminhtml\AdyenMotoConfigProvider;
 use Adyen\Payment\Model\Ui\AdyenPayByLinkConfigProvider;
 use Magento\Framework\App\State;
@@ -26,10 +27,14 @@ class ShopperInteractionDataBuilder implements BuilderInterface
     const SHOPPER_INTERACTION_ECOMMERCE = 'Ecommerce';
 
     private State $appState;
+    private StateData $stateData;
 
-    public function __construct(Context $context)
-    {
+    public function __construct(
+        Context $context,
+        StateData $stateData
+    ) {
         $this->appState = $context->getAppState();
+        $this->stateData = $stateData;
     }
 
     /**
@@ -42,6 +47,7 @@ class ShopperInteractionDataBuilder implements BuilderInterface
         /** @var \Magento\Payment\Gateway\Data\PaymentDataObject $paymentDataObject */
         $paymentDataObject = SubjectReader::readPayment($buildSubject);
         $payment = $paymentDataObject->getPayment();
+        $order = $payment->getOrder();
         $paymentMethod = $payment->getMethodInstance()->getCode();
 
         if ($paymentMethod == AdyenPayByLinkConfigProvider::CODE) {
@@ -52,11 +58,15 @@ class ShopperInteractionDataBuilder implements BuilderInterface
         // Ecommerce is the default shopperInteraction
         $shopperInteraction = self::SHOPPER_INTERACTION_ECOMMERCE;
 
+        // Check if it's a tokenised payment or not.
+        $stateData = $this->stateData->getStateData($order->getQuoteId());
+        $storedPaymentMethodId = $this->stateData->getStoredPaymentMethodIdFromStateData($stateData);
+
         if ($paymentMethod == AdyenMotoConfigProvider::CODE &&
             $this->appState->getAreaCode() == \Magento\Framework\App\Area::AREA_ADMINHTML) {
             // Backend CC orders are MOTO
             $shopperInteraction = self::SHOPPER_INTERACTION_MOTO;
-        } elseif (str_contains($paymentMethod, '_vault')) {
+        } elseif (str_contains($paymentMethod, '_vault') || isset($storedPaymentMethodId)) {
             // Vault is ContAuth
             $shopperInteraction = self::SHOPPER_INTERACTION_CONTAUTH;
         }

--- a/Helper/Requests.php
+++ b/Helper/Requests.php
@@ -338,7 +338,9 @@ class Requests extends AbstractHelper
             $request['storePaymentMethod'] = $storePaymentMethod;
         }
 
-        if ($storePaymentMethod) {
+        $storedPaymentMethodId = $this->stateData->getStoredPaymentMethodIdFromStateData($stateData);
+
+        if ($storePaymentMethod || isset($storedPaymentMethodId)) {
             $recurringProcessingModel = $payment->getAdditionalInformation('recurringProcessingModel');
 
             if (isset($recurringProcessingModel)) {

--- a/Helper/StateData.php
+++ b/Helper/StateData.php
@@ -125,4 +125,9 @@ class StateData
             return true;
         }
     }
+
+    public function getStoredPaymentMethodIdFromStateData(array $stateData): ?string
+    {
+        return $stateData['paymentMethod']['storedPaymentMethodId'] ?? null;
+    }
 }

--- a/Helper/Vault.php
+++ b/Helper/Vault.php
@@ -59,6 +59,7 @@ class Vault
     private PaymentTokenRepositoryInterface $paymentTokenRepository;
     private Config $config;
     private PaymentMethods $paymentMethodsHelper;
+    private StateData $stateData;
 
     public function __construct(
         AdyenLogger $adyenLogger,
@@ -66,7 +67,8 @@ class Vault
         PaymentTokenFactoryInterface $paymentTokenFactory,
         PaymentTokenRepositoryInterface $paymentTokenRepository,
         Config $config,
-        PaymentMethods $paymentMethodsHelper
+        PaymentMethods $paymentMethodsHelper,
+        StateData $stateData
     ) {
         $this->adyenLogger = $adyenLogger;
         $this->paymentTokenManagement = $paymentTokenManagement;
@@ -74,6 +76,7 @@ class Vault
         $this->paymentTokenRepository = $paymentTokenRepository;
         $this->config = $config;
         $this->paymentMethodsHelper = $paymentMethodsHelper;
+        $this->stateData = $stateData;
     }
 
     /**
@@ -144,11 +147,17 @@ class Vault
         $requestRpm = $payment->getAdditionalInformation('recurringProcessingModel');
         $configuredRpm = $this->getPaymentMethodRecurringProcessingModel($paymentMethod->getCode(), $storeId);
 
+        $stateData = $this->stateData->getStateData($payment->getOrder()->getQuoteId());
+        $storedPaymentMethodId = $this->stateData->getStoredPaymentMethodIdFromStateData($stateData);
+
         $recurringProcessingModel = $requestRpm ?? $configuredRpm;
 
         if (isset($recurringProcessingModel)) {
-            $request['storePaymentMethod'] = true;
             $request['recurringProcessingModel'] = $recurringProcessingModel;
+
+            if (is_null($storedPaymentMethodId)) {
+                $request['storePaymentMethod'] = true;
+            }
         }
 
         return $request;

--- a/Test/Unit/Gateway/Request/ShopperInteractionDataBuilderTest.php
+++ b/Test/Unit/Gateway/Request/ShopperInteractionDataBuilderTest.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2024 Adyen N.V. (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\Payment\Test\Gateway\Request;
+
+use Adyen\Payment\Gateway\Request\ShopperInteractionDataBuilder;
+use Adyen\Payment\Helper\StateData;
+use Adyen\Payment\Model\Method\Adapter;
+use Adyen\Payment\Model\Ui\Adminhtml\AdyenMotoConfigProvider;
+use Adyen\Payment\Model\Ui\AdyenCcConfigProvider;
+use Adyen\Payment\Model\Ui\AdyenPayByLinkConfigProvider;
+use Adyen\Payment\Test\Unit\AbstractAdyenTestCase;
+use Magento\Framework\App\Area;
+use Magento\Framework\App\State;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Magento\Payment\Gateway\Data\PaymentDataObject;
+use Magento\Sales\Model\Order;
+use Magento\Sales\Model\Order\Payment;
+
+class ShopperInteractionDataBuilderTest extends AbstractAdyenTestCase
+{
+    private $shopperInteractionDataBuilder;
+    private $appState;
+    private $stateData;
+
+    protected function setUp(): void
+    {
+        $this->objectManager = new ObjectManager($this);
+
+        $this->appState = $this->createMock(State::class);
+        $this->stateData = $this->createPartialMock(StateData::class, [
+            'getStateData'
+        ]);
+
+        $this->shopperInteractionDataBuilder = $this->objectManager->getObject(
+            ShopperInteractionDataBuilder::class, [
+                'appState' => $this->appState,
+                'stateData' => $this->stateData
+            ]
+        );
+    }
+
+    public function testPayByLinkRequest()
+    {
+        $buildSubject = [
+            'payment' => $this->createConfiguredMock(PaymentDataObject::class, [
+                'getPayment' => $this->createConfiguredMock(Payment::class, [
+                    'getMethodInstance' => $this->createConfiguredMock(Adapter::class, [
+                        'getCode' => AdyenPayByLinkConfigProvider::CODE
+                    ])
+                ])
+            ])
+        ];
+
+        $this->assertEmpty($this->shopperInteractionDataBuilder->build($buildSubject));
+    }
+
+    public function testMotoRequest()
+    {
+        $buildSubject = [
+            'payment' => $this->createConfiguredMock(PaymentDataObject::class, [
+                'getPayment' => $this->createConfiguredMock(Payment::class, [
+                    'getMethodInstance' => $this->createConfiguredMock(Adapter::class, [
+                        'getCode' => AdyenMotoConfigProvider::CODE
+                    ]),
+                    'getOrder' => $this->createConfiguredMock(Order::class, [
+                        'getQuoteId' => 1
+                    ])
+                ])
+            ])
+        ];
+
+        $this->appState->method('getAreaCode')->willReturn(Area::AREA_ADMINHTML);
+        $this->stateData->method('getStateData')->willReturn([]);
+
+        $request = $this->shopperInteractionDataBuilder->build($buildSubject);
+
+        $this->assertArrayHasKey('shopperInteraction', $request['body']);
+        $this->assertEquals(
+            ShopperInteractionDataBuilder::SHOPPER_INTERACTION_MOTO,
+            $request['body']['shopperInteraction']
+        );
+    }
+
+    public function testRecurringRequest()
+    {
+        $buildSubject = [
+            'payment' => $this->createConfiguredMock(PaymentDataObject::class, [
+                'getPayment' => $this->createConfiguredMock(Payment::class, [
+                    'getMethodInstance' => $this->createConfiguredMock(Adapter::class, [
+                        'getCode' => AdyenCcConfigProvider::CODE
+                    ]),
+                    'getOrder' => $this->createConfiguredMock(Order::class, [
+                        'getQuoteId' => 1
+                    ])
+                ])
+            ])
+        ];
+
+        $this->appState->method('getAreaCode')->willReturn(Area::AREA_ADMINHTML);
+        $this->stateData->method('getStateData')->willReturn([
+            'paymentMethod' => [
+                'storedPaymentMethodId' => hash('md5', time())
+            ]
+        ]);
+
+        $request = $this->shopperInteractionDataBuilder->build($buildSubject);
+
+        $this->assertArrayHasKey('shopperInteraction', $request['body']);
+        $this->assertEquals(
+            ShopperInteractionDataBuilder::SHOPPER_INTERACTION_CONTAUTH,
+            $request['body']['shopperInteraction']
+        );
+    }
+}

--- a/Test/Unit/Helper/StateDataTest.php
+++ b/Test/Unit/Helper/StateDataTest.php
@@ -91,4 +91,47 @@ class StateDataTest extends AbstractAdyenTestCase
 
         $this->stateDataHelper->removeStateData($stateDataId, $quoteId);
     }
+
+    /**
+     * @dataProvider storedPaymentMethodIdProvider
+     */
+    public function testGetStoredPaymentMethodId($stateData, $expectedResult)
+    {
+        $this->assertEquals(
+            $expectedResult,
+            $this->stateDataHelper->getStoredPaymentMethodIdFromStateData($stateData)
+        );
+    }
+
+    public static function storedPaymentMethodIdProvider(): array
+    {
+        $mockStoredPaymentMethodId = hash('md5', time());
+
+        return [
+            [
+                'stateData' => [
+                    'paymentMethod' => [
+                        'storedPaymentMethodId' => $mockStoredPaymentMethodId
+                    ]
+                ],
+                'expectedResult' => $mockStoredPaymentMethodId
+            ],
+            [
+                'stateData' => [
+                    'paymentMethod' => [
+                        'storedPaymentMethodId' => null
+                    ]
+                ],
+                'expectedResult' => null
+            ],
+            [
+                'stateData' => [
+                    'paymentMethod' => [
+                        'type' => 'scheme'
+                    ]
+                ],
+                'expectedResult' => null
+            ]
+        ];
+    }
 }

--- a/Test/Unit/Helper/VaultTest.php
+++ b/Test/Unit/Helper/VaultTest.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2024 Adyen N.V. (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\Payment\Test\Unit\Helper;
+
+use Adyen\Payment\Helper\Config;
+use Adyen\Payment\Helper\PaymentMethods;
+use Adyen\Payment\Helper\StateData;
+use Adyen\Payment\Helper\Vault;
+use Adyen\Payment\Logger\AdyenLogger;
+use Adyen\Payment\Model\Method\Adapter;
+use Adyen\Payment\Test\Unit\AbstractAdyenTestCase;
+use Magento\Sales\Model\Order;
+use Magento\Vault\Api\Data\PaymentTokenFactoryInterface;
+use Magento\Vault\Api\PaymentTokenRepositoryInterface;
+use Magento\Vault\Model\PaymentTokenManagement;
+
+class VaultTest extends AbstractAdyenTestCase
+{
+    private $vault;
+    private $adyenLogger;
+    private $paymentTokenManagement;
+    private $paymentTokenFactory;
+    private $paymentTokenRepository;
+    private $config;
+    private $paymentMethodsHelper;
+    private $stateData;
+
+    protected function setUp(): void
+    {
+        $this->stateData = $this->createPartialMock(StateData::class, [
+            'getStateData',
+            'getStoredPaymentMethodIdFromStateData'
+        ]);
+        $this->adyenLogger = $this->createMock(AdyenLogger::class);
+        $this->paymentTokenManagement = $this->createMock(PaymentTokenManagement::class);
+        $this->paymentTokenFactory = $this->createMock(PaymentTokenFactoryInterface::class);
+        $this->paymentTokenRepository = $this->createMock(PaymentTokenRepositoryInterface::class);
+        $this->config = $this->createMock(Config::class);
+        $this->paymentMethodsHelper = $this->createMock(PaymentMethods::class);
+
+        $this->vault = $this->getMockBuilder(Vault::class)
+            ->setMethods([
+                'getPaymentMethodRecurringActive',
+                'getPaymentMethodRecurringProcessingModel'
+            ])
+            ->setConstructorArgs([
+                $this->adyenLogger,
+                $this->paymentTokenManagement,
+                $this->paymentTokenFactory,
+                $this->paymentTokenRepository,
+                $this->config,
+                $this->paymentMethodsHelper,
+                $this->stateData
+            ])
+            ->getMock();
+
+        $this->vault->method('getPaymentMethodRecurringActive')->willReturn(true);
+    }
+
+    /**
+     * @dataProvider buildPaymentMethodRecurringDataDataProvider
+     */
+    public function testBuildPaymentMethodRecurringData(
+        $storedPaymentMethodId,
+        $recurringProcessingModel,
+        $storePaymentMethod
+    ) {
+        $paymentMock = $this->createConfiguredMock(Order\Payment::class, [
+            'getMethodInstance' => $this->createConfiguredMock(Adapter::class, [
+                'getCode' => 'adyen_klarna'
+            ]),
+            'getOrder' => $this->createConfiguredMock(Order::class, [
+                'getQuoteId' => 1
+            ])
+        ]);
+
+        $this->vault->method('getPaymentMethodRecurringProcessingModel')->willReturn(
+            $recurringProcessingModel
+        );
+        $this->stateData->method('getStoredPaymentMethodIdFromStateData')->willReturn($storedPaymentMethodId);
+        $storeId = 1;
+
+        $request = $this->vault->buildPaymentMethodRecurringData($paymentMock, $storeId);
+
+        if ($storePaymentMethod) {
+            $this->assertArrayHasKey('storePaymentMethod', $request);
+        }
+        $this->assertEquals($recurringProcessingModel, $request['recurringProcessingModel']);
+    }
+
+    public static function buildPaymentMethodRecurringDataDataProvider(): array
+    {
+        return [
+            [
+                'storedPaymentMethodId' => hash('md5', time()),
+                'recurringProcessingModel' => 'CardOnFile',
+                'storePaymentMethod' => false
+            ],
+            [
+                'storedPaymentMethodId' => null,
+                'recurringProcessingModel' => 'CardOnFile',
+                'storePaymentMethod' => true
+            ]
+        ];
+    }
+}


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
After deprecating OneClick payment method, the feature parity between V8 and V9 has been broken. After upgrading to V9, merchants have become unavailable to use stored payment methods through REST headless integration.

Currently, even if the `stateData` contains `storedPaymentMethodId`, payment facades can't distinguish between tokenised payments or normal payments. The request builder adds `shopperInteraction: ECOM` and doesn't add `recurringProcessingModel`.

Ideally, payment method facade should identify the tokenised payment if the `stateData` contains `storedPaymentMethodId` and add the correct request parameters.

This PR introduces the usage of `storedPaymentMethodId` parameter in the headless payment requests through `/payment-information` REST endpoint.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- Token generation for card and Klarna payments
- Token consumption thorugh `storedPaymentMethodId` parameter on headless integration