### PR TITLE
Remove post install commands for phpcompatibility/php-compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,12 +41,6 @@
     "test": [
       "Composer\\Config::disableProcessTimeout",
       "vendor/bin/phpunit -c Test/phpunit.xml"
-    ],
-    "post-install-cmd": [
-      "([ $COMPOSER_DEV_MODE -eq 0 ] || vendor/bin/phpcs --config-set installed_paths ../../magento/magento-coding-standard/,../../phpcompatibility/php-compatibility)"
-    ],
-    "post-update-cmd": [
-      "([ $COMPOSER_DEV_MODE -eq 0 ] || vendor/bin/phpcs --config-set installed_paths ../../magento/magento-coding-standard/,../../phpcompatibility/php-compatibility)"
     ]
   }
 }

--- a/view/adminhtml/templates/config/applepay_button.phtml
+++ b/view/adminhtml/templates/config/applepay_button.phtml
@@ -1,3 +1,3 @@
 <?php /** @var \Adyen\Payment\Model\Config\Adminhtml\ApplepayCertificateButton $block */ ?>
 
-<input type="button" onclick="location.href='<?= $block->getActionUrl() ?>';" value="Download certificate" />
+<input type="button" onclick="location.href='<?= $block->escapeJs($block->getActionUrl()) ?>';" value="Download certificate" />

--- a/view/adminhtml/templates/config/configuration_wizard.phtml
+++ b/view/adminhtml/templates/config/configuration_wizard.phtml
@@ -1,8 +1,8 @@
 <?php /** @var \Adyen\Payment\Model\Config\Adminhtml\ConfigurationWizard $block */ ?>
 <?php echo $block->getNextButtonHtml() ?>
 <span class="adyen-required-settings-config-admin" id="progress" style="display: none">
