### PR TITLE
[ECP-8707] Setup custom headers for each request made to Adyen

### DIFF
--- a/Controller/Return/Index.php
+++ b/Controller/Return/Index.php
@@ -394,6 +394,7 @@ class Index extends Action
 
         $request["details"] = $details;
         $requestOptions['idempotencyKey'] = $this->idempotencyHelper->generateIdempotencyKey($request);
+        $requestOptions['headers'] = $this->adyenDataHelper->buildRequestHeaders();
 
         try {
             $response = $service->paymentsDetails($request, $requestOptions);

--- a/Gateway/Http/Client/TransactionCancel.php
+++ b/Gateway/Http/Client/TransactionCancel.php
@@ -46,7 +46,7 @@ class TransactionCancel implements ClientInterface
                 $headers['idempotencyExtraData'] ?? null
             );
             $requestOptions['idempotencyKey'] = $idempotencyKey;
-            $requestOptions['headers'] = $this->adyenHelper->buildRequestHeaders();;
+            $requestOptions['headers'] = $this->adyenHelper->buildRequestHeaders();
             $this->adyenHelper->logRequest($requests, Client::API_CHECKOUT_VERSION, '/cancels');
             try {
                 $responses = $service->cancels($requests, $requestOptions);

--- a/Gateway/Http/Client/TransactionCancel.php
+++ b/Gateway/Http/Client/TransactionCancel.php
@@ -46,6 +46,7 @@ class TransactionCancel implements ClientInterface
                 $headers['idempotencyExtraData'] ?? null
             );
             $requestOptions['idempotencyKey'] = $idempotencyKey;
+            $requestOptions['headers'] = $this->adyenHelper->buildRequestHeaders();;
             $this->adyenHelper->logRequest($requests, Client::API_CHECKOUT_VERSION, '/cancels');
             try {
                 $responses = $service->cancels($requests, $requestOptions);

--- a/Gateway/Http/Client/TransactionCapture.php
+++ b/Gateway/Http/Client/TransactionCapture.php
@@ -57,7 +57,7 @@ class TransactionCapture implements ClientInterface
         );
 
         $requestOptions['idempotencyKey'] = $idempotencyKey;
-        $requestOptions['headers'] = $this->adyenHelper->buildRequestHeaders();;
+        $requestOptions['headers'] = $this->adyenHelper->buildRequestHeaders();
 
         if (array_key_exists(self::MULTIPLE_AUTHORIZATIONS, $request)) {
             return $this->placeMultipleCaptureRequests($service, $request, $requestOptions);

--- a/Gateway/Http/Client/TransactionCapture.php
+++ b/Gateway/Http/Client/TransactionCapture.php
@@ -57,6 +57,7 @@ class TransactionCapture implements ClientInterface
         );
 
         $requestOptions['idempotencyKey'] = $idempotencyKey;
+        $requestOptions['headers'] = $this->adyenHelper->buildRequestHeaders();;
 
         if (array_key_exists(self::MULTIPLE_AUTHORIZATIONS, $request)) {
             return $this->placeMultipleCaptureRequests($service, $request, $requestOptions);

--- a/Gateway/Http/Client/TransactionDonate.php
+++ b/Gateway/Http/Client/TransactionDonate.php
@@ -53,6 +53,7 @@ class TransactionDonate implements ClientInterface
         );
 
         $requestOptions['idempotencyKey'] = $idempotencyKey;
+        $requestOptions['headers'] = $this->adyenHelper->buildRequestHeaders();;
 
         $this->adyenHelper->logRequest($request, Client::API_CHECKOUT_VERSION, 'donations');
         try {

--- a/Gateway/Http/Client/TransactionDonate.php
+++ b/Gateway/Http/Client/TransactionDonate.php
@@ -53,7 +53,7 @@ class TransactionDonate implements ClientInterface
         );
 
         $requestOptions['idempotencyKey'] = $idempotencyKey;
-        $requestOptions['headers'] = $this->adyenHelper->buildRequestHeaders();;
+        $requestOptions['headers'] = $this->adyenHelper->buildRequestHeaders();
 
         $this->adyenHelper->logRequest($request, Client::API_CHECKOUT_VERSION, 'donations');
         try {

--- a/Gateway/Http/Client/TransactionPayment.php
+++ b/Gateway/Http/Client/TransactionPayment.php
@@ -84,6 +84,7 @@ class TransactionPayment implements ClientInterface
                 $headers['idempotencyExtraData'] ?? null
             );
             $requestOptions['idempotencyKey'] = $idempotencyKey;
