### PR TITLE
ShopperReference should be string to be aligned with checkout API

### DIFF
--- a/Helper/PaymentMethods.php
+++ b/Helper/PaymentMethods.php
@@ -266,7 +266,7 @@ class PaymentMethods extends AbstractHelper
         $this->quote = $quote;
     }
 
-    protected function getCurrentShopperReference(): ?int
+    protected function getCurrentShopperReference(): ?string
     {
         return $this->getQuote()->getCustomerId();
     }


### PR DESCRIPTION
Checkout API is expecting the shopper reference to be a string as well, the plugin should be aligned with it

The error:
```
TypeError: Adyen\Payment\Helper\PaymentMethods::getCurrentShopperReference(): Return value must be of type ?int, string returned in /var/www/html/vendor/adyen/module-payment/Helper/PaymentMethods.php:279
```