### PR TITLE
[ECP-9147] Fix unit test OrderRepositoryTest

### DIFF
--- a/Model/Sales/OrderRepository.php
+++ b/Model/Sales/OrderRepository.php
@@ -21,7 +21,6 @@ use Magento\Payment\Api\Data\PaymentAdditionalInfoInterfaceFactory;
 use Magento\Sales\Api\Data\OrderExtensionFactory;
 use Magento\Sales\Api\Data\OrderInterface;
 use Magento\Sales\Api\Data\OrderSearchResultInterfaceFactory as SearchResultFactory;
-use Magento\Sales\Model\Order\ShippingAssignmentBuilder;
 use Magento\Sales\Model\OrderRepository as SalesOrderRepository;
 use Magento\Sales\Model\ResourceModel\Metadata;
 use Magento\Tax\Api\OrderTaxManagementInterface;
@@ -43,8 +42,7 @@ class OrderRepository extends SalesOrderRepository
         OrderTaxManagementInterface $orderTaxManagement = null,
         PaymentAdditionalInfoInterfaceFactory $paymentAdditionalInfoFactory = null,
         JsonSerializer $serializer = null,
-        JoinProcessorInterface $extensionAttributesJoinProcessor = null,
-        ShippingAssignmentBuilder $shippingAssignmentBuilder = null
+        JoinProcessorInterface $extensionAttributesJoinProcessor = null
     ) {
         parent::__construct(
             $metadata,
@@ -54,8 +52,7 @@ class OrderRepository extends SalesOrderRepository
             $orderTaxManagement,
             $paymentAdditionalInfoFactory,
             $serializer,
-            $extensionAttributesJoinProcessor,
-            $shippingAssignmentBuilder
+            $extensionAttributesJoinProcessor
         );
 
         $this->searchCriteriaBuilder = $searchCriteriaBuilder;

--- a/Model/Sales/OrderRepository.php
+++ b/Model/Sales/OrderRepository.php
@@ -21,6 +21,7 @@ use Magento\Payment\Api\Data\PaymentAdditionalInfoInterfaceFactory;
 use Magento\Sales\Api\Data\OrderExtensionFactory;
 use Magento\Sales\Api\Data\OrderInterface;
 use Magento\Sales\Api\Data\OrderSearchResultInterfaceFactory as SearchResultFactory;
+use Magento\Sales\Model\Order\ShippingAssignmentBuilder;
 use Magento\Sales\Model\OrderRepository as SalesOrderRepository;
 use Magento\Sales\Model\ResourceModel\Metadata;
 use Magento\Tax\Api\OrderTaxManagementInterface;
@@ -42,7 +43,8 @@ class OrderRepository extends SalesOrderRepository
         OrderTaxManagementInterface $orderTaxManagement = null,
         PaymentAdditionalInfoInterfaceFactory $paymentAdditionalInfoFactory = null,
         JsonSerializer $serializer = null,
-        JoinProcessorInterface $extensionAttributesJoinProcessor = null
+        JoinProcessorInterface $extensionAttributesJoinProcessor = null,
+        ShippingAssignmentBuilder $shippingAssignmentBuilder = null
     ) {
         parent::__construct(
             $metadata,
@@ -52,7 +54,8 @@ class OrderRepository extends SalesOrderRepository
             $orderTaxManagement,
             $paymentAdditionalInfoFactory,
             $serializer,
-            $extensionAttributesJoinProcessor
+            $extensionAttributesJoinProcessor,
+            $shippingAssignmentBuilder
         );
 
         $this->searchCriteriaBuilder = $searchCriteriaBuilder;

--- a/Test/Unit/Model/Sales/OrderRepositoryTest.php
+++ b/Test/Unit/Model/Sales/OrderRepositoryTest.php
@@ -13,22 +13,15 @@ namespace Adyen\Payment\Test\Unit\Model\Sales;
 
 use Adyen\Payment\Model\Sales\OrderRepository;
 use Adyen\Payment\Test\Unit\AbstractAdyenTestCase;
-use Magento\Framework\Api\ExtensionAttribute\JoinProcessorInterface;
 use Magento\Framework\Api\Filter;
 use Magento\Framework\Api\FilterBuilder;
 use Magento\Framework\Api\Search\FilterGroup;
 use Magento\Framework\Api\Search\FilterGroupBuilder;
 use Magento\Framework\Api\SearchCriteria;
-use Magento\Framework\Api\SearchCriteria\CollectionProcessorInterface;
 use Magento\Framework\Api\SearchCriteriaBuilder;
-use Magento\Framework\Serialize\Serializer\Json as JsonSerializer;
-use Magento\Payment\Api\Data\PaymentAdditionalInfoInterfaceFactory;
-use Magento\Sales\Api\Data\OrderExtensionFactory;
 use Magento\Sales\Api\Data\OrderInterface;
 use Magento\Sales\Api\Data\OrderSearchResultInterface;
-use Magento\Sales\Api\Data\OrderSearchResultInterfaceFactory as SearchResultFactory;
-use Magento\Sales\Model\ResourceModel\Metadata;
-use Magento\Tax\Api\OrderTaxManagementInterface;
+use ReflectionClass;
 
 class OrderRepositoryTest extends AbstractAdyenTestCase
 {
@@ -61,15 +54,7 @@ class OrderRepositoryTest extends AbstractAdyenTestCase
     public function buildOrderRepositoryClass(
         $searchCriteriaBuilderMock = null,
         $filterBuilderMock = null,
-        $filterGroupBuilderMock = null,
-        $metadataMock = null,
-        $searchResultFactoryMock = null,
-        $collectionProcessorMock = null,
-        $orderExtensionFactoryMock = null,
-        $orderTaxManagementMock = null,
-        $paymentAdditionalInfoFactoryMock = null,
-        $serializerMock = null,
-        $extensionAttributesJoinProcessorMock = null
+        $filterGroupBuilderMock = null
     ): OrderRepository {
         if (is_null($searchCriteriaBuilderMock)) {
             $searchCriteriaBuilderMock = $this->createMock(SearchCriteriaBuilder::class);
@@ -83,54 +68,24 @@ class OrderRepositoryTest extends AbstractAdyenTestCase
             $filterGroupBuilderMock = $this->createMock(FilterGroupBuilder::class);
         }
 
-        if (is_null($metadataMock)) {
-            $metadataMock = $this->createMock(Metadata::class);
-        }
-
-        if (is_null($searchResultFactoryMock)) {
-            $searchResultFactoryMock = $this->createGeneratedMock(SearchResultFactory::class);
-        }
-
-        if (is_null($collectionProcessorMock)) {
-            $collectionProcessorMock = $this->createMock(CollectionProcessorInterface::class);
-        }
-
-        if (is_null($orderExtensionFactoryMock)) {
-            $orderExtensionFactoryMock = $this->createGeneratedMock(OrderExtensionFactory::class);
-        }
-
-        if (is_null($orderTaxManagementMock)) {
-            $orderTaxManagementMock = $this->createMock(OrderTaxManagementInterface::class);
-        }
-
-        if (is_null($paymentAdditionalInfoFactoryMock)) {
-            $paymentAdditionalInfoFactoryMock = $this->createGeneratedMock(PaymentAdditionalInfoInterfaceFactory::class);
-        }
-
-        if (is_null($serializerMock)) {
-            $serializerMock = $this->createMock(JsonSerializer::class);
-        }
-
-        if (is_null($extensionAttributesJoinProcessorMock)) {
-            $extensionAttributesJoinProcessorMock = $this->createMock(JoinProcessorInterface::class);
-        }
-
         $orderRepositoryPartialMock = $this->getMockBuilder(OrderRepository::class)
             ->setMethods(['getList'])
-            ->setConstructorArgs([
-                $searchCriteriaBuilderMock,
-                $filterBuilderMock,
-                $filterGroupBuilderMock,
-                $metadataMock,
-                $searchResultFactoryMock,
-                $collectionProcessorMock,
-                $orderExtensionFactoryMock,
-                $orderTaxManagementMock,
-                $paymentAdditionalInfoFactoryMock,
-                $serializerMock,
-                $extensionAttributesJoinProcessorMock
-            ])
+            ->disableOriginalConstructor()
             ->getMock();
+
+        $reflection = new ReflectionClass(OrderRepository::class);
+
+        $searchCriteriaBuilderProperty = $reflection->getProperty('searchCriteriaBuilder');
+        $searchCriteriaBuilderProperty->setAccessible(true);
+        $searchCriteriaBuilderProperty->setValue($orderRepositoryPartialMock, $searchCriteriaBuilderMock);
+
+        $filterBuilderProperty = $reflection->getProperty('filterBuilder');
+        $filterBuilderProperty->setAccessible(true);
+        $filterBuilderProperty->setValue($orderRepositoryPartialMock, $filterBuilderMock);
+
+        $filterGroupBuilderProperty = $reflection->getProperty('filterGroupBuilder');
+        $filterGroupBuilderProperty->setAccessible(true);
+        $filterGroupBuilderProperty->setValue($orderRepositoryPartialMock, $filterGroupBuilderMock);
 
         $orderSearchResultMock = $this->createConfiguredMock(OrderSearchResultInterface::class, [
             'getItems' => [$this->createMock(OrderInterface::class)]

--- a/Test/Unit/Model/Sales/OrderRepositoryTest.php
+++ b/Test/Unit/Model/Sales/OrderRepositoryTest.php
@@ -27,7 +27,6 @@ use Magento\Sales\Api\Data\OrderExtensionFactory;
 use Magento\Sales\Api\Data\OrderInterface;
 use Magento\Sales\Api\Data\OrderSearchResultInterface;
 use Magento\Sales\Api\Data\OrderSearchResultInterfaceFactory as SearchResultFactory;
-use Magento\Sales\Model\Order\ShippingAssignmentBuilder;
 use Magento\Sales\Model\ResourceModel\Metadata;
 use Magento\Tax\Api\OrderTaxManagementInterface;
 
@@ -70,8 +69,7 @@ class OrderRepositoryTest extends AbstractAdyenTestCase
         $orderTaxManagementMock = null,
         $paymentAdditionalInfoFactoryMock = null,
         $serializerMock = null,
-        $extensionAttributesJoinProcessorMock = null,
-        $shippingAssignmentBuilderMock = null
+        $extensionAttributesJoinProcessorMock = null
     ): OrderRepository {
         if (is_null($searchCriteriaBuilderMock)) {
             $searchCriteriaBuilderMock = $this->createMock(SearchCriteriaBuilder::class);
@@ -117,10 +115,6 @@ class OrderRepositoryTest extends AbstractAdyenTestCase
             $extensionAttributesJoinProcessorMock = $this->createMock(JoinProcessorInterface::class);
         }
 
-        if (is_null($shippingAssignmentBuilderMock)) {
-            $shippingAssignmentBuilderMock = $this->createMock(ShippingAssignmentBuilder::class);
-        }
-
         $orderRepositoryPartialMock = $this->getMockBuilder(OrderRepository::class)
             ->setMethods(['getList'])
             ->setConstructorArgs([
@@ -134,8 +128,7 @@ class OrderRepositoryTest extends AbstractAdyenTestCase
                 $orderTaxManagementMock,
                 $paymentAdditionalInfoFactoryMock,
                 $serializerMock,
-                $extensionAttributesJoinProcessorMock,
-                $shippingAssignmentBuilderMock
+                $extensionAttributesJoinProcessorMock
             ])
             ->getMock();
 

--- a/Test/Unit/Model/Sales/OrderRepositoryTest.php
+++ b/Test/Unit/Model/Sales/OrderRepositoryTest.php
@@ -27,6 +27,7 @@ use Magento\Sales\Api\Data\OrderExtensionFactory;
 use Magento\Sales\Api\Data\OrderInterface;
 use Magento\Sales\Api\Data\OrderSearchResultInterface;
 use Magento\Sales\Api\Data\OrderSearchResultInterfaceFactory as SearchResultFactory;
+use Magento\Sales\Model\Order\ShippingAssignmentBuilder;
 use Magento\Sales\Model\ResourceModel\Metadata;
 use Magento\Tax\Api\OrderTaxManagementInterface;
 
@@ -69,7 +70,8 @@ class OrderRepositoryTest extends AbstractAdyenTestCase
         $orderTaxManagementMock = null,
         $paymentAdditionalInfoFactoryMock = null,
         $serializerMock = null,
-        $extensionAttributesJoinProcessorMock = null
+        $extensionAttributesJoinProcessorMock = null,
+        $shippingAssignmentBuilderMock = null
     ): OrderRepository {
         if (is_null($searchCriteriaBuilderMock)) {
             $searchCriteriaBuilderMock = $this->createMock(SearchCriteriaBuilder::class);
@@ -115,6 +117,10 @@ class OrderRepositoryTest extends AbstractAdyenTestCase
             $extensionAttributesJoinProcessorMock = $this->createMock(JoinProcessorInterface::class);
         }
 
+        if (is_null($shippingAssignmentBuilderMock)) {
+            $shippingAssignmentBuilderMock = $this->createMock(ShippingAssignmentBuilder::class);
+        }
+
         $orderRepositoryPartialMock = $this->getMockBuilder(OrderRepository::class)
             ->setMethods(['getList'])
             ->setConstructorArgs([
@@ -128,7 +134,8 @@ class OrderRepositoryTest extends AbstractAdyenTestCase
                 $orderTaxManagementMock,
                 $paymentAdditionalInfoFactoryMock,
                 $serializerMock,
-                $extensionAttributesJoinProcessorMock
+                $extensionAttributesJoinProcessorMock,
+                $shippingAssignmentBuilderMock
             ])
             ->getMock();
 


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Missing default value for the constructor argument has been added to pass during the unit tests.

`$shippingAssignmentBuilder` argument has been added to the constructor of Magento's [OrderRepository](https://github.com/magento/magento2/blob/fcebd3a4ad2a6863af2e2092f5e548cbd81cb0f8/app/code/Magento/Sales/Model/OrderRepository.php#L108) class. This addition breaks the unit tests on version 2.4.7 and above since the constructor is trying to use `ObjectManager` which is not initiated on the test pipeline.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- Unit tests