### PR TITLE
[ECP-8959] Fix values being sent in headers

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -1171,9 +1171,9 @@ class Data extends AbstractHelper
     {
         $magentoDetails = $this->getMagentoDetails();
         return [
-            'external-platform-name' => $this->getModuleName(),
+            'external-platform-name' => $magentoDetails['name'],
             'external-platform-version' => $this->getModuleVersion(),
-            'merchant-application-name' => $magentoDetails['name'],
+            'merchant-application-name' => $this->getModuleName(),
             'merchant-application-version' => $magentoDetails['version'],
             'merchant-application-edition' => $magentoDetails['edition'],
         ];

--- a/Test/Unit/Helper/DataTest.php
+++ b/Test/Unit/Helper/DataTest.php
@@ -207,9 +207,9 @@ class DataTest extends AbstractAdyenTestCase
     public function testBuildRequestHeaders()
     {
         $expectedHeaders = [
-            'external-platform-name' => 'adyen-magento2',
+            'external-platform-name' => 'magento',
             'external-platform-version' => '1.2.3',
-            'merchant-application-name' => 'magento',
+            'merchant-application-name' => 'adyen-magento2',
             'merchant-application-version' => '2.x.x',
             'merchant-application-edition' => 'Community'
         ];


### PR DESCRIPTION
**Description**
This PR fixes a problem of the values sent for external-platform-name and merchant-application-name currently being switched in `Helper/Data::buildRequestHeaders()`. 

**Tested scenarios**
- make sure all the transaction clients are sending the correct key-value pairs in headers
