### PR TITLE
[ECP-9064] Make asynchronous POS flow configurable

### DIFF
--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -51,6 +51,7 @@ class Config
     const XML_MOTO_MERCHANT_ACCOUNTS = 'moto_merchant_accounts';
     const XML_CONFIGURATION_MODE = 'configuration_mode';
     const XML_ADYEN_POS_CLOUD = 'adyen_pos_cloud';
+    const XML_PAYMENT_ACTION = 'payment_action';
     const XML_WEBHOOK_NOTIFICATION_PROCESSOR = 'webhook_notification_processor';
     const AUTO_CAPTURE_OPENINVOICE = 'auto';
     const XML_RECURRING_CONFIGURATION = 'recurring_configuration';
@@ -463,6 +464,11 @@ class Config
     public function getAdyenPosCloudConfigData(string $field, int $storeId = null, bool $flag = false)
     {
         return $this->getConfigData($field, self::XML_ADYEN_POS_CLOUD, $storeId, $flag);
+    }
+
+    public function getAdyenPosCloudPaymentAction(int $storeId): string
+    {
+        return $this->getAdyenPosCloudConfigData(self::XML_PAYMENT_ACTION, $storeId);
     }
 
     public function useQueueProcessor($storeId = null): bool

--- a/Model/Config/Source/PaymentAction.php
+++ b/Model/Config/Source/PaymentAction.php
@@ -26,5 +26,4 @@ class PaymentAction implements OptionSourceInterface
             ['value' => MethodInterface::ACTION_ORDER, 'label' => MethodInterface::ACTION_ORDER],
         ];
     }
-
 }

--- a/Model/Config/Source/PaymentAction.php
+++ b/Model/Config/Source/PaymentAction.php
@@ -12,6 +12,7 @@
 namespace Adyen\Payment\Model\Config\Source;
 
 use Magento\Framework\Data\OptionSourceInterface;
