### PR TITLE
[ECP-9092] - Remove redundant loadCheckoutComponent call on initialization to rely on observer updates

### DIFF
--- a/Test/Unit/Model/Config/Backend/DonationAmountsTest.php
+++ b/Test/Unit/Model/Config/Backend/DonationAmountsTest.php
@@ -52,7 +52,7 @@ class DonationAmountsTest extends \PHPUnit\Framework\TestCase
     public function testValidateDonationAmounts($donationAmounts, $expectedResult)
     {
         $result = $this->donationAmounts->validateDonationAmounts(explode(',', $donationAmounts));
-        $this->assertEquals($result, $expectedResult);
+        $this->assertEquals($expectedResult, $result);
     }
 
     public static function donationAmountsProvider()

--- a/view/frontend/web/js/view/payment/method-renderer/adyen-cc-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-cc-method.js
@@ -87,7 +87,6 @@ define(
                         self.loadCheckoutComponent(paymentMethodsResponse)
                     });
 
-                self.loadCheckoutComponent(paymentMethodsObserver());
                 return this;
             },
             loadCheckoutComponent: async function (paymentMethodsResponse) {

--- a/view/frontend/web/js/view/payment/method-renderer/adyen-hpp-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-hpp-method.js
@@ -98,7 +98,6 @@ define(
                         self.loadAdyenPaymentMethods(paymentMethodsResponse);
                     });
 
-                self.loadAdyenPaymentMethods(paymentMethodsObserver());
             },
             loadAdyenPaymentMethods: async function (paymentMethodsResponse) {
                 var self = this;


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->


**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->

This commit removes the immediate invocation of `loadCheckoutComponent` during the module initialization.  The component will now rely solely on the observer's updates to trigger this function.

**Tested scenarios**
<!-- Description of tested scenarios -->
Tested the checkout process using both HPP and  CC PMs. 

<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

Fixes  <!-- #-prefixed github issue number -->
