### PR TITLE
[ECP-9172] Solving Full Capture for Partial Payments

### DIFF
--- a/Gateway/Http/Client/TransactionCapture.php
+++ b/Gateway/Http/Client/TransactionCapture.php
@@ -80,6 +80,7 @@ class TransactionCapture implements ClientInterface
     private function placeMultipleCaptureRequests($service, $requestContainer, $requestOptions): array
     {
         $response = [];
+        $headers = $requestContainer->getHeaders();
         foreach ($requestContainer[self::MULTIPLE_AUTHORIZATIONS] as $request) {
             $idempotencyKey = $this->idempotencyHelper->generateIdempotencyKey(
                 $request,

--- a/Gateway/Http/Client/TransactionCapture.php
+++ b/Gateway/Http/Client/TransactionCapture.php
@@ -51,16 +51,17 @@ class TransactionCapture implements ClientInterface
         $client = $this->adyenHelper->initializeAdyenClientWithClientConfig($clientConfig);
         $service = $this->adyenHelper->createAdyenCheckoutService($client);
 
-        $idempotencyKey = $this->idempotencyHelper->generateIdempotencyKey(
-            $request,
-            $headers['idempotencyExtraData'] ?? null
-        );
-
-        $requestOptions['idempotencyKey'] = $idempotencyKey;
         $requestOptions['headers'] = $this->adyenHelper->buildRequestHeaders();
 
         if (array_key_exists(self::MULTIPLE_AUTHORIZATIONS, $request)) {
             return $this->placeMultipleCaptureRequests($service, $request, $requestOptions);
+        }
+        else {
+            $idempotencyKey = $this->idempotencyHelper->generateIdempotencyKey(
+                $request,
+                $headers['idempotencyExtraData'] ?? null
+            );
+            $requestOptions['idempotencyKey'] = $idempotencyKey;
         }
 
         $this->adyenHelper->logRequest($request, Client::API_CHECKOUT_VERSION, '/captures');
@@ -80,15 +81,20 @@ class TransactionCapture implements ClientInterface
     {
         $response = [];
         foreach ($requestContainer[self::MULTIPLE_AUTHORIZATIONS] as $request) {
+            $idempotencyKey = $this->idempotencyHelper->generateIdempotencyKey(
+                $request,
+                $headers['idempotencyExtraData'] ?? null
+            );
+            $requestOptions['idempotencyKey'] = $idempotencyKey;
             try {
                 // Copy merchant account from parent array to every request array
                 $request[Requests::MERCHANT_ACCOUNT] = $requestContainer[Requests::MERCHANT_ACCOUNT];
                 $singleResponse = $service->captures($request, $requestOptions);
                 $singleResponse[self::FORMATTED_CAPTURE_AMOUNT] = $request['amount']['currency'] . ' ' .
-                $this->adyenHelper->originalAmount(
-                    $request['amount']['value'],
-                    $request['amount']['currency']
-                );
+                    $this->adyenHelper->originalAmount(
+                        $request['amount']['value'],
+                        $request['amount']['currency']
+                    );
                 $singleResponse = $this->copyParamsToResponse($singleResponse, $request);
                 $response[self::MULTIPLE_AUTHORIZATIONS][] = $singleResponse;
             } catch (AdyenException $e) {

--- a/Gateway/Http/Client/TransactionCapture.php
+++ b/Gateway/Http/Client/TransactionCapture.php
@@ -80,12 +80,14 @@ class TransactionCapture implements ClientInterface
     private function placeMultipleCaptureRequests($service, $requestContainer, $requestOptions): array
     {
         $response = [];
-        $headers = $requestContainer->getHeaders();
         foreach ($requestContainer[self::MULTIPLE_AUTHORIZATIONS] as $request) {
+            $idempotencyKeyExtraData = $request['idempotencyExtraData'];
+            unset($request['idempotencyExtraData']);
             $idempotencyKey = $this->idempotencyHelper->generateIdempotencyKey(
                 $request,
-                $headers['idempotencyExtraData'] ?? null
+                $idempotencyKeyExtraData ?? null
             );
+
             $requestOptions['idempotencyKey'] = $idempotencyKey;
             try {
                 // Copy merchant account from parent array to every request array

--- a/Gateway/Request/CaptureDataBuilder.php
+++ b/Gateway/Request/CaptureDataBuilder.php
@@ -188,6 +188,10 @@ class CaptureDataBuilder implements BuilderInterface
                     $openInvoiceFields = $this->openInvoiceHelper->getOpenInvoiceDataForInvoice($invoice);
                     $authToCapture = array_merge($authToCapture, $openInvoiceFields);
                 }
+                $authToCapture['idempotencyExtraData'] = [
+                    'totalInvoiced' => $adyenOrderPayment[OrderPaymentInterface::TOTAL_CAPTURED] ?? 0,
+                    'originalPspReference' => $adyenOrderPayment[OrderPaymentInterface::PSPREFRENCE]
+            ] ;
 
                 $captureData[] = $authToCapture;
             }
@@ -200,11 +204,6 @@ class CaptureDataBuilder implements BuilderInterface
 
         $request['body'] = $requestBody;
         $request['clientConfig'] = ["storeId" => $payment->getOrder()->getStoreId()];
-        $request['headers'] = [
-            'idempotencyExtraData' => [
-                'totalInvoiced' => $payment->getOrder()->getTotalInvoiced() ?? 0
-            ]
-        ];
 
         return $request;
     }

--- a/Test/Unit/Gateway/Request/CaptureDataBuilderTest.php
+++ b/Test/Unit/Gateway/Request/CaptureDataBuilderTest.php
@@ -144,7 +144,7 @@ class CaptureDataBuilderTest extends AbstractAdyenTestCase
 
         $this->assertArrayHasKey('body', $request);
         $this->assertArrayHasKey('clientConfig', $request);
-        $this->assertArrayHasKey('headers', $request);
+        //$this->assertArrayHasKey('headers', $request);
 
         if (count($adyenOrderPayments) > 1) {
             $this->assertArrayHasKey(TransactionCapture::MULTIPLE_AUTHORIZATIONS, $request['body']);

--- a/Test/Unit/Gateway/Request/CaptureDataBuilderTest.php
+++ b/Test/Unit/Gateway/Request/CaptureDataBuilderTest.php
@@ -144,7 +144,6 @@ class CaptureDataBuilderTest extends AbstractAdyenTestCase
 
         $this->assertArrayHasKey('body', $request);
         $this->assertArrayHasKey('clientConfig', $request);
-        //$this->assertArrayHasKey('headers', $request);
 
         if (count($adyenOrderPayments) > 1) {
             $this->assertArrayHasKey(TransactionCapture::MULTIPLE_AUTHORIZATIONS, $request['body']);


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
With current implementation, there were no capture requests being sent for partial payments. The reason was idempotency key was not being sent correctly for all the partial payments and therefore we were receiving the last payment method captures only. This PR solves the issue by sending correct idempotency key for all the payment methods.

<!-- Please provide a description of the changes proposed in the Pull Request -->

**Tested scenarios**
Single Giftcard, multiple giftcards, single CC, giftcard+creditcard
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

Fixes  <!-- #-prefixed github issue number -->
