### PR TITLE
Fix undefined method getQuoteId() exception when trying to check out

### DIFF
--- a/Gateway/Data/Order/OrderAdapter.php
+++ b/Gateway/Data/Order/OrderAdapter.php
@@ -11,10 +11,11 @@
 
 namespace Adyen\Payment\Gateway\Data\Order;
 
-use Magento\Payment\Gateway\Data\Order\AddressAdapterFactory;
+use Magento\Quote\Api\CartRepositoryInterface;
 use Magento\Sales\Model\Order;
+use PayPal\Braintree\Gateway\Data\Order\AddressAdapterFactory;
 
-class OrderAdapter extends \Magento\Payment\Gateway\Data\Order\OrderAdapter
+class OrderAdapter extends \PayPal\Braintree\Gateway\Data\Order\OrderAdapter
 {
     /**
      * @var Order
@@ -23,14 +24,16 @@ class OrderAdapter extends \Magento\Payment\Gateway\Data\Order\OrderAdapter
 
     /**
      * @param Order $order
+     * @param CartRepositoryInterface $quoteRepository
      * @param AddressAdapterFactory $addressAdapterFactory
      */
     public function __construct(
         Order $order,
+        CartRepositoryInterface $quoteRepository,
         AddressAdapterFactory $addressAdapterFactory
     ) {
         $this->order = $order;
-        parent::__construct($order, $addressAdapterFactory);
+        parent::__construct($order, $quoteRepository, $addressAdapterFactory);
     }
 
     public function getQuoteId()

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     "magento/framework": ">=103.0.4",
     "magento/module-vault": ">=101.2.4",
     "magento/module-multishipping": ">=100.4.4",
+    "paypal/module-braintree-core": "*",
     "ext-json": "*"
   },
   "require-dev": {

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1440,7 +1440,7 @@
         </arguments>
     </virtualType>
     <preference for="Magento\Payment\Gateway\Data\Order\AddressAdapter" type="Adyen\Payment\Gateway\Data\Order\AddressAdapter" />
-    <preference for="Magento\Payment\Gateway\Data\Order\OrderAdapter" type="Adyen\Payment\Gateway\Data\Order\OrderAdapter" />
+    <preference for="PayPal\Braintree\Gateway\Data\Order\OrderAdapter" type="Adyen\Payment\Gateway\Data\Order\OrderAdapter" />
     <type name="Adyen\Payment\Logger\Handler\AdyenDebug">
         <arguments>
             <argument name="filesystem" xsi:type="object">Magento\Framework\Filesystem\Driver\File</argument>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -20,6 +20,7 @@
             <module name="Magento_AdminNotification"/>
             <module name="Magento_Vault"/>
             <module name="Magento_Multishipping"/>
+            <module name="PayPal_Braintree"/>
         </sequence>
     </module>
 </config>


### PR DESCRIPTION
**Description**

Change OrderAdapter preference target from Magento\Payment\Gateway\Data\Order\OrderAdapter to PayPal\Braintree\Gateway\Data\Order\OrderAdapter

`Adyen_Payment` creates a preference on `Magento\Payment\Gateway\Data\Order\OrderAdapter`. However, module `PayPal_Braintree` also creates a preference on the same class. 
Since `Adyen_Payment` does not define any dependency on `PayPal_Braintree`, it may happen that in the `config.php` file `PayPal_Braintree` is listed after `Adyen_Payment`. This causes the preference declared by `Adyen_Payment` to have no effect, and instead, the preference of `PayPal_Braintree` is taken into account. 
If this occurs, an exception is raised during the checkout:
`Call to undefined method PayPal\Braintree\Gateway\Data\Order\OrderAdapter::getQuoteId()`
To fix this, I ensured that the `Adyen_Payment` preference targets the rewrite class of `PayPal_Braintree`. Additionally, I have added the dependency in the `module.xml` file. 
By doing this, we ensure that the `Adyen_Payment` preference takes effect and avoids the exception during checkout. 
Moreover, by targeting `PayPal_Braintree` rewrite class in the preference and extending it, we also carry along the changes made by `PayPal_Braintree` to the original class. 
Since `PayPal_Braintree` is included in the core from version 2.4 onwards, this is a necessary and secure fix.

I haven't set a minimum version in the dependency on `paypal/module-braintree-core` specified in the composer.json. Feel free to set the minimum version that you find most appropriate or leave it as it is.


Fixes [#2307](https://github.com/Adyen/adyen-magento2/issues/2307)
