### PR TITLE
[ECP-8788-v9] Use default value for recurringProcessingModel if no value set on token details

### DIFF
--- a/Gateway/Request/RecurringVaultDataBuilder.php
+++ b/Gateway/Request/RecurringVaultDataBuilder.php
@@ -14,7 +14,6 @@ namespace Adyen\Payment\Gateway\Request;
 use Adyen\Payment\Helper\StateData;
 use Adyen\Payment\Helper\Vault;
 use Adyen\Payment\Model\Ui\AdyenCcConfigProvider;
-use Magento\Framework\Exception\LocalizedException;
 use Magento\Payment\Gateway\Data\PaymentDataObject;
 use Magento\Payment\Gateway\Helper\SubjectReader;
 use Magento\Payment\Gateway\Request\BuilderInterface;
@@ -22,10 +21,14 @@ use Magento\Payment\Gateway\Request\BuilderInterface;
 class RecurringVaultDataBuilder implements BuilderInterface
 {
     private StateData $stateData;
+    private Vault $vaultHelper;
 
-    public function __construct(StateData $stateData)
-    {
+    public function __construct(
+        StateData $stateData,
+        Vault $vaultHelper
+    ) {
         $this->stateData = $stateData;
+        $this->vaultHelper = $vaultHelper;
     }
 
     public function build(array $buildSubject): array
@@ -45,6 +48,12 @@ class RecurringVaultDataBuilder implements BuilderInterface
         // For now this will only be used by tokens created trough adyen_hpp payment methods
         if (array_key_exists(Vault::TOKEN_TYPE, $details)) {
             $requestBody['recurringProcessingModel'] = $details[Vault::TOKEN_TYPE];
+        } else {
+            // If recurringProcessingModel doesn't exist in the token details, use the default value from config.
+            $requestBody['recurringProcessingModel'] = $this->vaultHelper->getPaymentMethodRecurringProcessingModel(
+                $paymentMethod->getProviderCode(),
+                $order->getStoreId()
+            );
         }
 
         /*

--- a/Test/Unit/Gateway/Request/RecurringVaultDataBuilderTest.php
+++ b/Test/Unit/Gateway/Request/RecurringVaultDataBuilderTest.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2024 Adyen N.V. (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\Payment\Test\Gateway\Request;
+
+use Adyen\Payment\Gateway\Request\RecurringVaultDataBuilder;
+use Adyen\Payment\Test\Unit\AbstractAdyenTestCase;
+use Magento\Framework\Api\ExtensionAttributesInterface;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Magento\Payment\Gateway\Data\PaymentDataObject;
+use Magento\Sales\Model\Order;
+use Magento\Sales\Model\Order\Payment;
+use Magento\Vault\Api\Data\PaymentTokenInterface;
+use Magento\Vault\Model\Method\Vault;
+
+class RecurringVaultDataBuilderTest extends AbstractAdyenTestCase
+{
+    private object $recurringVaultDataBuilder;
+    private $vaultHelperMock;
+
+    /**
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        $this->vaultHelperMock = $this->createMock(\Adyen\Payment\Helper\Vault::class);
+
+        $objectManager = new ObjectManager($this);
+        $this->recurringVaultDataBuilder = $objectManager->getObject(RecurringVaultDataBuilder::class, [
+            'vaultHelper' => $this->vaultHelperMock
+        ]);
+    }
+
+    /**
+     * @param $paymentMethodCode
+     * @param $tokenDetails
+     * @param $expect3dsFlag
+     * @dataProvider dataProvider
+     * @return void
+     */
+    public function testBuild($paymentMethodCode, $tokenDetails, $expect3dsFlag)
+    {
+        $paymentMethodProviderCode = str_replace('_vault', '', $paymentMethodCode);
+
+        $orderMock = $this->createMock(Order::class);
+        $orderMock->method('getQuoteId')->willReturn(1);
+        $orderMock->method('getStoreId')->willReturn(1);
+
+        $paymentMethodInstanceMock = $this->createMock(Vault::class);
+        $paymentMethodInstanceMock->method('getProviderCode')->willReturn($paymentMethodProviderCode);
+        $paymentMethodInstanceMock->method('getCode')->willReturn($paymentMethodCode);
+
+        $paymentTokenMock = $this->createMock(PaymentTokenInterface::class);
+        $paymentTokenMock->method('getTokenDetails')->willReturn($tokenDetails);
+        $paymentTokenMock->method('getGatewayToken')->willReturn("ABC1234567");
+
+        $extensionAttributesMock = $this->createGeneratedMock(ExtensionAttributesInterface::class, [
+            'getVaultPaymentToken'
+        ]);
+        $extensionAttributesMock->method('getVaultPaymentToken')->willReturn($paymentTokenMock);
+
+        $paymentMock = $this->createMock(Payment::class);
+        $paymentMock->method('getOrder')->willReturn($orderMock);
+        $paymentMock->method('getMethodInstance')->willReturn($paymentMethodInstanceMock);
+        $paymentMock->method('getExtensionAttributes')->willReturn($extensionAttributesMock);
+
+        $buildSubject = [
+            'payment' => $this->createConfiguredMock(PaymentDataObject::class, [
+                'getPayment' => $paymentMock
+            ])
+        ];
+
+        $this->vaultHelperMock->method('getPaymentMethodRecurringProcessingModel')
+            ->willReturn('CardOnFile');
+
+        $request = $this->recurringVaultDataBuilder->build($buildSubject);
+
+        $this->assertIsArray($request);
+        $this->assertArrayHasKey('recurringProcessingModel', $request['body']);
+        if ($expect3dsFlag) {
+            $this->assertArrayHasKey('allow3DS2', $request['body']['additionalData']);
+        }
+    }
+
+    public static function dataProvider(): array
+    {
+        return [
+            [
+                'paymentMethodCode' => 'adyen_cc_vault',
+                'tokenDetails' => '{"type":"visa","maskedCC":"1111","expirationDate":"3\/2030", "tokenType": "CardOnFile"}',
+                'expect3dsFlag' => true
+            ],
+            [
+                'paymentMethodCode' => 'adyen_cc_vault',
+                'tokenDetails' => '{"type":"visa","maskedCC":"1111","expirationDate":"3\/2030"}',
+                'expect3dsFlag' => true
+            ],
+            [
+                'paymentMethodCode' => 'adyen_klarna_vault',
+                'tokenDetails' => '{"type":"klarna", "tokenType": "CardOnFile"}',
+                'expect3dsFlag' => false
+            ],
+            [
+                'paymentMethodCode' => 'adyen_klarna_vault',
+                'tokenDetails' => '{"type":"klarna"}',
+                'expect3dsFlag' => false
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
After migrating from earlier version of the plugin (ex: 8.3.5), missing `recurringProcessingModel` exception has been seen. This has been caused by missing information on token details, since earlier versions of the plugin didn't used to add `recurringProcessingModel` key to token details.

This PR introduces default value to `recurringProcessingModel` field if there is no information on token details.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- Tokenised payments

Fixes #2362 