### PR TITLE
Revert removing details array from graphql schema

### DIFF
--- a/etc/schema.graphqls
+++ b/etc/schema.graphqls
@@ -80,6 +80,7 @@ type AdyenPaymentMethodsArray {
     brand: String @doc(description: "Brand for the selected gift card. For example: plastix, hmclub.")
     brands: [String] @doc(description: "List of possible brands. For example: visa, mc.")
     configuration: AdyenPaymentMethodsConfiguration @doc(description: "The configuration of the payment method.")
+    details: [AdyenPaymentMethodsDetails] @deprecated(reason: "This field will be removed in the next major version following the deprecation in the Checkout API.") @doc(description: "All input details to be provided to complete the payment with this payment method.")
     issuers: [AdyenPaymentMethodsIssuers] @doc(description: "Payment method issuer list.")
 }
 


### PR DESCRIPTION
**Description**
Adhering to semantic versioning principles, this PR re-adds the details filed in AdyenPaymentMethodsArray GraphQL schema adding the `@deprecated` tag. The filed will be removed in the next major version.

Fixes  #2663 