+            $requestOptions['headers'] = $this->adyenHelper->buildRequestHeaders();
 
             $this->adyenHelper->logRequest($request, Client::API_CHECKOUT_VERSION, '/payments');
             $response = $service->payments($request, $requestOptions);

--- a/Gateway/Http/Client/TransactionPaymentLinks.php
+++ b/Gateway/Http/Client/TransactionPaymentLinks.php
@@ -52,6 +52,7 @@ class TransactionPaymentLinks implements ClientInterface
         );
 
         $requestOptions['idempotencyKey'] = $idempotencyKey;
+        $requestOptions['headers'] = $this->adyenHelper->buildRequestHeaders();;
 
         $this->adyenHelper->logRequest($request, Client::API_CHECKOUT_VERSION, '/paymentLinks');
         try {

--- a/Gateway/Http/Client/TransactionPaymentLinks.php
+++ b/Gateway/Http/Client/TransactionPaymentLinks.php
@@ -52,7 +52,7 @@ class TransactionPaymentLinks implements ClientInterface
         );
 
         $requestOptions['idempotencyKey'] = $idempotencyKey;
-        $requestOptions['headers'] = $this->adyenHelper->buildRequestHeaders();;
+        $requestOptions['headers'] = $this->adyenHelper->buildRequestHeaders();
 
         $this->adyenHelper->logRequest($request, Client::API_CHECKOUT_VERSION, '/paymentLinks');
         try {

--- a/Gateway/Http/Client/TransactionRefund.php
+++ b/Gateway/Http/Client/TransactionRefund.php
@@ -47,8 +47,9 @@ class TransactionRefund implements TransactionRefundInterface
                 $headers['idempotencyExtraData'] ?? null
             );
             $requestOptions['idempotencyKey'] = $idempotencyKey;
-            $this->adyenHelper->logRequest($request, Client::API_CHECKOUT_VERSION, '/refunds');
+            $requestOptions['headers'] = $this->adyenHelper->buildRequestHeaders();
 
+            $this->adyenHelper->logRequest($request, Client::API_CHECKOUT_VERSION, '/refunds');
             try {
                 $response = $service->refunds($request, $requestOptions);
                 // Add amount original reference and amount information to response

--- a/Gateway/Request/CheckoutDataBuilder.php
+++ b/Gateway/Request/CheckoutDataBuilder.php
@@ -210,6 +210,7 @@ class CheckoutDataBuilder implements BuilderInterface
 
         $requestBody['additionalData']['allow3DS2'] = true;
 
+        // @todo cleanup, this variable was became obsolete in https://github.com/Adyen/adyen-magento2/pull/2246
         if (isset($requestBodyPaymentMethod)) {
             $requestBody['paymentMethod'] = $requestBodyPaymentMethod;
         }

--- a/Gateway/Request/CheckoutDataBuilder.php
+++ b/Gateway/Request/CheckoutDataBuilder.php
@@ -210,11 +210,6 @@ class CheckoutDataBuilder implements BuilderInterface
 
         $requestBody['additionalData']['allow3DS2'] = true;
 
-        // @todo cleanup, this variable was became obsolete in https://github.com/Adyen/adyen-magento2/pull/2246
-        if (isset($requestBodyPaymentMethod)) {
-            $requestBody['paymentMethod'] = $requestBodyPaymentMethod;
-        }
-
         return [
             'body' => $requestBody
         ];

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -1146,9 +1146,9 @@ class Data extends AbstractHelper
             $client->setRegion($checkoutFrontendRegion);
         }
 
-        $moduleVersion = $this->getModuleVersion();
-        $client->setMerchantApplication($this->getModuleName(), $moduleVersion);
-        $client->setExternalPlatform($this->productMetadata->getName(), $this->productMetadata->getVersion(), 'Adyen');
+        $client->setMerchantApplication($this->getModuleName(), $this->getModuleVersion());
+        $platformData = $this->getMagentoDetails();
+        $client->setExternalPlatform($platformData['name'], $platformData['version'], 'Adyen');
         if ($isDemo) {
             $client->setEnvironment(Environment::TEST);
         } else {
@@ -1156,6 +1156,27 @@ class Data extends AbstractHelper
         }
 
         return $client;
