### PR TITLE
[ECP-9375v8] Ensure compliance with the new Visa Secure Authentication requirements for Magento2 plugin v8

### DIFF
--- a/Gateway/Request/RecurringVaultDataBuilder.php
+++ b/Gateway/Request/RecurringVaultDataBuilder.php
@@ -78,10 +78,12 @@ class RecurringVaultDataBuilder implements BuilderInterface
         /*
          * allow3DS flag is required to trigger the native 3DS challenge.
          * Otherwise, shopper will be redirected to the issuer for challenge.
+         * Due to new VISA compliance requirements, holderName is added to the payments call
          */
         if ($paymentMethod->getCode() === AdyenCcConfigProvider::CC_VAULT_CODE ||
             $paymentMethod->getCode() === AdyenOneclickConfigProvider::CODE) {
             $requestBody['additionalData']['allow3DS2'] = true;
+            $requestBody['paymentMethod']['holderName'] = $details['cardHolderName'] ?? null;
         }
 
         $request['body'] = $requestBody;

--- a/Helper/Vault.php
+++ b/Helper/Vault.php
@@ -36,6 +36,7 @@ use Magento\Vault\Model\PaymentTokenManagement;
 class Vault
 {
     const RECURRING_DETAIL_REFERENCE = 'recurring.recurringDetailReference';
+    const CARDHOLDER_NAME= 'cardHolderName';
     const CARD_SUMMARY = 'cardSummary';
     const EXPIRY_DATE = 'expiryDate';
     const PAYMENT_METHOD = 'paymentMethod';
@@ -393,6 +394,10 @@ class Vault
 
         if (isset($recurringModel)) {
             $details[self::TOKEN_TYPE] = $recurringModel;
+            // Set token cardHolderName for new Visa compliance requirements
+            if ($additionalData[self::CARDHOLDER_NAME] !== null) {
+                $details[self::CARDHOLDER_NAME] = $additionalData[self::CARDHOLDER_NAME];
+            }
         }
 
         $paymentToken->setTokenDetails(json_encode($details));


### PR DESCRIPTION
**Description**
Following the updates to the required fields for Visa Secure Authentication coming into effect on [12th of August 2024](https://help.adyen.com/updates/visa-secure-authentication-data-field-mandate-of-required-data-fields), it has been identified that the holderName field, which is currently optional for card payments in the Magento 2 plugin, needs to be made mandatory. This change is necessary to ensure compliance with the new Visa requirements. This contribution is backwards compatible.

This PR introduces the following:
- extracts the `cardHolderName` field from the response to the `/payments` call
- stores the value in `details` field of `vault_payment_token` table
- passes the value into the `paymentMethod.holderName` field of recurring `/payment` call

**Important**
Additional configuration in Adobe Commerce admin panel and Adyen Customer Area is required:
* enable the holder name required field in admin panel (`Stores >> Configuration >> Sales >> Payment Methods >> Advanced settings >> Checkout Experience >> Holder name required >> Yes`, `Stores >> Configuration >> Sales >> Payment Methods >> Advanced settings >> Checkout Experience >> Show holder name field for card payment methods >> Yes`)
* enable `Cardholder name field in CA` -> `Developers >> Additional data >> Card >> enable Cardholder name`

**Tested scenarios**
- tested with non-3DS  Visa card
- tested with 3DS Visa card
- tested a recurring payment with stored 3DS and non-3DS Visa cards
