### PR TITLE
[ECP-9111] Fix multishipping failed if only one payment method is activated

### DIFF
--- a/view/frontend/templates/checkout/multishipping/billing.phtml
+++ b/view/frontend/templates/checkout/multishipping/billing.phtml
@@ -106,11 +106,7 @@
                                                    data-bind="
                                                        value: getCode(),
                                                        checked: isChecked,
-                                                       click: selectPaymentMethod,
                                                        visible: isRadioButtonVisible()"
-                                                <?php if ($checked): ?>
-                                                    checked="checked"
-                                                <?php endif; ?>
                                                    class="radio"/>
                                         <?php else: ?>
                                             <input type="radio"
@@ -118,8 +114,7 @@
                                                    value="<?= $block->escapeHtml($code); ?>"
                                                    name="payment[method]"
                                                    data-bind="
-                                                       value: getCode(),
-                                                       afterRender: selectPaymentMethod"
+                                                       value: getCode()"
                                                    checked="checked"
                                                    class="radio solo method" />
                                         <?php endif; ?>

--- a/view/frontend/web/template/payment/multishipping/cc-form.html
+++ b/view/frontend/web/template/payment/multishipping/cc-form.html
@@ -1,1 +1,4 @@
-<div id="cardContainer"></div>
+<div class="field number cardContainerField">
+    <div class="checkout-component-dock" afterRender="selectPaymentMethod()" data-bind="attr: { id: 'cardContainer'}">
+    </div>
+</div>


### PR DESCRIPTION
**Description**
The issue this PR is solving is that it is not possible to complete the payment in multishipping checkout if only one payment method is enabled in Adyen Customer Area. This is solved by including a nested div with a custom data attribute and an afterRender binding to trigger `selectPaymentMethod()`.

**Tested scenarios**
- card / alternative payment method multishipping payment when only one payment method is enabled in Adyen CA
- card / alternative payment method multishipping payment when multiple payment methods are enabled in Adyen CA
