### PR TITLE
[ECP-8895] Crosscheck storedPaymentMethods coming from paymentMethods response with vault DB table

### DIFF
--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -54,6 +54,7 @@ class Config
     const XML_WEBHOOK_NOTIFICATION_PROCESSOR = 'webhook_notification_processor';
     const AUTO_CAPTURE_OPENINVOICE = 'auto';
     const XML_RECURRING_CONFIGURATION = 'recurring_configuration';
+    const XML_ALLOW_MULTISTORE_TOKENS = 'allow_multistore_tokens';
 
     protected ScopeConfigInterface $scopeConfig;
     private EncryptorInterface $encryptor;
@@ -557,6 +558,18 @@ class Config
     public function getRatePayId(int $storeId = null)
     {
         return $this->getConfigData("ratepay_id", self::XML_ADYEN_RATEPAY, $storeId);
+    }
+
+    public function getAllowMultistoreTokens(int $storeId = null): ?bool
+    {
+        $result =  $this->getConfigData(
+            self::XML_ALLOW_MULTISTORE_TOKENS,
+            self::XML_ADYEN_ABSTRACT_PREFIX,
+            $storeId,
+            true
+        );
+
+        return $result;
     }
 
     public function getConfigData(string $field, string $xmlPrefix, ?int $storeId, bool $flag = false): mixed

--- a/etc/adminhtml/system/adyen_tokenization.xml
+++ b/etc/adminhtml/system/adyen_tokenization.xml
@@ -28,5 +28,11 @@
             <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
             <config_path>payment/adyen_cc_vault/require_cvc</config_path>
         </field>
+        <field id="allow_mutistore_tokens" translate="label" type="select" sortOrder="30" showInDefault="1" showInWebsite="1"
+            showInStore="1">
+            <label>Allow multistore tokens</label>
+            <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+            <config_path>payment/adyen_abstract/allow_multistore_tokens</config_path>
+        </field>
     </group>
 </include>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -66,6 +66,7 @@
                 <title>Stored Cards (Adyen)</title>
                 <model>AdyenPaymentCardVaultFacade</model>
                 <require_cvc>1</require_cvc>
+                <allow_multistore_tokens>1</allow_multistore_tokens>
             </adyen_cc_vault>
             <adyen_oneclick>
                 <active>0</active>


### PR DESCRIPTION
**Description**
The response from paymentMethods call contains all the recurring tokens that have been generated under that merchant account and might be coming from a different Magento storefront.

Idea of this ticket is filtering out the tokens in the paymentMethods response if that token doesn't exist in the vault_payment_token table. Admin panel configuration is also added, so this crosschecking can be disabled from the configuration if the merchant wants to use the tokens coming from a different store.

**Tested scenarios**
- the tokens that are not existing in vault_payment_token table are removed from the response of paymentMethods call
