### PR TITLE
Fixed issue for order status pre-authorized state configuration

### DIFF
--- a/Helper/Webhook.php
+++ b/Helper/Webhook.php
@@ -46,7 +46,7 @@ class Webhook
      * Indicative matrix for possible states to enter after given event
      */
     const STATE_TRANSITION_MATRIX = [
-        'payment_pre_authorized' => [Order::STATE_NEW, PreAuthorized::STATE_ADYEN_AUTHORIZED],
+        'payment_pre_authorized' => [PreAuthorized::STATE_ADYEN_AUTHORIZED, Order::STATE_NEW],
         'payment_authorized' => [Order::STATE_PROCESSING]
     ];
 


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
As per the Webhook Helper[adyen/module-payment/Helper/Webhook.php] file, we can assign states if order is in pre-authorized condition.

![image](https://github.com/Adyen/adyen-magento2/assets/30382023/b5814b2d-a7f6-4361-824f-4d0e19a2d167)

But when we create new order status "adyen_authorized" [ref. from adyen-magento2/Model/Config/Source/PreAuthorized.php], and assign this status in Adyen configuration, it's not working.

![image](https://github.com/Adyen/adyen-magento2/assets/30382023/dea7714e-63e6-41cb-b948-cc53dc679464)

When the order is Authorized, Even if we have assigned new status in configuration, it will show order in "Pending" status only. The reason is, below function only grab the first item from the assigned Statuses. [file ref. vendor/adyen/module-payment/Helper/Order.php]

![image](https://github.com/Adyen/adyen-magento2/assets/30382023/a002ec42-432b-4307-a4eb-6439edcf1638)

So As solution, I switched the sequence in Webhook Helper[adyen/module-payment/Helper/Webhook.php] file to pick "adyen_authorized" first and then check for "NEW" status. See updated file below:

![image](https://github.com/Adyen/adyen-magento2/assets/30382023/d3bc9c0f-739c-443a-852f-50785ebbccf2)

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

- Create new Order status from admin panel
- Assign order status for pre-authorized configuraiton
- Verify order status once Payment is authorized

Fixes  <!-- #-prefixed github issue number -->
There is no such issue reported.
