### PR TITLE
[ECP-8992] Add Apple Pay billing address requirement

### DIFF
--- a/view/frontend/layout/checkout_index_index.xml
+++ b/view/frontend/layout/checkout_index_index.xml
@@ -299,6 +299,9 @@
                                                                         <item name="adyen_ach" xsi:type="array">
                                                                             <item name="isBillingAddressRequired" xsi:type="boolean">true</item>
                                                                         </item>
+                                                                        <item name="adyen_applepay" xsi:type="array">
+                                                                            <item name="isBillingAddressRequired" xsi:type="boolean">true</item>
+                                                                        </item>
                                                                     </item>
                                                                 </item>
                                                             </item>


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Add Apple Pay billing address requirement `checkout_index_index` layout file.

<img width="572" alt="Screenshot 2024-03-26 at 17 04 32" src="https://github.com/Adyen/adyen-magento2/assets/20255503/06f09d49-f780-4a37-a1ab-91cde89ebd46">

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- Apple Pay billing address change