### PR TITLE
[ECP-8855] Fix payment pspreference update after a failing payment attempt

### DIFF
--- a/Helper/Webhook.php
+++ b/Helper/Webhook.php
@@ -420,7 +420,9 @@ class Webhook
              * the  previous notification was authorisation : true do not update pspreference
              */
             if (!$notification->isSuccessful()) {
-                $previousAdyenEventCode = $order->getData('adyen_notification_event_code');
+                $previousAdyenEventCode = $this->orderRepository
+                    ->get($order->getId())
+                    ->getData('adyen_notification_event_code');
                 if ($previousAdyenEventCode != "AUTHORISATION : TRUE") {
                     $this->updateOrderPaymentWithAdyenAttributes($order->getPayment(), $notification, $additionalData);
                 }


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Failing payment attempts were updating the pspreference on an order's addition information block due to bug on the conditional update. This PR fixes the condition to obtain the previous Adyen payment event and obtains it from the DB instead of the object on the memory.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- Obtaining the previous Adyen event code
- Notification processing

Fixes #2409 
