### PR TITLE
[ECP-9112] Fix broken feature of obtaining state data from DB

### DIFF
--- a/Observer/AdyenCcDataAssignObserver.php
+++ b/Observer/AdyenCcDataAssignObserver.php
@@ -115,14 +115,21 @@ class AdyenCcDataAssignObserver extends AbstractDataAssignObserver
 
         // JSON decode state data from the frontend or fetch it from the DB entity with the quote ID
         if (!empty($additionalData[self::STATE_DATA])) {
-            $stateData = json_decode((string) $additionalData[self::STATE_DATA], true);
+            $stateData = json_decode((string)$additionalData[self::STATE_DATA], true);
+        } else {
+            $stateData = $this->stateDataCollection->getStateDataArrayWithQuoteId($paymentInfo->getData('quote_id'));
         }
 
         // Get validated state data array
-        if (!empty($stateData)) {
+        if (!empty($stateData) && $stateData['paymentMethod']['type'] != 'giftcard') {
             $stateData = $this->checkoutStateDataValidator->getValidatedAdditionalData($stateData);
             // Set stateData in a service and remove from payment's additionalData
             $this->stateData->setStateData($stateData, $paymentInfo->getData('quote_id'));
+
+            // set storeCc
+            if (!empty($stateData[self::STORE_PAYMENT_METHOD])) {
+                $paymentInfo->setAdditionalInformation(self::STORE_CC, $stateData[self::STORE_PAYMENT_METHOD]);
+            }
         }
 
         unset($additionalData[self::STATE_DATA]);
@@ -143,11 +150,6 @@ class AdyenCcDataAssignObserver extends AbstractDataAssignObserver
         // set ccType
         if (!empty($additionalData[self::CC_TYPE])) {
             $paymentInfo->setCcType($additionalData[self::CC_TYPE]);
-        }
-
-        // set storeCc
-        if (!empty($stateData[self::STORE_PAYMENT_METHOD])) {
-            $paymentInfo->setAdditionalInformation(self::STORE_CC, $stateData[self::STORE_PAYMENT_METHOD]);
         }
     }
 }

--- a/Observer/AdyenPaymentMethodDataAssignObserver.php
+++ b/Observer/AdyenPaymentMethodDataAssignObserver.php
@@ -89,10 +89,12 @@ class AdyenPaymentMethodDataAssignObserver extends AbstractDataAssignObserver
         } elseif (!empty($additionalData[self::CC_NUMBER])) {
             $stateData = json_decode((string) $additionalData[self::CC_NUMBER], true);
             $paymentInfo->setAdditionalInformation(self::BRAND_CODE, $stateData['paymentMethod']['type']);
+        } elseif($paymentInfo->getData('method') != 'adyen_giftcard') {
+            $stateData = $this->stateDataCollection->getStateDataArrayWithQuoteId($paymentInfo->getData('quote_id'));
         }
 
         // Get validated state data array
-        if (!empty($stateData)) {
+        if (!empty($stateData) && $stateData['paymentMethod']['type'] != 'giftcard') {
             $stateData = $this->checkoutStateDataValidator->getValidatedAdditionalData($stateData);
             // Set stateData in a service and remove from payment's additionalData
             $this->stateData->setStateData($stateData, $paymentInfo->getData('quote_id'));

--- a/Observer/AdyenPaymentMethodDataAssignObserver.php
+++ b/Observer/AdyenPaymentMethodDataAssignObserver.php
@@ -87,14 +87,19 @@ class AdyenPaymentMethodDataAssignObserver extends AbstractDataAssignObserver
         if (!empty($additionalData[self::STATE_DATA])) {
             $stateData = json_decode((string) $additionalData[self::STATE_DATA], true);
         } elseif (!empty($additionalData[self::CC_NUMBER])) {
+            //This block goes for multi shipping scenarios
             $stateData = json_decode((string) $additionalData[self::CC_NUMBER], true);
             $paymentInfo->setAdditionalInformation(self::BRAND_CODE, $stateData['paymentMethod']['type']);
         } elseif($paymentInfo->getData('method') != 'adyen_giftcard') {
             $stateData = $this->stateDataCollection->getStateDataArrayWithQuoteId($paymentInfo->getData('quote_id'));
+            if($stateData['paymentMethod']['type'] == 'giftcard')
+            {
+                $stateData = null;
+            }
         }
 
         // Get validated state data array
-        if (!empty($stateData) && $stateData['paymentMethod']['type'] != 'giftcard') {
+        if (!empty($stateData)) {
             $stateData = $this->checkoutStateDataValidator->getValidatedAdditionalData($stateData);
             // Set stateData in a service and remove from payment's additionalData
             $this->stateData->setStateData($stateData, $paymentInfo->getData('quote_id'));


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
obtaining state data from DB and ignoring it for Giftcard type payment methods
<!-- Please provide a description of the changes proposed in the Pull Request -->

**Tested scenarios**

- Card payment can be completed with a stored state data.
- Single gift card payment can be completed with a stored state data.
- Gift card payments though graphql can be completed (card + giftcard)
- Gift card payment can be completed without saving the state data to the DB (pass in the additional information)

<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

Fixes  <!-- #-prefixed github issue number -->
