### PR TITLE
Update headless docs page link

### DIFF
--- a/etc/adminhtml/system/adyen_online_checkout.xml
+++ b/etc/adminhtml/system/adyen_online_checkout.xml
@@ -35,7 +35,7 @@
         <group id="adyen_headless_integration" translate="label" type="text" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1">
             <label><![CDATA[Headless integration]]></label>
             <frontend_model>Magento\Config\Block\System\Config\Form\Fieldset</frontend_model>
-            <comment><![CDATA[<p>With headless integration, you can build your front end using Adyen’s pre-configured back end.<br><a href="https://docs-admin.is.adyen.com/plugins/magento-2/magento-headless-integration" target="_blank">Learn more about headless integration</a></p>]]></comment>
+            <comment><![CDATA[<p>With headless integration, you can build your front end using Adyen’s pre-configured back end.<br><a href="https://docs.adyen.com/plugins/adobe-commerce/headless-integration" target="_blank">Learn more about headless integration</a></p>]]></comment>
             <field id="payments_origin_url" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Payment Origin URL</label>
                 <tooltip>Only relevant if you process payments from an external URL different to that of Magento</tooltip>


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
The headless integration docs page URL in the plugin configuration page is not accessible to the public. The link contains `docs-admin.is.adyen.com`. This PR updates the URL with the correct docs page link.

<img width="996" alt="Screenshot 2024-07-17 at 13 13 26" src="https://github.com/user-attachments/assets/aa889e60-2bad-474f-8815-f7356aaf8b9c">