-    <img class="processing" hidden="hidden" alt="Configuring" style="margin:0 5px" src="<?php echo $block->getViewFileUrl('images/process_spinner.gif') ?>"/>
-    <img class="configured" hidden="hidden" alt="Configured" style="margin:-3px 5px" src="<?php echo $block->getViewFileUrl('images/rule_component_apply.gif') ?>"/>
+    <img class="processing" hidden="hidden" alt="Configuring" style="margin:0 5px" src="<?= $block->escapeUrl($block->getViewFileUrl('images/process_spinner.gif')) ?>"/>
+    <img class="configured" hidden="hidden" alt="Configured" style="margin:-3px 5px" src="<?= $block->escapeUrl($block->getViewFileUrl('images/rule_component_apply.gif')) ?>"/>
 <script>
     require(['jquery'], function ($) {
         $(window).on('load', function () {
@@ -90,7 +90,7 @@
                 let apiKey = parseInt(demoMode)
                     ? $(testApiKeySelector).val()
                     : $(liveApiKeySelector).val();
-                $.ajax('<?php echo $block->getMerchantAccountsUrl() ?>', {
+                $.ajax('<?= $block->escapeJs($block->getMerchantAccountsUrl()) ?>', {
                     data: {apiKey, demoMode},
                     method: "POST"
                 }).done(function (response) {
@@ -171,7 +171,7 @@
 
                 convertActionButtonToFinished();
 
-                progressUpdate('success', 'You completed the configuration. Now, you can click "<?= __('Save Config') ?>" to save it');
+                progressUpdate('success', 'You completed the configuration. Now, you can click "<?= $block->escapeJS(__('Save Config')) ?>" to save it');
 
                 $(createNewWebhookSelector).on('change', function () {
                     let createNewWebhook = parseInt(this.value);

--- a/view/adminhtml/templates/config/configuration_wizard.phtml
+++ b/view/adminhtml/templates/config/configuration_wizard.phtml
@@ -171,7 +171,7 @@
 
                 convertActionButtonToFinished();
 
-                progressUpdate('success', 'You completed the configuration. Now, you can click "<?= $block->escapeJS(__('Save Config')) ?>" to save it');
+                progressUpdate('success', 'You completed the configuration. Now, you can click "<?= $block->escapeJs(__('Save Config')) ?>" to save it');
 
                 $(createNewWebhookSelector).on('change', function () {
                     let createNewWebhook = parseInt(this.value);

--- a/view/adminhtml/templates/config/required_settings.phtml
+++ b/view/adminhtml/templates/config/required_settings.phtml
@@ -21,8 +21,8 @@ echo $block->getButtonHtml() ?>
                     xapi_key = document.querySelector(
                         "div.adyen_required_config_settings input[name*='api_key_live']").value;
                 }
-                const storeId = '<?=$block->getStoreId()?>';
-                new Ajax.Request('<?php echo $block->getAjaxUrl() ?>', {
+                const storeId = '<?= $block->escapeJs($block->getStoreId()) ?>';
+                new Ajax.Request('<?= $block->escapeJs($block->getAjaxUrl()) ?>', {
                     parameters: {xapikey: xapi_key, demoMode: demo_mode, storeId},
                     type: "POST",
                     loaderArea:     false,
@@ -97,6 +97,6 @@ echo $block->getButtonHtml() ?>
 </span>-->
 <!--if we want to add a note under the button-->
 <p class="note">
-    <span><?php echo __('Retrieves the associated merchant accounts, client key and the allowed origin.'); ?></span>
+    <span><?= $block->escapeHtml(__('Retrieves the associated merchant accounts, client key and the allowed origin.')); ?></span>
 </p>
 <hr>

--- a/view/adminhtml/templates/config/token_type_table_array.phtml
+++ b/view/adminhtml/templates/config/token_type_table_array.phtml
@@ -90,7 +90,7 @@ $_colspan = $block->isAddAfter() ? 2 : 1;
 
             // add existing rows
             <?php foreach ($block->getArrayRows() as $_rowId => $_row): ?>
-                arrayRow<?= $block->escapeJs($_htmlId) ?>.add(<?= $_row->toJson() ?>);
+                arrayRow<?= $block->escapeJs($_htmlId) ?>.add(<?= $block->escapeJs($_row->toJson()) ?>);
             <?php endforeach; ?>
 
             <?php if ($block->getElement()->getDisabled()): ?>

--- a/view/adminhtml/templates/config/webhook_test.phtml
+++ b/view/adminhtml/templates/config/webhook_test.phtml
@@ -8,7 +8,7 @@
             let progressSpan = jQuery('#webhook_progress');
             jQuery('#adyen_webhook_test').click(function () {
 
-                new Ajax.Request('<?php echo $block->getAjaxUrl() ?>', {
+                new Ajax.Request('<?= $block->escapeJs($block->getAjaxUrl()) ?>', {
                     parameters: {},
                     type: "POST",
                     loaderArea:     false,
@@ -50,11 +50,11 @@
 <?php if ($block->isWebhookIdConfigured()) : ?>
     <?php echo $block->getButtonHtml() ?>
     <span class="adyen_webhook_test_config" id="webhook_progress">
-        <img class="test-processing" hidden="hidden" alt="Configuring" style="margin:0 5px" src="<?php echo $block->getViewFileUrl('images/process_spinner.gif') ?>"/>
-        <img class="test-configured" hidden="hidden" alt="Configured" style="margin:-3px 5px" src="<?php echo $block->getViewFileUrl('images/rule_component_apply.gif') ?>"/>
+        <img class="test-processing" hidden="hidden" alt="Configuring" style="margin:0 5px" src="<?= $block->escapeUrl($block->getViewFileUrl('images/process_spinner.gif')) ?>"/>
+        <img class="test-configured" hidden="hidden" alt="Configured" style="margin:-3px 5px" src="<?= $block->escapeUrl($block->getViewFileUrl('images/rule_component_apply.gif')) ?>"/>
         <span id="adyen_webhook_test_message"></span>
     </span>
     <p class="note">
-        <span><?php echo __('Sends sample notifications to test if the webhook is set up correctly.'); ?></span>
+        <span><?= $block->escapeHtml(__('Sends sample notifications to test if the webhook is set up correctly.')); ?></span>
     </p>
 <?php endif; ?>

--- a/view/adminhtml/templates/form/pay_by_link.phtml
+++ b/view/adminhtml/templates/form/pay_by_link.phtml
@@ -30,7 +30,7 @@ if (!isset($escaper)) {
                 dateFormat: 'dd-mm-yy',
                 minDate: new Date(<?=$escaper->escapeHtml($block->getMinExpiryTimestamp())?>),
                 maxDate: new Date(<?=$escaper->escapeHtml($block->getMaxExpiryTimestamp())?>)
-            }).val('<?= $block->getDefaultExpiryDate() ?>');
+            }).val('<?= $block->escapeJs($block->getDefaultExpiryDate()) ?>');
 
         });
 </script>

--- a/view/adminhtml/templates/form/pos_cloud.phtml
+++ b/view/adminhtml/templates/form/pos_cloud.phtml
@@ -132,7 +132,7 @@ $fundingSourceOptions = $block->getFundingSourceOptions();
                 },
 
                 hasInstallment: function () {
-                    return Boolean(<?= $block->hasInstallment() ?>) && this.fundingSourceOption !== 'debit';
+                    return Boolean(<?= $block->escapeJs($block->hasInstallment()) ?>) && this.fundingSourceOption !== 'debit';
                 },
 
                 setFundingSourceOption: function (option) {
@@ -148,7 +148,7 @@ $fundingSourceOptions = $block->getFundingSourceOptions();
             'adyenPosCloudComponent',
         ],
         function ($, adyenPosCloudComponent) {
-            let hasFundingSource = Boolean(<?= $block->hasFundingSource() ?>);
+            let hasFundingSource = Boolean(<?= $block->escapeJs($block->hasFundingSource()) ?>);
             adyenPosCloudComponent.init(hasFundingSource);
 
             if (hasFundingSource) {

--- a/view/adminhtml/templates/info/adyen_moto.phtml
+++ b/view/adminhtml/templates/info/adyen_moto.phtml
@@ -36,7 +36,7 @@
 <?php if ($_pspReferenceBlock = $block->getPspReferenceBlock()): ?>
     <div>
         <?= $block->escapeHtml(__('Adyen PSP Reference: ')); ?>
-        <?= $_pspReferenceBlock ?>
+        <?= $block->escapeHtml($_pspReferenceBlock) ?>
     </div>
 <?php endif; ?>
 

--- a/view/adminhtml/templates/info/adyen_pos_cloud.phtml
+++ b/view/adminhtml/templates/info/adyen_pos_cloud.phtml
@@ -78,4 +78,4 @@ $_isDemoMode = $block->isDemoMode();
         padding-bottom: 5px;
     }
 </style>
-<?= $block->getMethod()->getInfoInstance()->getAdditionalInformation('receipt'); ?>
+<?= $block->escapeHtml($block->getMethod()->getInfoInstance()->getAdditionalInformation('receipt')); ?>

--- a/view/adminhtml/templates/info/adyen_pos_cloud.phtml
+++ b/view/adminhtml/templates/info/adyen_pos_cloud.phtml
@@ -78,4 +78,4 @@ $_isDemoMode = $block->isDemoMode();
         padding-bottom: 5px;
     }
 </style>
-<?= $block->escapeHtml($block->getMethod()->getInfoInstance()->getAdditionalInformation('receipt')); ?>
+<?= /* @noEscape */ $block->getMethod()->getInfoInstance()->getAdditionalInformation('receipt') ?>

--- a/view/adminhtml/templates/support/custom_title.phtml
+++ b/view/adminhtml/templates/support/custom_title.phtml
@@ -12,5 +12,5 @@ $titleClass = ($block->getTitleClass()) ? ' ' . $block->getTitleClass() : '';
 $title = $block->getPageTitle();
 ?>
 
-<img src="<?= $block->getViewFileUrl('Adyen_Payment::images/adyen/adyen-support.svg') ?>"
+<img src="<?= $block->escapeUrl($block->getViewFileUrl('Adyen_Payment::images/adyen/adyen-support.svg')) ?>"
      alt="Adyen Logo" class="adyen-support-logo" />

--- a/view/adminhtml/templates/support/menu.phtml
+++ b/view/adminhtml/templates/support/menu.phtml
@@ -11,7 +11,7 @@
             role="tab"
             aria-controls="support_form_tabs_config_section_content"
             aria-labelledby="support_form_tabs_config_section">
-            <a href="<?=$block->configurationSettingsUrl();?>" id="support_form_tabs_config_section" name="config_section" title="Configuration settings" class="admin__page-nav-link tab-item-link ui-tabs-anchor" data-tab-type="" data-ui-id="support-form-tabs-tab-link-config-section" role="presentation" tabindex="-1">
+            <a href="<?= $block->escapeUrl($block->configurationSettingsUrl()); ?>" id="support_form_tabs_config_section" name="config_section" title="Configuration settings" class="admin__page-nav-link tab-item-link ui-tabs-anchor" data-tab-type="" data-ui-id="support-form-tabs-tab-link-config-section" role="presentation" tabindex="-1">
                 <span>Configuration Settings</span>
             </a>
         </li>
@@ -21,7 +21,7 @@
             role="tab"
             aria-controls="support_form_tabs_order_section_content"
             aria-labelledby="support_form_tabs_order_section">
-            <a href="<?=$block->orderProcessingUrl();?>" id="support_form_tabs_order_section" name="order_section" title="Order processing" class="admin__page-nav-link tab-item-link ui-tabs-anchor" data-tab-type="" data-ui-id="support-form-tabs-tab-link-order-section" role="presentation" tabindex="-1">
+            <a href="<?= $block->escapeUrl($block->orderProcessingUrl());?>" id="support_form_tabs_order_section" name="order_section" title="Order processing" class="admin__page-nav-link tab-item-link ui-tabs-anchor" data-tab-type="" data-ui-id="support-form-tabs-tab-link-order-section" role="presentation" tabindex="-1">
                 <span>Order Processing</span>
             </a>
         </li>
@@ -31,7 +31,7 @@
             role="tab"
             aria-controls="support_form_tabs_other_section_content"
             aria-labelledby="support_form_tabs_other_section">
-            <a href="<?=$block->otherTopicsFormUrl();?>" id="support_form_tabs_other_section" name="other_section" title="Other topics" class="admin__page-nav-link tab-item-link ui-tabs-anchor" data-tab-type="" data-ui-id="support-form-tabs-tab-link-other-section" role="presentation" tabindex="-1">
+            <a href="<?= $block->escapeUrl($block->otherTopicsFormUrl()); ?>" id="support_form_tabs_other_section" name="other_section" title="Other topics" class="admin__page-nav-link tab-item-link ui-tabs-anchor" data-tab-type="" data-ui-id="support-form-tabs-tab-link-other-section" role="presentation" tabindex="-1">
                 <span>Other Topics</span>
             </a>
         </li>

--- a/view/adminhtml/templates/support/success.phtml
+++ b/view/adminhtml/templates/support/success.phtml
@@ -1,12 +1,12 @@
 <?php /** @var \Adyen\Payment\Block\Adminhtml\Support\Success $block */ ?>
 
 <div>
-    <h1><?= $block->getSuccessTitle() ?></h1>
-    <p class="adyen_support-success_message"><?= $block->getSuccessMessage() ?></p>
+    <h1><?= $block->escapeHtml($block->getSuccessTitle()) ?></h1>
+    <p class="adyen_support-success_message"><?= $block->escapeHtml($block->getSuccessMessage()) ?></p>
 
-    <form action="<?= $block->getDashboardUrl(); ?>" method="GET" class="adyen_support-redirect_form">
+    <form action="<?= $block->escapeUrl($block->getDashboardUrl()); ?>" method="GET" class="adyen_support-redirect_form">
         <button class="adyen_support-form_link btn btn-large btn-prime">
-            <?= __("Return to Dashboard") ?>
+            <?= $block->escapeHtml(__("Return to Dashboard")) ?>
         </button>
     </form>
 </div>

--- a/view/adminhtml/templates/support/support_links.phtml
+++ b/view/adminhtml/templates/support/support_links.phtml
@@ -3,13 +3,13 @@
 use Adyen\Payment\Block\Adminhtml\Support\SupportTabInterface; ?>
 <fieldset class="fieldset&#x20;admin__fieldset&#x20;" id="base_fieldset">
     <legend class="admin__legend legend">
-        <span><?= $block->getPageTitle() ?></span>
+        <span><?= $block->escapeHtml($block->getPageTitle()) ?></span>
     </legend>
 </fieldset>
 
 
 <div class="adyen_support-main">
-    <form action="<?= $block->supportFormUrl(); ?>" method="GET">
+    <form action="<?= $block->escapeUrl($block->supportFormUrl()); ?>" method="GET">
         <table class="adyen_support-content" aria-describedby="Support Form Content">
             <tr>
                 <td class="adyen_support-label">Topic</td>
@@ -18,7 +18,7 @@ use Adyen\Payment\Block\Adminhtml\Support\SupportTabInterface; ?>
                         <select name="topic" id="support_topic_value">
                             <option value="">Please select a topic</option>
                             <?php foreach ($block->getSupportTopics() as $key => $topic): ?>
-                                <option value="<?= $key; ?>"><?= $topic; ?></option>
+                                <option value="<?= $block->escapeHtmlAttr($key); ?>"><?= $block->escapeHtml($topic); ?></option>
                             <?php endforeach; ?>
                         </select>
                     </div>

--- a/view/frontend/templates/checkout/multishipping/billing.phtml
+++ b/view/frontend/templates/checkout/multishipping/billing.phtml
@@ -211,7 +211,7 @@
     ], function(
         adyenPaymentService
     ) {
-        let adyenPaymentMethods = '<?= $block->getAdyenPaymentMethodsResponse() ?>';
+        let adyenPaymentMethods = '<?= $block->escapeJs($block->getAdyenPaymentMethodsResponse()) ?>';
         let paymentMethods = JSON.parse(adyenPaymentMethods);
 
         adyenPaymentService.setPaymentMethods(paymentMethods);

--- a/view/frontend/templates/checkout/multishipping/success.phtml
+++ b/view/frontend/templates/checkout/multishipping/success.phtml
@@ -92,7 +92,7 @@ $paymentResponseEntities = $block->getPaymentResponseEntities();
     $scriptString = __('window.checkoutConfig = %1;', $checkoutConfig);
     ?>
     <script type="text/javascript">
-        <?= $block->escapeJs($scriptString) ?>
+        <?= /* @noEscape */ $scriptString ?>
 
         require([
             'jquery',

--- a/view/frontend/templates/checkout/multishipping/success.phtml
+++ b/view/frontend/templates/checkout/multishipping/success.phtml
@@ -92,7 +92,7 @@ $paymentResponseEntities = $block->getPaymentResponseEntities();
     $scriptString = __('window.checkoutConfig = %1;', $checkoutConfig);
     ?>
     <script type="text/javascript">
-        <?=$scriptString?>
+        <?= $block->escapeJs($scriptString) ?>
 
         require([
             'jquery',

--- a/view/frontend/templates/checkout/success.phtml
+++ b/view/frontend/templates/checkout/success.phtml
@@ -50,7 +50,7 @@
     $scriptString = __('window.checkoutConfig = %1;', $checkoutConfig);
 ?>
 <script>
-    <?= $block->escapeHtml($scriptString) ?>
+    <?= /* @noEscape */ $scriptString ?>
     require([
         'jquery',
         'Adyen_Payment/js/adyen',

--- a/view/frontend/templates/checkout/success.phtml
+++ b/view/frontend/templates/checkout/success.phtml
@@ -30,9 +30,9 @@
         (async function () { // RequireJS does not support async callback
             var action = JSON.parse('<?= /* @noEscape */ $block->getAction(); ?>');
             var checkoutComponent = await AdyenCheckout({
-                locale: '<?= $block->escapeHtml($block->getLocale()); ?>',
-                environment: '<?= $block->escapeHtml($block->getEnvironment()); ?>',
-                clientKey: '<?= $block->escapeHtml($block->getClientKey()); ?>'
+                locale: '<?= $block->escapeJs($block->getLocale()); ?>',
+                environment: '<?= $block->escapeJs($block->getEnvironment()); ?>',
+                clientKey: '<?= $block->escapeJs($block->getClientKey()); ?>'
             });
             try {
                 checkoutComponent.createFromAction(action).mount('#ActionContainer');
@@ -50,7 +50,7 @@
     $scriptString = __('window.checkoutConfig = %1;', $checkoutConfig);
 ?>
 <script>
-    <?=$scriptString?>
+    <?= $block->escapeHtml($scriptString) ?>
     require([
         'jquery',
         'Adyen_Payment/js/adyen',
@@ -62,9 +62,9 @@
                 let payload = state.data;
                 payload.returnUrl = window.location.href;
 
-                const orderId = <?= $block->getOrder()->getId() ?>;
-                const isLoggedIn = Boolean(<?= $block->getIsCustomerLoggedIn() ?>);
-                const maskedQuoteId = "<?= $block->getMaskedQuoteId() ?>";
+                const orderId = <?= $block->escapeJs($block->getOrder()->getId()) ?>;
+                const isLoggedIn = Boolean(<?= $block->escapeJs($block->getIsCustomerLoggedIn()) ?>);
+                const maskedQuoteId = "<?= $block->escapeJs($block->getMaskedQuoteId()) ?>";
 
                 adyenPaymentService.donate(payload, isLoggedIn, orderId, maskedQuoteId)
                     .done(function (response) {
@@ -84,22 +84,22 @@
         }
         const donationConfig = {
             amounts: {
-                currency: "<?=$block->getOrder()->getOrderCurrencyCode()?>",
-                values: [<?=$block->getDonationComponentConfiguration()['donationAmounts'];?>]
+                currency: "<?= $block->escapeJs($block->getOrder()->getOrderCurrencyCode()) ?>",
+                values: [<?= $block->escapeJs($block->getDonationComponentConfiguration()['donationAmounts']); ?>]
             },
-            backgroundUrl: "<?=$block->getDonationComponentConfiguration()['backgroundUrl'];?>",
-            description: "<?=$block->getDonationComponentConfiguration()['description'];?>",
-            logoUrl: "<?=$block->getDonationComponentConfiguration()['logoUrl'];?>",
-            name: "<?=$block->getDonationComponentConfiguration()['name'];?>",
-            url: "<?=$block->getDonationComponentConfiguration()['website'];?>",
+            backgroundUrl: "<?= $block->escapeJs($block->getDonationComponentConfiguration()['backgroundUrl']); ?>",
+            description: "<?= $block->escapeJs($block->getDonationComponentConfiguration()['description']); ?>",
+            logoUrl: "<?= $block->escapeJs($block->getDonationComponentConfiguration()['logoUrl']); ?>",
+            name: "<?= $block->escapeJs($block->getDonationComponentConfiguration()['name']); ?>",
+            url: "<?= $block->escapeJs($block->getDonationComponentConfiguration()['website']); ?>",
             showCancelButton: true,
             onDonate: handleOnDonate,
             onCancel: handleOnCancel
         };
         var checkoutComponent = await AdyenCheckout({
-            locale: '<?= $block->escapeHtml($block->getLocale()); ?>',
-            environment: '<?= $block->escapeHtml($block->getEnvironment()); ?>',
-            clientKey: '<?= $block->escapeHtml($block->getClientKey()); ?>'
+            locale: '<?= $block->escapeJs($block->getLocale()); ?>',
+            environment: '<?= $block->escapeJs($block->getEnvironment()); ?>',
+            clientKey: '<?= $block->escapeJs($block->getClientKey()); ?>'
         });
         try {
             const donation = checkoutComponent.create('donation', donationConfig).mount('#donation-container');

--- a/view/frontend/templates/customer_account/payment_method.phtml
+++ b/view/frontend/templates/customer_account/payment_method.phtml
@@ -15,7 +15,7 @@ use Magento\Vault\Block\CardRendererInterface;
              width="<?= /* @noEscape */ $block->getIconWidth() ?>"
              height="<?= /* @noEscape */ $block->getIconHeight() ?>"
         >
-        <span><?= $block->getText() ?></span>
+        <span><?= $block->escapeHtml($block->getText()) ?></span>
     </td>
     <td data-th="<?= $block->escapeHtml(__('Actions')) ?>" class="col actions">
         <form class="form" action="<?= $block->escapeUrl($block->getUrl('vault/cards/deleteaction')) ?>" method="post">

--- a/view/frontend/templates/form/multishipping/abstract-form.phtml
+++ b/view/frontend/templates/form/multishipping/abstract-form.phtml
@@ -24,7 +24,7 @@ $code = $block->getMethod()->getCode();
         'jquery'
     ], function (layout, $) {
         $(function () {
-            const paymentMethodCode = "<?= $code ?>";
+            const paymentMethodCode = "<?= $block->escapeJs($code) ?>";
             const customMethodRenderers = window.checkoutConfig.payment.adyen.customMethodRenderers;
             const paymentMethodData = {
                 method: paymentMethodCode
@@ -42,7 +42,7 @@ $code = $block->getMethod()->getCode();
             layout([
                 {
                     component: multishippingFrontendComponent,
-                    name: 'payment_method_' + '<?= $code ?>',
+                    name: 'payment_method_' + '<?= $block->escapeJs($code) ?>',
                     method: paymentMethodData.method,
                     item: paymentMethodData
                 }

--- a/view/frontend/templates/info/adyen_boleto.phtml
+++ b/view/frontend/templates/info/adyen_boleto.phtml
@@ -25,7 +25,7 @@ $_info = $block->getInfo();
         <dt class="title"><b><?= $block->escapeHtml(__("Partial Payments")) ?></b></dt>
         <?php foreach ($block->getPartialPayments() as $payment): ?>
             <dt class="title">
-                <?= sprintf("%s - %s", $block->escapeHtml(ucwords($payment->getPaymentMethod())), $block->escapeHtml($payment->getFormattedAmountWithCurrency())) ?>
+                <?= $block->escapeHtml(sprintf("%s - %s", ucwords($payment->getPaymentMethod()), $payment->getFormattedAmountWithCurrency())) ?>
             </dt>
         <?php endforeach; ?>
     <?php endif; ?>

--- a/view/frontend/templates/info/adyen_cc.phtml
+++ b/view/frontend/templates/info/adyen_cc.phtml
@@ -14,14 +14,14 @@
 ?>
 <dl class="payment-method adyen_cc">
     <dt class="title">
-        <?= sprintf("%s: %s", $block->escapeHtml(ucwords($block->getMethod()->getTitle())), $block->escapeHtml(__($block->getCcTypeName()))) ?>
+        <?= $block->escapeHtml(sprintf("%s: %s", ucwords($block->getMethod()->getTitle()), __($block->getCcTypeName()))) ?>
     </dt>
 
     <?php if ($block->getPartialPayments()): ?>
         <dt class="title"><b><?= $block->escapeHtml(__("Partial Payments")) ?></b></dt>
         <?php foreach ($block->getPartialPayments() as $payment): ?>
             <dt class="title">
-                <?= sprintf("%s - %s", $block->escapeHtml(ucwords($payment->getPaymentMethod())), $block->escapeHtml($payment->getFormattedAmountWithCurrency())) ?>
+                <?= $block->escapeHtml(sprintf("%s - %s", ucwords($payment->getPaymentMethod()), $payment->getFormattedAmountWithCurrency())) ?>
             </dt>
         <?php endforeach; ?>
     <?php endif; ?>

--- a/view/frontend/templates/info/adyen_giftcard.phtml
+++ b/view/frontend/templates/info/adyen_giftcard.phtml
@@ -25,12 +25,12 @@ use Adyen\Payment\Block\Info\Giftcard;
         <dt class="title"><b><?= $block->escapeHtml(__("Partial Payments")) ?></b></dt>
         <?php foreach ($block->getPartialPayments() as $payment): ?>
             <dt class="title">
-                <?= sprintf("%s - %s", $block->escapeHtml(ucwords($payment->getPaymentMethod())), $block->escapeHtml($payment->getFormattedAmountWithCurrency())) ?>
+                <?= $block->escapeHtml(sprintf("%s - %s", ucwords($payment->getPaymentMethod()), $payment->getFormattedAmountWithCurrency())) ?>
             </dt>
         <?php endforeach; ?>
     <?php else: ?>
         <dt class="title">
-            <?= sprintf("%s: %s", $block->escapeHtml($_info->getMethodInstance()->getTitle()), $block->escapeHtml(ucwords($_info->getAdditionalInformation('brand_code')))); ?>
+            <?= $block->escapeHtml(sprintf("%s: %s", $_info->getMethodInstance()->getTitle(), ucwords($_info->getAdditionalInformation('brand_code')))); ?>
         </dt>
     <?php endif; ?>
 </dl>

--- a/view/frontend/templates/info/adyen_pm.phtml
+++ b/view/frontend/templates/info/adyen_pm.phtml
@@ -95,7 +95,7 @@
         <?php elseif ($_brandCode = $_info->getAdditionalInformation('brand_code')): ?>
             <dt class="title"><?= $block->escapeHtml($_brandCode); ?></dt>
         <?php else: ?>
-            <dt class="title"><?= $_info->getMethodInstance()->getTitle() ?></dt>
+            <dt class="title"><?= $block->escapeHtml($_info->getMethodInstance()->getTitle()) ?></dt>
         <?php endif; ?>
     <?php endif; ?>
 
@@ -103,7 +103,7 @@
         <dt class="title"><b><?= $block->escapeHtml(__("Partial Payments")) ?></b></dt>
         <?php foreach ($block->getPartialPayments() as $payment): ?>
             <dt class="title">
-                <?= sprintf("%s - %s", $block->escapeHtml(ucwords($payment->getPaymentMethod())), $block->escapeHtml($payment->getFormattedAmountWithCurrency())) ?>
+                <?= $block->escapeHtml(sprintf("%s - %s", ucwords($payment->getPaymentMethod()), $payment->getFormattedAmountWithCurrency())) ?>
             </dt>
         <?php endforeach; ?>
     <?php endif; ?>

--- a/view/frontend/templates/info/adyen_pos_cloud.phtml
+++ b/view/frontend/templates/info/adyen_pos_cloud.phtml
@@ -34,5 +34,5 @@
             padding-bottom: 5px;
         }
     </style>
-    <?= $block->escapeHtml($block->getMethod()->getInfoInstance()->getAdditionalInformation('receipt')); ?>
+    <?= /* @noEscape */ $block->getMethod()->getInfoInstance()->getAdditionalInformation('receipt'); ?>
 </dl>

--- a/view/frontend/templates/info/adyen_pos_cloud.phtml
+++ b/view/frontend/templates/info/adyen_pos_cloud.phtml
@@ -34,5 +34,5 @@
             padding-bottom: 5px;
         }
     </style>
-    <?= $block->getMethod()->getInfoInstance()->getAdditionalInformation('receipt'); ?>
+    <?= $block->escapeHtml($block->getMethod()->getInfoInstance()->getAdditionalInformation('receipt')); ?>
 </dl>


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
- Remove `post-install-cmd` and `post-update-cmd` commands from composer.json as `phpcompatibility/php-compatibility` is not a dependency of Magento anymore.
- Fix codesniffing errors.