+use Magento\Payment\Model\MethodInterface;
 
 class PaymentAction implements OptionSourceInterface
 {
@@ -21,8 +22,8 @@ class PaymentAction implements OptionSourceInterface
     public function toOptionArray()
     {
         return [
-            ['value' => 'authorize', 'label' => 'Authorize'],
-            ['value' => 'order', 'label' => 'Order']
+            ['value' => MethodInterface::ACTION_AUTHORIZE, 'label' => MethodInterface::ACTION_AUTHORIZE],
+            ['value' => MethodInterface::ACTION_ORDER, 'label' => MethodInterface::ACTION_ORDER],
         ];
     }
 

--- a/Model/Config/Source/PaymentAction.php
+++ b/Model/Config/Source/PaymentAction.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2024 Adyen N.V. (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\Payment\Model\Config\Source;
+
+use Magento\Framework\Data\OptionSourceInterface;
+
+class PaymentAction implements OptionSourceInterface
+{
+    /**
+     * @return array
+     */
+    public function toOptionArray()
+    {
+        return [
+            ['value' => 'authorize', 'label' => 'Authorize'],
+            ['value' => 'order', 'label' => 'Order']
+        ];
+    }
+
+}

--- a/Observer/SetOrderStateAfterPaymentObserver.php
+++ b/Observer/SetOrderStateAfterPaymentObserver.php
@@ -19,7 +19,7 @@ use Exception;
 use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
 use Magento\Framework\Exception\LocalizedException;
-use Magento\Paypal\Model\AbstractConfig;
+use Magento\Payment\Model\MethodInterface;
 use Magento\Sales\Model\Order;
 use Magento\Sales\Model\Order\Payment;
 use Magento\Sales\Model\Order\StatusResolver;
@@ -75,7 +75,7 @@ class SetOrderStateAfterPaymentObserver implements ObserverInterface
         $storeId = $payment->getOrder()->getStoreId();
         $posPaymentAction = $this->configHelper->getAdyenPosCloudPaymentAction($storeId);
 
-        if ($posPaymentAction === AbstractConfig::PAYMENT_ACTION_ORDER) {
+        if ($posPaymentAction === MethodInterface::ACTION_ORDER) {
             $order = $payment->getOrder();
             $status = $this->statusResolver->getOrderStatusByState(
                 $payment->getOrder(),

--- a/Observer/SetOrderStateAfterPaymentObserver.php
+++ b/Observer/SetOrderStateAfterPaymentObserver.php
@@ -12,31 +12,46 @@
 
 namespace Adyen\Payment\Observer;
 
+use Adyen\Payment\Helper\Config;
 use Adyen\Payment\Helper\PaymentResponseHandler;
 use Adyen\Payment\Model\Method\Adapter;
 use Exception;
 use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
 use Magento\Framework\Exception\LocalizedException;
+use Magento\Paypal\Model\AbstractConfig;
 use Magento\Sales\Model\Order;
 use Magento\Sales\Model\Order\Payment;
 use Magento\Sales\Model\Order\StatusResolver;
 
 class SetOrderStateAfterPaymentObserver implements ObserverInterface
 {
+    /**
+     * @var StatusResolver
+     */
     private StatusResolver $statusResolver;
 
+    /**
+     * @var Config
+     */
+    private Config $configHelper;
+
+    /**
+     * @param StatusResolver $statusResolver
+     * @param Config $configHelper
+     */
     public function __construct(
-        StatusResolver $statusResolver
+        StatusResolver $statusResolver,
+        Config $configHelper
     ) {
         $this->statusResolver = $statusResolver;
+        $this->configHelper = $configHelper;
     }
 
     /**
-     * @throws LocalizedException
      * @throws Exception
      */
-    public function execute(Observer $observer)
+    public function execute(Observer $observer): void
     {
         /** @var Payment $payment */
         $payment = $observer->getData('payment');
@@ -50,22 +65,36 @@ class SetOrderStateAfterPaymentObserver implements ObserverInterface
         }
     }
 
-    private function handlePosPayment(Payment $payment)
+    /**
+     * @param Payment $payment
+     * @return void
+     * @throws Exception
+     */
+    private function handlePosPayment(Payment $payment): void
     {
-        $order = $payment->getOrder();
-        $status = $this->statusResolver->getOrderStatusByState(
-            $payment->getOrder(),
-            Order::STATE_PENDING_PAYMENT
-        );
-        $order->setState(Order::STATE_PENDING_PAYMENT);
-        $order->setStatus($status);
-        $message = __("Pos payment initiated and waiting for payment");
-        $order->addCommentToStatusHistory($message, $status);
-        $order->save();
+        $storeId = $payment->getOrder()->getStoreId();
+        $posPaymentAction = $this->configHelper->getAdyenPosCloudPaymentAction($storeId);
+
+        if ($posPaymentAction === AbstractConfig::PAYMENT_ACTION_ORDER) {
+            $order = $payment->getOrder();
+            $status = $this->statusResolver->getOrderStatusByState(
+                $payment->getOrder(),
+                Order::STATE_PENDING_PAYMENT
+            );
+            $order->setState(Order::STATE_PENDING_PAYMENT);
+            $order->setStatus($status);
+            $message = __("Pos payment initiated and waiting for payment");
+            $order->addCommentToStatusHistory($message, $status);
+            $order->save();
+        }
     }
 
-  
-    private function handlePaymentWithAction(Payment $payment)
+    /**
+     * @param Payment $payment
+     * @return void
+     * @throws LocalizedException
+     */
+    private function handlePaymentWithAction(Payment $payment): void
     {
         $methodInstance = $payment->getMethodInstance();
 

--- a/Observer/SubmitQuoteObserver.php
+++ b/Observer/SubmitQuoteObserver.php
@@ -16,7 +16,7 @@ use Adyen\Payment\Helper\PaymentMethods;
 use Adyen\Payment\Helper\PaymentResponseHandler;
 use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
-use Magento\Paypal\Model\AbstractConfig;
+use Magento\Payment\Model\MethodInterface;
 use Magento\Quote\Model\Quote;
 use Magento\Sales\Model\Order;
 
@@ -66,7 +66,7 @@ class SubmitQuoteObserver implements ObserverInterface
         $isPosPayment = $payment->getMethod() === 'adyen_pos_cloud';
         $posPaymentAction = $this->configHelper->getAdyenPosCloudPaymentAction($storeId);
 
-        if (($isPosPayment && $posPaymentAction === AbstractConfig::PAYMENT_ACTION_ORDER) ||
+        if (($isPosPayment && $posPaymentAction === MethodInterface::ACTION_ORDER) ||
             ($isAdyenPaymentMethod && $isActionRequired)) {
             // Further shopper action required (e.g. redirect or 3DS authentication)
             /** @var Quote $quote */

--- a/Observer/SubmitQuoteObserver.php
+++ b/Observer/SubmitQuoteObserver.php
@@ -11,37 +11,63 @@
 
 namespace Adyen\Payment\Observer;
 
+use Adyen\Payment\Helper\Config;
 use Adyen\Payment\Helper\PaymentMethods;
 use Adyen\Payment\Helper\PaymentResponseHandler;
 use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
+use Magento\Paypal\Model\AbstractConfig;
 use Magento\Quote\Model\Quote;
 use Magento\Sales\Model\Order;
 
 class SubmitQuoteObserver implements ObserverInterface
 {
+    /**
+     * @var PaymentMethods
+     */
     private PaymentMethods $paymentMethodsHelper;
 
+    /**
+     * @var Config
+     */
+    private Config $configHelper;
+
+    /**
+     * @param PaymentMethods $paymentMethodsHelper
+     * @param Config $configHelper
+     */
     public function __construct(
-        PaymentMethods $paymentMethodsHelper
+        PaymentMethods $paymentMethodsHelper,
+        Config $configHelper
     ) {
         $this->paymentMethodsHelper = $paymentMethodsHelper;
+        $this->configHelper = $configHelper;
     }
 
-    public function execute(Observer $observer)
+    /**
+     * @param Observer $observer
+     * @return void
+     */
+    public function execute(Observer $observer): void
     {
         /** @var  Order $order */
         $order = $observer->getEvent()->getOrder();
+
         /** @var Order\Payment $payment */
         $payment = $order->getPayment();
+        $storeId = $payment->getOrder()->getStoreId();
+
         $isAdyenPaymentMethod = $this->paymentMethodsHelper->isAdyenPayment($payment->getMethod());
         $isActionRequired = in_array(
             $payment->getAdditionalInformation('resultCode'),
             PaymentResponseHandler::ACTION_REQUIRED_STATUSES
         );
-        $isPosPayment = $payment->getMethod() === 'adyen_pos_cloud';
 
-        if ($isPosPayment || ($isAdyenPaymentMethod && $isActionRequired)) {
+        $isPosPayment = $payment->getMethod() === 'adyen_pos_cloud';
+        $posPaymentAction = $this->configHelper->getAdyenPosCloudPaymentAction($storeId);
+
+        if (($isPosPayment && $posPaymentAction === AbstractConfig::PAYMENT_ACTION_ORDER) ||
+            ($isAdyenPaymentMethod && $isActionRequired)) {
             // Further shopper action required (e.g. redirect or 3DS authentication)
             /** @var Quote $quote */
             $quote = $observer->getEvent()->getQuote();

--- a/Test/Unit/Helper/ConfigTest.php
+++ b/Test/Unit/Helper/ConfigTest.php
@@ -16,6 +16,7 @@ use Adyen\Payment\Test\Unit\AbstractAdyenTestCase;
 use Magento\Framework\App\Config\Storage\WriterInterface;
 use Magento\Framework\Encryption\EncryptorInterface;
 use Magento\Framework\Serialize\SerializerInterface;
+use Magento\Payment\Model\MethodInterface;
 use Magento\Store\Model\ScopeInterface;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 
@@ -81,6 +82,28 @@ class ConfigTest extends AbstractAdyenTestCase
             ->willReturn($expectedResult);
 
         $result = $this->configHelper->getAllowMultistoreTokens($storeId);
+
+        $this->assertEquals($expectedResult, $result);
+    }
+
+    public function testGetAdyenPosCloudPaymentAction()
+    {
+        $storeId = PHP_INT_MAX;
+
+        $expectedResult = MethodInterface::ACTION_ORDER;
+        $path = sprintf(
+            "%s/%s/%s",
+            Config::XML_PAYMENT_PREFIX,
+            Config::XML_ADYEN_POS_CLOUD,
+            Config::XML_PAYMENT_ACTION
+        );
+
+        $this->scopeConfigMock->expects($this->once())
+            ->method('getValue')
+            ->with($this->equalTo($path), $this->equalTo(ScopeInterface::SCOPE_STORE), $this->equalTo($storeId))
+            ->willReturn($expectedResult);
+
+        $result = $this->configHelper->getAdyenPosCloudPaymentAction($storeId);
 
         $this->assertEquals($expectedResult, $result);
     }

--- a/Test/Unit/Model/Config/Source/PaymentActionTest.php
+++ b/Test/Unit/Model/Config/Source/PaymentActionTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Adyen\Payment\Test\Unit\Model\Config\Source;
+
+use Adyen\Payment\Model\Config\Source\PaymentAction;
+use Adyen\Payment\Test\Unit\AbstractAdyenTestCase;
+use Magento\Payment\Model\MethodInterface;
+
+class PaymentActionTest extends AbstractAdyenTestCase
+{
+    public function testToOptionArray()
+    {
+        $paymentActionClass = new PaymentAction();
+
+        $expected = [
+            ['value' => MethodInterface::ACTION_AUTHORIZE, 'label' => MethodInterface::ACTION_AUTHORIZE],
+            ['value' => MethodInterface::ACTION_ORDER, 'label' => MethodInterface::ACTION_ORDER],
+        ];
+
+        $this->assertEquals($expected, $paymentActionClass->toOptionArray());
+    }
+}

--- a/Test/Unit/Model/Ui/AdyenPosCloudConfigProviderTest.php
+++ b/Test/Unit/Model/Ui/AdyenPosCloudConfigProviderTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Adyen\Payment\Test\Unit\Model\Ui;
+
+use Adyen\Payment\Helper\Config;
+use Adyen\Payment\Helper\ConnectedTerminals;
+use Adyen\Payment\Model\Ui\AdyenPosCloudConfigProvider;
+use Adyen\Payment\Test\Unit\AbstractAdyenTestCase;
+use Magento\Framework\App\RequestInterface;
+use Magento\Framework\Serialize\SerializerInterface;
+use Magento\Framework\UrlInterface;
+use Magento\Payment\Model\MethodInterface;
+use Magento\Store\Api\Data\StoreInterface;
+use Magento\Store\Model\StoreManager;
+
+class AdyenPosCloudConfigProviderTest extends AbstractAdyenTestCase
+{
+    private $adyenPosCloudConfigProvider;
+
+    private $requestMock;
+    private $urlBuilderMock;
+    private $connectedTerminalsHelperMock;
+    private $serializerMock;
+    private $configHelperMock;
+    private $storeManagerMock;
+
+    const STORE_ID = 1;
+
+    public function setUp(): void
+    {
+        $storeMock = $this->createMock(StoreInterface::class);
+        $storeMock->method('getId')->willReturn(self::STORE_ID);
+
+        $this->requestMock = $this->createMock(RequestInterface::class);
+        $this->urlBuilderMock = $this->createMock(UrlInterface::class);
+        $this->connectedTerminalsHelperMock = $this->createMock(ConnectedTerminals::class);
+        $this->serializerMock = $this->createMock(SerializerInterface::class);
+        $this->configHelperMock = $this->createMock(Config::class);
+        $this->storeManagerMock = $this->createMock(StoreManager::class);
+
+        $this->storeManagerMock->method('getStore')->willReturn($storeMock);
+
+        $this->adyenPosCloudConfigProvider = new AdyenPosCloudConfigProvider(
+            $this->requestMock,
+            $this->urlBuilderMock,
+            $this->connectedTerminalsHelperMock,
+            $this->serializerMock,
+            $this->configHelperMock,
+            $this->storeManagerMock
+        );
+    }
+
+    public function testGetConfigWithoutInstallments()
+    {
+        $successPageUrl = '/onepage/success';
+        $isActive = true;
+
+        $this->urlBuilderMock->expects($this->once())->method('getUrl')->willReturn($successPageUrl);
+
+        $this->configHelperMock->expects($this->once())
+            ->method('getAdyenPosCloudPaymentAction')
+            ->with(self::STORE_ID)
+            ->willReturn(MethodInterface::ACTION_ORDER);
+        $this->configHelperMock->expects($this->any())
+            ->method('getAdyenPosCloudConfigData')
+            ->will($this->returnValueMap([
+                ['active', self::STORE_ID, true, $isActive],
+                ['enable_installments', self::STORE_ID, false, false],
+                ['installments', self::STORE_ID, false, []]
+            ]));
+
+        $config = $this->adyenPosCloudConfigProvider->getConfig();
+
+        $this->assertIsArray($config);
+        $this->assertArrayHasKey('payment', $config);
+        $this->assertTrue($config['payment']['adyen_pos_cloud']['isActive']);
+    }
+}

--- a/Test/Unit/Observer/SubmitQuoteObserverTest.php
+++ b/Test/Unit/Observer/SubmitQuoteObserverTest.php
@@ -11,10 +11,12 @@
 
 namespace Adyen\Payment\Test\Unit\Observer;
 
+use Adyen\Payment\Helper\Config;
 use Adyen\Payment\Helper\PaymentMethods;
 use Adyen\Payment\Observer\SubmitQuoteObserver;
 use Adyen\Payment\Helper\PaymentResponseHandler;
 use Magento\Framework\Event\Observer;
+use Magento\Payment\Model\MethodInterface;
 use Magento\Quote\Model\Quote;
 use Magento\Sales\Model\Order;
 use Magento\Sales\Model\Order\Payment;
@@ -23,6 +25,7 @@ use PHPUnit\Framework\TestCase;
 class SubmitQuoteObserverTest extends TestCase
 {
     private $paymentMethodsHelperMock;
+    private $configHelperMock;
     private $submitQuoteObserver;
     private $observerMock;
     private $orderMock;
@@ -33,6 +36,7 @@ class SubmitQuoteObserverTest extends TestCase
     protected function setUp(): void
     {
         $this->paymentMethodsHelperMock = $this->createMock(PaymentMethods::class);
+        $this->configHelperMock = $this->createMock(Config::class);
         $this->observerMock = $this->createMock(Observer::class);
         $this->orderMock = $this->createMock(Order::class);
         $this->paymentMock = $this->createMock(Payment::class);
@@ -42,17 +46,26 @@ class SubmitQuoteObserverTest extends TestCase
             ->getMock();
 
         $this->submitQuoteObserver = new SubmitQuoteObserver(
-            $this->paymentMethodsHelperMock
+            $this->paymentMethodsHelperMock,
+            $this->configHelperMock
         );
     }
 
     public function testObserverPaymentMethodRequiresAction()
     {
+        $this->configHelperMock->method('getAdyenPosCloudPaymentAction')
+            ->willReturn(MethodInterface::ACTION_ORDER);
+
         $this->observerMock->method('getEvent')->willReturn($this->eventMock);
+
         $this->eventMock->method('getOrder')->willReturn($this->orderMock);
         $this->eventMock->method('getQuote')->willReturn($this->quoteMock);
+
         $this->orderMock->method('getPayment')->willReturn($this->paymentMock);
+        $this->orderMock->method('getStoreId')->willReturn(1);
+
         $this->paymentMock->method('getMethod')->willReturn('adyen_method');
+        $this->paymentMock->method('getOrder')->willReturn($this->orderMock);
         $this->paymentMock->method('getAdditionalInformation')->with('resultCode')
             ->willReturn(PaymentResponseHandler::ACTION_REQUIRED_STATUSES[0]);
 
@@ -70,10 +83,15 @@ class SubmitQuoteObserverTest extends TestCase
         $resultCode = 'Authorised'; // Assuming 'Authorised' is not in ACTION_REQUIRED_STATUSES
 
         $this->observerMock->method('getEvent')->willReturn($this->eventMock);
+
         $this->eventMock->method('getOrder')->willReturn($this->orderMock);
         $this->eventMock->method('getQuote')->willReturn($this->quoteMock);
+
         $this->orderMock->method('getPayment')->willReturn($this->paymentMock);
+        $this->orderMock->method('getStoreId')->willReturn(1);
+
         $this->paymentMock->method('getMethod')->willReturn('adyen_method');
+        $this->paymentMock->method('getOrder')->willReturn($this->orderMock);
         $this->paymentMock->method('getAdditionalInformation')->with('resultCode')
             ->willReturn($resultCode);
 

--- a/etc/adminhtml/system/adyen_inperson_payments.xml
+++ b/etc/adminhtml/system/adyen_inperson_payments.xml
@@ -55,20 +55,20 @@
             <config_path>payment/adyen_pos_cloud/api_key_live</config_path>
             <comment model="Adyen\Payment\Model\Comment\ApiKeyEnding" />
         </field>
-        <field id="capture_mode_pos" translate="label" type="select" sortOrder="90" showInDefault="1" showInWebsite="1" showInStore="1">
+        <field id="capture_mode_pos" translate="label" type="select" sortOrder="80" showInDefault="1" showInWebsite="1" showInStore="1">
             <label>Capture Delay</label>
             <tooltip>Please set your Capture Delay for POS transactions. Immediate is the default. Set to manual if you want to perform the capture of funds manually later. You need to change this setting as well in Adyen Customer Area => Settings => Merchant Settings => POS Capture Delay. If you have selected a capture delay of a couple of days in Adyen keep it here on immediate</tooltip>
             <source_model>Adyen\Payment\Model\Config\Source\CaptureMode</source_model>
             <config_path>payment/adyen_pos_cloud/capture_mode_pos</config_path>
         </field>
-        <field id="enable_installments" translate="label" type="select" sortOrder="219" showInDefault="1"
+        <field id="enable_installments" translate="label" type="select" sortOrder="90" showInDefault="1"
                showInWebsite="1" showInStore="1">
             <label>Enable Installments</label>
             <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
             <tooltip>Enable installments for each credit card type.</tooltip>
             <config_path>payment/adyen_pos_cloud/enable_installments</config_path>
         </field>
-        <field id="installments" translate="label" sortOrder="220" showInDefault="1" showInWebsite="1"
+        <field id="installments" translate="label" sortOrder="100" showInDefault="1" showInWebsite="1"
                showInStore="1">
             <label>Installments</label>
             <depends>
@@ -83,7 +83,13 @@
             <backend_model>Adyen\Payment\Model\Config\Backend\InstallmentsPosCloud</backend_model>
             <config_path>payment/adyen_pos_cloud/installments</config_path>
         </field>
-        <group id="adyen_pos_country_specific" translate="label" showInDefault="1" showInWebsite="1" sortOrder="210">
+        <field id="payment_action" translate="label" type="select" sortOrder="110" showInDefault="1" showInWebsite="1" showInStore="0">
+            <label>Payment Action</label>
+            <tooltip></tooltip>
+            <source_model>Adyen\Payment\Model\Config\Source\PaymentAction</source_model>
+            <config_path>payment/adyen_pos_cloud/payment_action</config_path>
+        </field>
+        <group id="adyen_pos_country_specific" translate="label" showInDefault="1" showInWebsite="1" sortOrder="200">
             <label>Country Specific Settings</label>
             <frontend_model>Magento\Config\Block\System\Config\Form\Fieldset</frontend_model>
             <field id="allowspecific" translate="label" type="allowspecific" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="0">

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -390,7 +390,7 @@
                 <title>Adyen POS Terminal Payment</title>
                 <allowspecific>0</allowspecific>
                 <sort_order>6</sort_order>
-                <payment_action>order</payment_action>
+                <payment_action>authorize</payment_action>
                 <is_gateway>1</is_gateway>
                 <can_authorize>1</can_authorize>
                 <can_use_checkout>1</can_use_checkout>

--- a/view/frontend/web/js/view/payment/method-renderer/adyen-pos-cloud-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-pos-cloud-method.js
@@ -97,13 +97,18 @@ define(
                         self.handleFailedResponse(response)
                     })
                     .done(function (orderId) {
-                        adyenPaymentService.posPayment(orderId)
-                            .fail(function (response) {
-                                self.handleFailedResponse(response)
-                            })
-                            .done(function () {
-                                self.posComplete()
-                            })
+                        let posPaymentAction = window.checkoutConfig.payment.adyenPos.paymentAction;
+                        if (posPaymentAction === 'order') {
+                            adyenPaymentService.posPayment(orderId)
+                                .fail(function (response) {
+                                    self.handleFailedResponse(response)
+                                })
+                                .done(function () {
+                                    self.posComplete()
+                                });
+                        } else {
+                            self.posComplete();
+                        }
                     })
             },
             handleFailedResponse: function (response) {


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
The new asynchronous POS cloud payment flow contains some breaking changes for the merchants who have already implement POS payments into their V9 stores. This PR introduces configuration `Payment Action` field for `In-person payments` to make POS flow synchronous/asynchronous. This field has two potential values where having `authorize` by default.

- `order`: Order will be created first then payment will be initiated. (More robust, allows asynchronous webhook to finalise the order in case of network degradation)
- `authorize`: Payment will be completed first then order will be created. (Fragile in case of network degradation, payment might be lost)

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- Synchronous/asynchronous payment flows for POS cloud payments
- Intentional network disruption and finalise the order with async webhook event
