### PR TITLE
[ECP-9113] Skip child items while building the line items array for credit memo

### DIFF
--- a/Helper/OpenInvoice.php
+++ b/Helper/OpenInvoice.php
@@ -97,7 +97,9 @@ class OpenInvoice
         $formFields = ['lineItems' => []];
 
         foreach ($creditMemo->getItems() as $creditmemoItem) {
-            if ($creditmemoItem->getQty() <= 0) {
+            // Child items only identifies the variant data and doesn't contain line item information.
+            $isChildItem = $creditmemoItem->getOrderItem()->getParentItem() !== null;
+            if ($creditmemoItem->getQty() <= 0 || $isChildItem) {
                 continue;
             }
 

--- a/Model/AdyenAmountCurrency.php
+++ b/Model/AdyenAmountCurrency.php
@@ -97,6 +97,10 @@ class AdyenAmountCurrency
 
     public function getCalculatedTaxPercentage()
     {
-        return $this->getTaxAmount() / ($this->getAmountWithDiscount()) * 100;
+        if ($this->getAmountWithDiscount() > 0) {
+            return ($this->getTaxAmount() / $this->getAmountWithDiscount()) * 100;
+        } else {
+            return 0;
+        }
     }
 }

--- a/Test/Unit/Model/AdyenAmountCurrencyTest.php
+++ b/Test/Unit/Model/AdyenAmountCurrencyTest.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2024 Adyen N.V. (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\Payment\Test\Helper\Unit\Model;
+
+use Adyen\Payment\Model\AdyenAmountCurrency;
+use Adyen\Payment\Test\Unit\AbstractAdyenTestCase;
+
+class AdyenAmountCurrencyTest extends AbstractAdyenTestCase
+{
+    /**
+     * @dataProvider getCalculatedTaxPercentageProvider
+     * @return void
+     */
+    public function testGetCalculatedTaxPercentage($amount, $currencyCode, $taxPercentage, $expectedValue)
+    {
+        $adyenAmountCurrency = new AdyenAmountCurrency($amount, $currencyCode, 0, $taxPercentage);
+
+        $this->assertEquals($adyenAmountCurrency->getCalculatedTaxPercentage(), $expectedValue);
+    }
+
+    public static function getCalculatedTaxPercentageProvider()
+    {
+        return [
+            [
+                'amount' => 100.0,
+                'currencyCode' => 'EUR',
+                'taxAmount' => 21,
+                'expectedValue' => 21
+            ],
+            [
+                'amount' => 0,
+                'currencyCode' => 'EUR',
+                'taxAmount' => 21,
+                'expectedValue' => 0
+            ]
+        ];
+    }
+}


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Magento `CreditmemoItem` returns child items for the products which have variants. However, this child variant item doesn't have line item related information (price, row_total etc.). `getPrice()` returns `0` for this item and causes zero division exception.

This PR filters out the child items from credit memo line items and sends only parent items. Also, an extra check has been implemented to prevent possible zero divisions.
 
**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- Refund a product with a variant