### PR TITLE
[ECP-8822] Use correct endpoint for webhooks on auto configuration

### DIFF
--- a/Model/Config/Backend/WebhookCredentials.php
+++ b/Model/Config/Backend/WebhookCredentials.php
@@ -62,7 +62,7 @@ class WebhookCredentials extends Value
             $username = $this->getValue();
             $password = $this->getFieldsetDataValue('notification_password');
 
-            $webhookUrl = $this->url->getBaseUrl() . 'adyen/process/json';
+            $webhookUrl = $this->url->getBaseUrl() . 'adyen/webhook';
             $isDemoMode = (int)$this->getFieldsetDataValue('demo_mode');
             $environment = $isDemoMode ? 'test' : 'live';
 


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Management API webhook generation now uses the following endpoint.
`BASE_URL/adyen/webhook`

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- Auto configuration

Fixes  #2379