### PR TITLE
[ECP-8984] Remove version from data patches and setup_version from module.xml

### DIFF
--- a/Setup/Patch/Data/CreateStatusAuthorized.php
+++ b/Setup/Patch/Data/CreateStatusAuthorized.php
@@ -15,7 +15,6 @@ use Adyen\Payment\Helper\DataPatch;
 use Magento\Framework\Exception\AlreadyExistsException;
 use Magento\Framework\Setup\ModuleDataSetupInterface;
 use Magento\Framework\Setup\Patch\DataPatchInterface;
-use Magento\Framework\Setup\Patch\PatchVersionInterface;
 use Magento\Framework\App\Config\ReinitableConfigInterface;
 use Magento\Framework\App\Config\Storage\WriterInterface;
 use Magento\Sales\Model\Order;
@@ -23,7 +22,7 @@ use Magento\Sales\Model\Order\StatusFactory;
 use Magento\Sales\Model\ResourceModel\Order\StatusFactory as StatusResourceFactory;
 use Magento\Sales\Model\ResourceModel\Order\Status as StatusResource;
 
-class CreateStatusAuthorized implements DataPatchInterface, PatchVersionInterface
+class CreateStatusAuthorized implements DataPatchInterface
 {
     private ModuleDataSetupInterface $moduleDataSetup;
     private WriterInterface $configWriter;
@@ -102,10 +101,5 @@ class CreateStatusAuthorized implements DataPatchInterface, PatchVersionInterfac
     public static function getDependencies(): array
     {
         return [];
-    }
-
-    public static function getVersion(): string
-    {
-        return '9.0.3';
     }
 }

--- a/Setup/Patch/Data/CreditCardsBecomeCards.php
+++ b/Setup/Patch/Data/CreditCardsBecomeCards.php
@@ -6,7 +6,7 @@ use Magento\Framework\Setup\ModuleDataSetupInterface;
 use Magento\Framework\Setup\Patch\DataPatchInterface;
 use Magento\Framework\Setup\Patch\PatchVersionInterface;
 
-class CreditCardsBecomeCards implements DataPatchInterface, PatchVersionInterface
+class CreditCardsBecomeCards implements DataPatchInterface
 {
     private ModuleDataSetupInterface $moduleDataSetup;
 
@@ -64,13 +64,5 @@ class CreditCardsBecomeCards implements DataPatchInterface, PatchVersionInterfac
     public static function getDependencies()
     {
         return [];
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public static function getVersion()
-    {
-        return '9.0.5';
     }
 }

--- a/Setup/Patch/Data/RatepayIdConfiguration.php
+++ b/Setup/Patch/Data/RatepayIdConfiguration.php
@@ -15,9 +15,8 @@ use Magento\Framework\App\Config\ReinitableConfigInterface;
 use Magento\Framework\App\Config\Storage\WriterInterface;
 use Magento\Framework\Setup\ModuleDataSetupInterface;
 use Magento\Framework\Setup\Patch\DataPatchInterface;
-use Magento\Framework\Setup\Patch\PatchVersionInterface;
 
-class RatepayIdConfiguration implements DataPatchInterface, PatchVersionInterface
+class RatepayIdConfiguration implements DataPatchInterface
 {
     private ModuleDataSetupInterface $moduleDataSetup;
     private WriterInterface $configWriter;
@@ -95,10 +94,5 @@ class RatepayIdConfiguration implements DataPatchInterface, PatchVersionInterfac
     public static function getDependencies(): array
     {
         return [];
-    }
-
-    public static function getVersion(): string
-    {
-        return '9.0.0';
     }
 }

--- a/Setup/Patch/Data/RemoveMinMaxOrderConfigMigration.php
+++ b/Setup/Patch/Data/RemoveMinMaxOrderConfigMigration.php
@@ -2,23 +2,18 @@
 
 namespace Adyen\Payment\Setup\Patch\Data;
 
-use Magento\Framework\App\Config\ReinitableConfigInterface;
 use Magento\Framework\Setup\ModuleDataSetupInterface;
 use Magento\Framework\Setup\Patch\DataPatchInterface;
-use Magento\Framework\Setup\Patch\PatchVersionInterface;
 
-class RemoveMinMaxOrderConfigMigration implements DataPatchInterface, PatchVersionInterface
+class RemoveMinMaxOrderConfigMigration implements DataPatchInterface
 {
     private ModuleDataSetupInterface $moduleDataSetup;
-    private ReinitableConfigInterface $reinitableConfig;
 
     public function __construct(
         ModuleDataSetupInterface  $moduleDataSetup,
-        ReinitableConfigInterface $reinitableConfig
     )
     {
         $this->moduleDataSetup = $moduleDataSetup;
-        $this->reinitableConfig = $reinitableConfig;
     }
 
     /**
@@ -66,13 +61,5 @@ class RemoveMinMaxOrderConfigMigration implements DataPatchInterface, PatchVersi
     public static function getDependencies()
     {
         return [];
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public static function getVersion()
-    {
-        return '9.0.0';
     }
 }

--- a/Setup/Patch/Data/VaultMigration.php
+++ b/Setup/Patch/Data/VaultMigration.php
@@ -19,7 +19,6 @@ use Magento\Framework\Encryption\EncryptorInterface;
 use Magento\Framework\Setup\ModuleDataSetupInterface;
 use Magento\Framework\Setup\Patch\DataPatchInterface;
 use Magento\Vault\Api\Data\PaymentTokenFactoryInterface;
-use Magento\Vault\Api\Data\PaymentTokenInterface;
 use Magento\Vault\Api\PaymentTokenManagementInterface;
 use Magento\Vault\Api\PaymentTokenRepositoryInterface;
 

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -12,7 +12,7 @@
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
 
-    <module name="Adyen_Payment" setup_version="9.4.0">
+    <module name="Adyen_Payment">
         <sequence>
             <module name="Magento_Sales"/>
             <module name="Magento_Quote"/>


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Accoding to Adobe's [Develop data and schema patches](https://developer.adobe.com/commerce/php/development/components/declarative-schema/patches) documentation, there is no need to use `PatchVersionInterface` on data patches if declarative schema is being used. Moreover, `setup_version` can be removed from `module.xml`. 

This PR introduces a fix for skipped data patches and removes `module_version` from `module.xml` file.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- Clean installation
- Card payments

Fixes #2496 