+    }
+
+    public function getMagentoDetails()
+    {
+        return [
+            'name' => $this->productMetadata->getName(),
+            'version' => $this->productMetadata->getVersion(),
+            'edition' => $this->productMetadata->getEdition(),
+        ];
+    }
+
+    public function buildRequestHeaders()
+    {
+        $magentoDetails = $this->getMagentoDetails();
+        return [
+            'external-platform-name' => $this->getModuleName(),
+            'external-platform-version' => $this->getModuleVersion(),
+            'merchant-application-name' => $magentoDetails['name'],
+            'merchant-application-version' => $magentoDetails['version'],
+            'merchant-application-edition' => $magentoDetails['edition'],
+        ];
     }
 
     /**

--- a/Helper/PaymentsDetails.php
+++ b/Helper/PaymentsDetails.php
@@ -65,6 +65,7 @@ class PaymentsDetails
             $service = $this->adyenHelper->createAdyenCheckoutService($client);
 
             $requestOptions['idempotencyKey'] = $this->idempotencyHelper->generateIdempotencyKey($apiPayload);
+            $requestOptions['headers'] = $this->adyenHelper->buildRequestHeaders();
 
             $paymentDetails = $service->paymentsDetails($apiPayload, $requestOptions);
         } catch (AdyenException $e) {

--- a/Test/Unit/Gateway/Http/Client/TransactionPaymentTest.php
+++ b/Test/Unit/Gateway/Http/Client/TransactionPaymentTest.php
@@ -1,4 +1,13 @@
 <?php
+/**
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2024 Adyen N.V. (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
 
 namespace Adyen\Payment\Test\Unit\Gateway\Http\Client;
 
@@ -33,7 +42,6 @@ class TransactionPaymentTest extends AbstractAdyenTestCase
         $objectManager = new ObjectManager($this);
 
         $this->adyenHelperMock = $this->createMock(Data::class);
-        $this->paymentResponseFactoryMock = $this->createGeneratedMock(PaymentResponseFactory::class, ['create']);
         $this->paymentResponseResourceModelMock = $this->createMock(PaymentResponseResourceModel::class);
         $this->idempotencyHelperMock = $this->createMock(Idempotency::class);
         $this->orderApiHelperMock = $this->createMock(OrdersApi::class);
@@ -44,8 +52,6 @@ class TransactionPaymentTest extends AbstractAdyenTestCase
         $paymentResponseMock->method('setResponse')->willReturn($paymentResponseInterfaceMock);
         $paymentResponseMock->method('setResultCode')->willReturn($paymentResponseInterfaceMock);
         $paymentResponseMock->method('setMerchantReference')->willReturn($paymentResponseInterfaceMock);
-
-        // Configure PaymentResponseFactory mock to return the PaymentResponse mock
         $this->paymentResponseFactoryMock = $this->createGeneratedMock(PaymentResponseFactory::class, ['create']);
         $this->paymentResponseFactoryMock->method('create')->willReturn($paymentResponseMock);
 

--- a/Test/Unit/Gateway/Http/Client/TransactionPaymentTest.php
+++ b/Test/Unit/Gateway/Http/Client/TransactionPaymentTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Adyen\Payment\Test\Unit\Gateway\Http\Client;
+
+use Adyen\Payment\Api\Data\PaymentResponseInterface;
+use Adyen\Payment\Model\PaymentResponse;
+use Adyen\Payment\Test\Unit\AbstractAdyenTestCase;
+use Adyen\Service\Checkout;
+use PHPUnit\Framework\TestCase;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Adyen\Payment\Helper\Data;
+use Adyen\Payment\Model\PaymentResponseFactory;
+use Adyen\Payment\Model\ResourceModel\PaymentResponse as PaymentResponseResourceModel;
+use Adyen\Payment\Helper\Idempotency;
+use Adyen\Payment\Helper\OrdersApi;
+use Adyen\Payment\Gateway\Http\Client\TransactionPayment;
+use Magento\Store\Model\StoreManagerInterface;
+use Adyen\Payment\Helper\GiftcardPayment;
+use Magento\Payment\Gateway\Http\TransferInterface;
+
+class TransactionPaymentTest extends AbstractAdyenTestCase
+{
+    private $adyenHelperMock;
+    private $paymentResponseFactoryMock;
+    private $paymentResponseResourceModelMock;
+    private $idempotencyHelperMock;
+    private $orderApiHelperMock;
+    private $storeManagerMock;
+    private $giftcardPaymentHelperMock;
+    private $transactionPayment;
+
+    protected function setUp(): void
+    {
+        $objectManager = new ObjectManager($this);
+
+        $this->adyenHelperMock = $this->createMock(Data::class);
+        $this->paymentResponseFactoryMock = $this->createGeneratedMock(PaymentResponseFactory::class, ['create']);
+        $this->paymentResponseResourceModelMock = $this->createMock(PaymentResponseResourceModel::class);
+        $this->idempotencyHelperMock = $this->createMock(Idempotency::class);
+        $this->orderApiHelperMock = $this->createMock(OrdersApi::class);
+        $this->storeManagerMock = $this->createMock(StoreManagerInterface::class);
+        $this->giftcardPaymentHelperMock = $this->createMock(GiftcardPayment::class);
+        $paymentResponseInterfaceMock = $this->createMock(PaymentResponseInterface::class);
+        $paymentResponseMock = $this->createMock(PaymentResponse::class);
+        $paymentResponseMock->method('setResponse')->willReturn($paymentResponseInterfaceMock);
+        $paymentResponseMock->method('setResultCode')->willReturn($paymentResponseInterfaceMock);
+        $paymentResponseMock->method('setMerchantReference')->willReturn($paymentResponseInterfaceMock);
+
+        // Configure PaymentResponseFactory mock to return the PaymentResponse mock
+        $this->paymentResponseFactoryMock = $this->createGeneratedMock(PaymentResponseFactory::class, ['create']);
+        $this->paymentResponseFactoryMock->method('create')->willReturn($paymentResponseMock);
+
+        $this->transactionPayment = $objectManager->getObject(
+            TransactionPayment::class,
+            [
+                'adyenHelper' => $this->adyenHelperMock,
+                'paymentResponseFactory' => $this->paymentResponseFactoryMock,
+                'paymentResponseResourceModel' => $this->paymentResponseResourceModelMock,
+                'idempotencyHelper' => $this->idempotencyHelperMock,
+                'orderApiHelper' => $this->orderApiHelperMock,
+                'storeManager' => $this->storeManagerMock,
+                'giftcardPaymentHelper' => $this->giftcardPaymentHelperMock,
+            ]
+        );
+    }
+
+    public function testPlaceRequestWithResultCode()
+    {
+        $transferObjectMock = $this->createMock(TransferInterface::class);
+        $requestBody = ['resultCode' => 'Authorised', 'amount' => ['value' => 1000]];
+        $transferObjectMock->method('getBody')->willReturn($requestBody);
+
+        $result = $this->transactionPayment->placeRequest($transferObjectMock);
+
+        $this->assertEquals($requestBody, $result);
+    }
+
+    public function testPlaceRequestGeneratesIdempotencyKey()
+    {
+        $requestBody = ['reference' => 'ABC12345', 'amount' => ['value' => 100]];
+        $transferObjectMock = $this->createConfiguredMock(TransferInterface::class, [
+            'getBody' => $requestBody,
+            'getHeaders' => ['idempotencyExtraData' => ['someData']],
+            'getClientConfig' => []
+        ]);
+
+        $expectedIdempotencyKey = 'generated_idempotency_key';
+        $this->idempotencyHelperMock->expects($this->once())
+            ->method('generateIdempotencyKey')
+            ->with(
+                $this->equalTo(['reference' => 'ABC12345', 'amount' => ['value' => 100]]),
+                $this->equalTo(['someData'])
+            )
+            ->willReturn($expectedIdempotencyKey);
+
+        $mockedPaymentResponse = [
+            'reference' => 'ABC12345',
+            'amount' => ['value' => 100],
+            'resultCode' => 'Authorised'
+        ];
+        $serviceMock = $this->createMock(Checkout::class);
+        $serviceMock->expects($this->once())
+            ->method('payments')
+            ->with(
+                $this->anything(),
+                $this->callback(function ($requestOptions) use ($expectedIdempotencyKey) {
+                    return isset($requestOptions['idempotencyKey']) &&
+                        $requestOptions['idempotencyKey'] === $expectedIdempotencyKey;
+                })
+            )
+            ->willReturn($mockedPaymentResponse);
+
+        $this->adyenHelperMock->method('createAdyenCheckoutService')->willReturn($serviceMock);
+
+        $this->transactionPayment->placeRequest($transferObjectMock);
+    }
+}

--- a/Test/Unit/Gateway/Http/Client/TransactionPaymentTest.php
+++ b/Test/Unit/Gateway/Http/Client/TransactionPaymentTest.php
@@ -6,7 +6,6 @@ use Adyen\Payment\Api\Data\PaymentResponseInterface;
 use Adyen\Payment\Model\PaymentResponse;
 use Adyen\Payment\Test\Unit\AbstractAdyenTestCase;
 use Adyen\Service\Checkout;
-use PHPUnit\Framework\TestCase;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Adyen\Payment\Helper\Data;
 use Adyen\Payment\Model\PaymentResponseFactory;

--- a/Test/Unit/Gateway/Http/Client/TransactionRefundTest.php
+++ b/Test/Unit/Gateway/Http/Client/TransactionRefundTest.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2024 Adyen N.V. (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\Payment\Test\Unit\Gateway\Http\Client;
+
+use Adyen\Client;
+use Adyen\Payment\Gateway\Http\Client\TransactionRefund;
+use Adyen\Payment\Helper\Data;
+use Adyen\Payment\Helper\Idempotency;
+use Adyen\Payment\Test\Unit\AbstractAdyenTestCase;
+use Adyen\Service\Checkout;
+use Magento\Payment\Gateway\Http\TransferInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class TransactionRefundTest extends AbstractAdyenTestCase
+{
+    /**
+     * @var Data|MockObject
+     */
+    private $adyenHelperMock;
+
+    /**
+     * @var Idempotency|MockObject
+     */
+    private $idempotencyHelperMock;
+
+    /**
+     * @var TransactionRefund
+     */
+    private $transactionRefund;
+
+    protected function setUp(): void
+    {
+        $this->adyenHelperMock = $this->createMock(Data::class);
+        $this->idempotencyHelperMock = $this->createMock(Idempotency::class);
+
+        $this->transactionRefund = new TransactionRefund(
+            $this->adyenHelperMock,
+            $this->idempotencyHelperMock
+        );
+    }
+
+    public function testPlaceRequestIncludesHeadersInRequest()
+    {
+        $requestBody = [
+            'amount' => ['value' => 1000, 'currency' => 'EUR'],
+            'paymentPspReference' => '123456789'
+        ];
+
+        $headers = ['idempotencyExtraData' => ['order_id' => '1001']];
+
+        $transferObjectMock = $this->createConfiguredMock(TransferInterface::class, [
+            'getBody' => [$requestBody],
+            'getHeaders' => $headers,
+            'getClientConfig' => []
+        ]);
+
+        $checkoutServiceMock = $this->createMock(Checkout::class);
+        $adyenClientMock = $this->createMock(Client::class);
+
+        $this->adyenHelperMock->method('initializeAdyenClientWithClientConfig')->willReturn($adyenClientMock);
+        $this->adyenHelperMock->method('createAdyenCheckoutService')->willReturn($checkoutServiceMock);
+        $this->adyenHelperMock->method('buildRequestHeaders')->willReturn(['custom-header' => 'value']);
+
+        $this->idempotencyHelperMock->expects($this->once())
+            ->method('generateIdempotencyKey')
+            ->with($requestBody, $headers['idempotencyExtraData'])
+            ->willReturn('generated_idempotency_key');
+
+        $checkoutServiceMock->expects($this->once())
+            ->method('refunds')
+            ->with(
+                $this->equalTo($requestBody),
+                $this->callback(function ($requestOptions) {
+                    $this->assertArrayHasKey('idempotencyKey', $requestOptions);
+                    $this->assertArrayHasKey('headers', $requestOptions);
+                    $this->assertEquals('generated_idempotency_key', $requestOptions['idempotencyKey']);
+                    $this->assertArrayHasKey('custom-header', $requestOptions['headers']);
+                    return true;
+                })
+            )
+            ->willReturn(['pspReference' => 'refund_psp_reference']);
+
+        $responses = $this->transactionRefund->placeRequest($transferObjectMock);
+
+        $this->assertIsArray($responses);
+        $this->assertCount(1, $responses);
+        $this->assertArrayHasKey('pspReference', $responses[0]);
+    }
+}

