### PR TITLE
add optional quoteId to getShopperReference to allow tokenization for…

### DIFF
--- a/Gateway/Request/AdditionalDataLevel23DataBuilder.php
+++ b/Gateway/Request/AdditionalDataLevel23DataBuilder.php
@@ -72,7 +72,7 @@ class AdditionalDataLevel23DataBuilder implements BuilderInterface
 
             $prefix = 'enhancedSchemeData';
             $requestBody['additionalData'][$prefix . '.totalTaxAmount'] = $this->adyenHelper->formatAmount($order->getTaxAmount(), $currencyCode);
-            $requestBody['additionalData'][$prefix . '.customerReference'] = $this->adyenRequestHelper->getShopperReference($order->getCustomerId(), $order->getIncrementId());
+            $requestBody['additionalData'][$prefix . '.customerReference'] = $this->adyenRequestHelper->getShopperReference($order->getCustomerId(), $order->getIncrementId(), $payment->getOrder()->getQuoteId());
             if ($order->getIsNotVirtual()) {
                 $requestBody['additionalData'][$prefix . '.freightAmount'] = $this->adyenHelper->formatAmount($order->getBaseShippingAmount(), $currencyCode);
                 $requestBody['additionalData'][$prefix . '.destinationPostalCode'] = $order->getShippingAddress()->getPostcode();

--- a/Helper/Requests.php
+++ b/Helper/Requests.php
@@ -86,7 +86,7 @@ class Requests extends AbstractHelper
         $additionalData = null,
         $request = []
     ) {
-        $request['shopperReference'] = $this->getShopperReference($customerId, $payment->getOrder()->getIncrementId());
+        $request['shopperReference'] = $this->getShopperReference($customerId, $payment->getOrder()->getIncrementId(), $payment->getOrder()->getQuoteId());
 
         // In case of virtual product and guest checkout there is a workaround to get the guest's email address
         if (!empty($additionalData['guestEmail'])) {
@@ -417,13 +417,12 @@ class Requests extends AbstractHelper
      * @param string $orderIncrementId
      * @return string
      */
-    public function getShopperReference($customerId, $orderIncrementId): string
+    public function getShopperReference($customerId, $orderIncrementId, $quoteId): string
     {
         if ($customerId) {
             $shopperReference = $this->adyenHelper->padShopperReference($customerId);
         } else {
-            $uuid = Uuid::generateV4();
-            $guestCustomerId = $orderIncrementId . $uuid;
+            $guestCustomerId = $quoteId ? "guest-cart" . quoteId : orderIncrementId . Uuid::generateV4();
             $shopperReference = $guestCustomerId;
         }
 

--- a/Helper/Requests.php
+++ b/Helper/Requests.php
@@ -422,7 +422,7 @@ class Requests extends AbstractHelper
         if ($customerId) {
             $shopperReference = $this->adyenHelper->padShopperReference($customerId);
         } else {
-            $guestCustomerId = $quoteId ? "guest-cart" . quoteId : orderIncrementId . Uuid::generateV4();
+            $guestCustomerId = $quoteId ? "guest-cart" . $quoteId : $orderIncrementId . Uuid::generateV4();
             $shopperReference = $guestCustomerId;
         }
 

--- a/Plugin/PaymentVaultDeleteToken.php
+++ b/Plugin/PaymentVaultDeleteToken.php
@@ -94,7 +94,7 @@ class PaymentVaultDeleteToken
                 $paymentToken->getPaymentMethodCode()
             ),
             Requests::SHOPPER_REFERENCE =>
-                $this->requestsHelper->getShopperReference($paymentToken->getCustomerId(), null),
+                $this->requestsHelper->getShopperReference($paymentToken->getCustomerId(), null, null),
             Requests::RECURRING_DETAIL_REFERENCE => $paymentToken->getGatewayToken()
         ];
     }

--- a/Test/Unit/Gateway/Request/AdditionalDataLevel23DataBuilderTest.php
+++ b/Test/Unit/Gateway/Request/AdditionalDataLevel23DataBuilderTest.php
@@ -181,6 +181,53 @@ class AdditionalDataLevel23DataBuilderTest extends AbstractAdyenTestCase
         $this->assertEquals($expectedResult, $result);
     }
 
+    public function testVirtualOrderGuest()
+    {
+        $storeId = 1;
+        $quoteId = 123;
+        $currencyCode = 'USD';
+        $customerId = null;
+        $orderIncrementId = '000000123';
+        $shopperReference = 'guest-cart-123';
+        $taxAmount = 10.00;
+        $formattedTaxAmount = '1000';
+
+        $this->storeMock->method('getId')->willReturn($storeId);
+        $this->configMock->method('sendLevel23AdditionalData')->with($storeId)->willReturn(true);
+        $this->chargedCurrencyMock->method('getOrderAmountCurrency')->willReturn(new AdyenAmountCurrency(null, $currencyCode));
+        $this->adyenHelperMock->method('formatAmount')->willReturn($formattedTaxAmount);
+        $this->adyenRequestHelperMock->method('getShopperReference')->with(null, $orderIncrementId, $quoteId)->willReturn($shopperReference);
+
+        $orderMock = $this->createConfiguredMock(Order::class, [
+            'getCustomerId' => $customerId,
+            'getIncrementId' => $orderIncrementId,
+            'getTaxAmount' => $taxAmount,
+            'getItems' => [],
+            'getIsNotVirtual' => false,
+            'getShippingAddress' => null,
+            'getBaseShippingAmount' => 0.00,
+            'getQuoteId' => '123'
+        ]);
+
+        $orderAdapterMock = $this->createMock(OrderAdapterInterface::class);
+        $paymentMock = $this->createMock(Payment::class);
+        $paymentMock->method('getOrder')->willReturn($orderMock);
+        $paymentDataObject = new PaymentDataObject($orderAdapterMock, $paymentMock);
+        $buildSubject = ['payment' => $paymentDataObject, 'order' => $orderMock];
+        $result = $this->additionalDataBuilder->build($buildSubject);
+
+        $expectedResult = [
+            'body' => [
+                'additionalData' => [
+                    'enhancedSchemeData.totalTaxAmount' => '1000',
+                    'enhancedSchemeData.customerReference' => $shopperReference
+                ]
+            ]
+        ];
+
+        $this->assertEquals($expectedResult, $result);
+    }
+
     public function testNonVirtualOrder()
     {
         $storeId = 1;


### PR DESCRIPTION
**Description**
This PR addresses #2607 and adds a way to link guest-carts to a predictable but unique shopperReference (guest-cart prefix plus the cartId). If the `quoteId` is missing, it falls back to the old `uuid` behavior.

In the above Github issue, I outlined a few possible solutions to our issue. I believe this is the "least invasive" way to achieve our goals.

**Tested scenarios**
Extended existing unit testing strategy for `getShopperReference`

#2607 