### PR TITLE
[ECP-8787] Handle Pending resultCode on multishipping payments

### DIFF
--- a/Block/Checkout/Multishipping/Success.php
+++ b/Block/Checkout/Multishipping/Success.php
@@ -28,12 +28,12 @@ use Magento\Sales\Api\OrderRepositoryInterface;
 
 class Success extends \Magento\Multishipping\Block\Checkout\Success
 {
-    const FINAL_RESULT_CODES = array(
-        PaymentResponseHandler::AUTHORISED,
-        PaymentResponseHandler::PENDING,
-        PaymentResponseHandler::REFUSED,
-        PaymentResponseHandler::PRESENT_TO_SHOPPER
-    );
+    const ACTION_REQUIRED_STATUSES = [
+        PaymentResponseHandler::REDIRECT_SHOPPER,
+        PaymentResponseHandler::IDENTIFY_SHOPPER,
+        PaymentResponseHandler::CHALLENGE_SHOPPER,
+        PaymentResponseHandler::PENDING
+    ];
 
     /**
      * @var bool
@@ -122,7 +122,7 @@ class Success extends \Magento\Multishipping\Block\Checkout\Success
     public function renderAction()
     {
         foreach ($this->paymentResponseEntities as $paymentResponseEntity) {
-            if (!in_array($paymentResponseEntity['result_code'], self::FINAL_RESULT_CODES)) {
+            if (in_array($paymentResponseEntity['result_code'], self::ACTION_REQUIRED_STATUSES)) {
                 return true;
             }
         }
@@ -189,7 +189,7 @@ class Success extends \Magento\Multishipping\Block\Checkout\Success
     public function getIsPaymentCompleted(int $orderId)
     {
         // TODO check for all completed responses, not only Authorised, Refused, Pending or PresentToShopper
-        return in_array($this->ordersInfo[$orderId]['resultCode'], self::FINAL_RESULT_CODES);
+        return !in_array($this->ordersInfo[$orderId]['resultCode'], self::ACTION_REQUIRED_STATUSES);
     }
 
     public function getPaymentButtonLabel(int $orderId)

--- a/view/frontend/templates/checkout/multishipping/success.phtml
+++ b/view/frontend/templates/checkout/multishipping/success.phtml
@@ -187,9 +187,7 @@ $paymentResponseEntities = $block->getPaymentResponseEntities();
                 try {
                     let response = $(this).data('adyen-response');
 
-                    // Only show the modal for some result codes
-                    const modalResponseCodes = ['IdentifyShopper'];
-                    if (modalResponseCodes.includes(response.resultCode)) {
+                    if (response.resultCode !== 'RedirectShopper') {
                         showModal();
                     }
 


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
This PR fixes payments that have `Pending` resultCode on multishipping. `Pending` resultCode expects an action container, which is now mounted on success page.  

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- Multishipping Bancontact Mobile (QR)
- Multishipping 3DS2 card payment