### PR TITLE
Fix #2619 Parse error: syntax error, unexpected ')', expecting variab…

### DIFF
--- a/Helper/Webhook/WebhookHandlerFactory.php
+++ b/Helper/Webhook/WebhookHandlerFactory.php
@@ -58,7 +58,7 @@ class WebhookHandlerFactory
         RequestForInformationWebhookHandler $requestForInformationWebhookHandler,
         ChargebackReversedWebhookHandler $chargebackReversedWebhookHandler,
         SecondChargebackWebhookHandler $secondChargebackWebhookHandler,
-        NotificationOfChargebackWebhookHandler $notificationOfChargebackWebhookHandler,
+        NotificationOfChargebackWebhookHandler $notificationOfChargebackWebhookHandler
     ) {
         $this->adyenLogger = $adyenLogger;
         $this->authorisationWebhookHandler = $authorisationWebhookHandler;


### PR DESCRIPTION
…le (T_VARIABLE) in app/code/Adyen/Payment/Helper/Webhook/WebhookHandlerFactory.php on line 62

<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
- Possibly fix for https://github.com/Adyen/adyen-magento2/issues/2619


**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- Run `setup:di:compile` without any problem.
- Unit tests are passing

Fixes https://github.com/Adyen/adyen-magento2/issues/2619