### PR TITLE
Make `Payment methods enabled` a global setting

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "adyen/module-payment",
   "description": "Official Magento2 Plugin to connect to Payment Service Provider Adyen.",
   "type": "magento2-module",
-  "version": "9.0.5",
+  "version": "9.0.6",
   "license": "MIT",
   "repositories": [
     {

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -12,7 +12,7 @@
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
 
-    <module name="Adyen_Payment" setup_version="9.0.5">
+    <module name="Adyen_Payment" setup_version="9.0.6">
         <sequence>
             <module name="Magento_Sales"/>
             <module name="Magento_Quote"/>


### PR DESCRIPTION
**Description**
The configuration setting `Payment methods enabled` is shown across all scopes. No matter what scope is selected, the underlying backend model `Adyen\Payment\Model\Config\Backend\PaymentMethodsStatus` is always updating the default scope for the single payment methods.
This leads to inconsistencies between `payment/adyen_abstract/payment_methods_active` and all the single payment method configurations.

* Set `Payment methods enabled` to `Yes` in `Default` scope
* Having a `Website A` and a `Website B` in place
* Set `Payment methods enabled`to `Yes` in `Website A` scope

**Expected Result**
Payment methods are still active in `Website B`
**Actual Result**
Payment methods are deactived in `Website B` as well

Showing the configuration setting only in `Default` scope won't lead to such inconsistencies.

**Tested scenarios**
`Stores > Configuration > Sales > Adyen > Accepting Payments > Payment methods > Payment methods enabled` is a global setting