### PR TITLE
Place order button is disabled after re-render of payment component

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/adyen-pm-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-pm-method.js
@@ -181,7 +181,7 @@ define(
             },
 
             renderCheckoutComponent: function() {
-                this.isPlaceOrderAllowed(false);
+                this.isPlaceOrderAllowed(quote.billingAddress() != null);
                 let configuration = this.buildComponentConfiguration(this.paymentMethod(), this.paymentMethodsExtraInfo());
 
                 this.mountPaymentMethodComponent(this.paymentMethod(), configuration);


### PR DESCRIPTION
**Description**

There is a bug in the checkout that prevents people from clicking the place order button when the customer makes a modification in the shipping method or details (see video). The button is by default disabled, even though there is a saved active state for a payment method.

**Tested scenarios**

https://github.com/Adyen/adyen-magento2/assets/14089150/3a1e7187-3f50-4596-bb34-138a67cd1900


1. Go to step 3 'Payment' in the checkout and choose a payment method (excluding credit card or PayPal).
2. Go back to step 2 'Shipping'.
3. Return to step 3 'Payment' via the 'Next' button.
4. Now, the button of the selected payment method no longer works unless you switch to a different payment method.

**Fixes**

This code fix ensures that when the component is re-rendered, it checks whether a billing address is set. If it is set, the button is activated. This check is necessary because no onchange event is triggered.