--- a/Test/Unit/Helper/DataTest.php
+++ b/Test/Unit/Helper/DataTest.php
@@ -64,7 +64,8 @@ class DataTest extends AbstractAdyenTestCase
         $backendHelper = $this->createMock(BackendHelper::class);
         $productMetadata = $this->createConfiguredMock(ProductMetadata::class, [
             'getName' => 'magento',
-            'getVersion' => '2.x.x'
+            'getVersion' => '2.x.x',
+            'getEdition' => 'Community'
         ]);
         $adyenLogger = $this->createMock(AdyenLogger::class);
         $storeManager = $this->createMock(StoreManager::class);
@@ -189,5 +190,31 @@ class DataTest extends AbstractAdyenTestCase
             Client::class,
             $this->dataHelper->initializeAdyenClientWithClientConfig($clientConfig)
         );
+    }
+
+    public function testGetMagentoDetails()
+    {
+        $expectedDetails = [
+            'name' => 'magento',
+            'version' => '2.x.x',
+            'edition' => 'Community'
+        ];
+
+        $actualDetails = $this->dataHelper->getMagentoDetails();
+        $this->assertEquals($expectedDetails, $actualDetails);
+    }
+
+    public function testBuildRequestHeaders()
+    {
+        $expectedHeaders = [
+            'external-platform-name' => 'adyen-magento2',
+            'external-platform-version' => '1.2.3',
+            'merchant-application-name' => 'magento',
+            'merchant-application-version' => '2.x.x',
+            'merchant-application-edition' => 'Community'
+        ];
+
+        $headers = $this->dataHelper->buildRequestHeaders();
+        $this->assertEquals($expectedHeaders, $headers);
     }
 }

