### PR TITLE
[ECP-8979] Bump pipeline hard stop time to 25 mins for E2E pipelines

### DIFF
--- a/.github/workflows/e2e-test-dispatch.yml
+++ b/.github/workflows/e2e-test-dispatch.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on:
       group: larger-runners
       labels: ubuntu-latest-8-cores
-    timeout-minutes: 20
+    timeout-minutes: 25
     env:
       PHP_VERSION: "8.1"
       MAGENTO_VERSION: "2.4.5"

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on:
       group: larger-runners
       labels: ubuntu-latest-8-cores
-    timeout-minutes: 20
+    timeout-minutes: 25
     env:
       PHP_VERSION: "8.1"
       MAGENTO_VERSION: "2.4.5"


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Bump E2E pipeline cutoff time to 25 mins. We used to have a hard stop at 20 mins to avoid extra costs if the pipelines took longer, but the variable time of composer responses, hence the installation of magento causes E2E tests to go over 20 mins from time to time. Until we get rid of the installation of Magento step, we need to bump this time to 25 mins

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

Fixes  <!-- #-prefixed github issue number -->
