### PR TITLE
[ECP-8907] - Allow passing optional quoteId while fetching order payment status

### DIFF
--- a/view/frontend/web/js/model/adyen-payment-service.js
+++ b/view/frontend/web/js/model/adyen-payment-service.js
@@ -72,14 +72,18 @@ define(
                 this.connectedTerminals(connectedTerminals);
             },
 
-            getOrderPaymentStatus: function(orderId) {
+            getOrderPaymentStatus: function(orderId, quoteId = null) {
                 let serviceUrl;
 
                 if (customer.isLoggedIn()) {
                     serviceUrl = urlBuilder.createUrl('/adyen/orders/carts/mine/payment-status', {});
-                } else {
+                }
+                else {
+                    if (quoteId == null){
+                        quoteId = quote.getQuoteId()
+                    }
                     serviceUrl = urlBuilder.createUrl('/adyen/orders/guest-carts/:cartId/payment-status', {
-                        cartId: quote.getQuoteId()
+                        cartId: quoteId
                     });
                 }
 

--- a/view/frontend/web/js/model/adyen-payment-service.js
+++ b/view/frontend/web/js/model/adyen-payment-service.js
@@ -77,13 +77,9 @@ define(
 
                 if (customer.isLoggedIn()) {
                     serviceUrl = urlBuilder.createUrl('/adyen/orders/carts/mine/payment-status', {});
-                }
-                else {
-                    if (quoteId == null){
-                        quoteId = quote.getQuoteId()
-                    }
+                } else {
                     serviceUrl = urlBuilder.createUrl('/adyen/orders/guest-carts/:cartId/payment-status', {
-                        cartId: quoteId
+                        cartId: quoteId ?? quote.getQuoteId()
                     });
                 }
 


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
`quoteId` is required to fetch the order payment status. However, `quote` object is not available on product detail pages, which blocks express payments.

This PR introduces a quick fix to solve the issue on the express module by allowing to pass optional `quoteId` to `getOrderPaymentStatus()` function.