--- a/Test/Unit/Helper/PaymentDetailsTest.php
+++ b/Test/Unit/Helper/PaymentDetailsTest.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2023 Adyen N.V. (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+use Adyen\Payment\Helper\PaymentsDetails;
+use Adyen\Payment\Test\Unit\AbstractAdyenTestCase;
+use Magento\Sales\Api\Data\OrderInterface;
+use Magento\Sales\Model\Order\Payment;
+use Adyen\Payment\Helper\Data;
+use Adyen\Payment\Logger\AdyenLogger;
+use Adyen\Payment\Helper\PaymentResponseHandler;
+use Adyen\Payment\Helper\Idempotency;
+use Adyen\AdyenException;
+use Magento\Checkout\Model\Session;
+use Magento\Framework\Exception\ValidatorException;
+use Adyen\Service\Checkout;
+use Adyen\Client;
+
+class PaymentDetailsTest extends AbstractAdyenTestCase
+{
+    private $checkoutSessionMock;
+    private $adyenHelperMock;
+    private $adyenLoggerMock;
+    private $paymentResponseHandlerMock;
+    private $idempotencyHelperMock;
+    private $paymentDetails;
+
+    protected function setUp(): void
+    {
+        $this->checkoutSessionMock = $this->createMock(Session::class);
+        $this->adyenHelperMock = $this->createMock(Data::class);
+        $this->adyenLoggerMock = $this->createMock(AdyenLogger::class);
+        $this->paymentResponseHandlerMock = $this->createMock(PaymentResponseHandler::class);
+        $this->idempotencyHelperMock = $this->createMock(Idempotency::class);
+
+        $this->paymentDetails = new PaymentsDetails(
+            $this->checkoutSessionMock,
+            $this->adyenHelperMock,
+            $this->adyenLoggerMock,
+            $this->paymentResponseHandlerMock,
+            $this->idempotencyHelperMock
+            );
+    }
+
+    public function testRequestHeadersAreAddedToRequest()
+    {
+        $orderMock = $this->createMock(OrderInterface::class);
+        $paymentMock = $this->createMock(Payment::class);
+        $checkoutServiceMock = $this->createMock(Checkout::class);
+        $adyenClientMock = $this->createMock(Client::class);
+        $storeId = 1;
+        $payload = json_encode([
+            'details' => 'some_details',
+            'paymentData' => 'some_payment_data',
+            'threeDSAuthenticationOnly' => true
+        ]);
+        $requestOptions = [
+        'idempotencyKey' => 'some_idempotency_key',
+        'headers' => ['headerKey' => 'headerValue']
+        ];
+        $paymentDetailsResult = ['resultCode' => 'Authorised', 'action' => null, 'additionalData' => null];
+
+        $orderMock->method('getPayment')->willReturn($paymentMock);
+        $orderMock->method('getStoreId')->willReturn($storeId);
+        $paymentMock->method('getOrder')->willReturn($orderMock);
+
+        $this->adyenHelperMock->method('initializeAdyenClient')->willReturn($adyenClientMock);
+        $this->adyenHelperMock->method('createAdyenCheckoutService')->willReturn($checkoutServiceMock);
+        $this->adyenHelperMock->method('buildRequestHeaders')->willReturn($requestOptions['headers']);
+        $this->idempotencyHelperMock->method('generateIdempotencyKey')->willReturn($requestOptions['idempotencyKey']);
+
+        $checkoutServiceMock->expects($this->once())
+            ->method('paymentsDetails')
+            ->with(
+                $this->equalTo([
+                    'details' => 'some_details',
+                    'paymentData' => 'some_payment_data',
+                    'threeDSAuthenticationOnly' => true
+                ]),
+                $this->equalTo($requestOptions)
+            )
+            ->willReturn($paymentDetailsResult);
+
+        $this->paymentResponseHandlerMock->method('handlePaymentResponse')->willReturn(true);
+        $this->paymentResponseHandlerMock->method('formatPaymentResponse')->willReturn($paymentDetailsResult);
+
+        $result = $this->paymentDetails->initiatePaymentDetails($orderMock, $payload);
+
+        $this->assertJson($result);
+        $this->assertEquals(json_encode($paymentDetailsResult), $result);
+    }
+}

--- a/Test/Unit/Helper/PaymentDetailsTest.php
+++ b/Test/Unit/Helper/PaymentDetailsTest.php
@@ -3,11 +3,12 @@
  *
  * Adyen Payment module (https://www.adyen.com/)
  *
- * Copyright (c) 2023 Adyen N.V. (https://www.adyen.com/)
+ * Copyright (c) 2024 Adyen N.V. (https://www.adyen.com/)
  * See LICENSE.txt for license details.
  *
  * Author: Adyen <magento@adyen.com>
  */
+namespace Adyen\Payment\Test\Unit\Helper;
 
 use Adyen\Payment\Helper\PaymentsDetails;
 use Adyen\Payment\Test\Unit\AbstractAdyenTestCase;
@@ -17,9 +18,7 @@ use Adyen\Payment\Helper\Data;
 use Adyen\Payment\Logger\AdyenLogger;
 use Adyen\Payment\Helper\PaymentResponseHandler;
 use Adyen\Payment\Helper\Idempotency;
-use Adyen\AdyenException;
 use Magento\Checkout\Model\Session;
-use Magento\Framework\Exception\ValidatorException;
 use Adyen\Service\Checkout;
 use Adyen\Client;
 

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   ],
   "require": {
     "php": ">=8.1",
-    "adyen/php-api-library": "^15.4.0",
+    "adyen/php-api-library": "^17.0.0",
     "adyen/php-webhook-module": "^0.8.0",
     "magento/framework": ">=103.0.4",
     "magento/module-vault": ">=101.2.4",


### PR DESCRIPTION
**Description**
This PR migrates all the values sent to appInfo to custom request headers that were enabled by the php library with the release of v17. Hence, this PR also updates the library version to v17. The custom headers sent in a request are:
- external-platform-name
- external-platform-version
- merchant-application-name
- merchant-application-version
- merchant-application-edition

**Tested scenarios**
Confirmed the custom headers are added to all the requests:
- payments
- payment details
- cancel
- capture
- refund
- donation
- pay by link
