### PR TITLE
[ECP-9162] Submitting `transactionLimit` value in `/payments` request instead of `balance` value

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/adyen-giftcard-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-giftcard-method.js
@@ -213,9 +213,16 @@ define(
             handleBalanceResult: function (balanceResponse, stateData, resolve) {
                 let self = this;
 
-                let consumableBalance = balanceResponse.transactionLimit ?
-                    balanceResponse.transactionLimit :
-                    balanceResponse.balance;
+                let consumableBalance;
+                if (balanceResponse.transactionLimit && balanceResponse.transactionLimit.value) {
+                    if (balanceResponse.transactionLimit.value <= balanceResponse.balance.value) {
+                        consumableBalance = balanceResponse.transactionLimit;
+                    } else {
+                        consumableBalance = balanceResponse.balance;
+                    }
+                } else {
+                    consumableBalance = balanceResponse.balance;
+                }
 
                 let orderAmount = currencyHelper.formatAmount(
                     quote.totals().grand_total,


### PR DESCRIPTION
**Description**
In cases, where the `transactionLimit` object is present in the response of the `/balance` endpoint and the balance of the giftcard is lower than the allowed transaction limit of the country, our plugin submits the value of the `transactionLimit` object instead of the `balance` object as the consumable balance of the giftcard, to the `/payments` request. This PR adds a check for validating the amount of `transactionLimit` compared to `balance` for the cases where `transactionLimit` is present in the `/balance` response. 

**Tested scenarios**
- giftcard balance > allowed transaction limit, transactionLimit present in /balance response
- giftcard balance < allowed transaction limit, transactionLimit present in /balance response
- giftcard balance < allowed transaction limit, transactionLimit not present in /balance response
- giftcard balance > allowed transaction limit, transactionLimit not present in /balance response
