### PR TITLE
[ECP-8717] Fix undefined getQuoteId() exception on GiftcardDataBuilder

### DIFF
--- a/Gateway/Request/GiftcardDataBuilder.php
+++ b/Gateway/Request/GiftcardDataBuilder.php
@@ -31,7 +31,8 @@ class GiftcardDataBuilder implements BuilderInterface
     {
         /** @var PaymentDataObject $paymentDataObject */
         $paymentDataObject = SubjectReader::readPayment($buildSubject);
-        $order = $paymentDataObject->getOrder();
+        $payment = $paymentDataObject->getPayment();
+        $order = $payment->getOrder();
 
         $request = [];
 


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Obtain `order` from `payment` object to be able to get `quoteId`.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- Giftcard payments

Fixes  #2307 
