### PR TITLE
[ECP-9171] Add the merchant reference check in the paymentResponseHandler

### DIFF
--- a/Helper/PaymentResponseHandler.php
+++ b/Helper/PaymentResponseHandler.php
@@ -168,7 +168,7 @@ class PaymentResponseHandler
             return false;
         }
 
-        if(!$this->isValidMerchantReference($paymentDetailsResponse, $order)) {
+        if(!$this->isValidMerchantReference($paymentsResponse, $order)) {
             $order->setState(\Magento\Sales\Model\Order::STATE_NEW);
             $order->save();
             $order->setActionFlag(\Magento\Sales\Model\Order::ACTION_FLAG_CANCEL, true);
@@ -317,9 +317,9 @@ class PaymentResponseHandler
         return true;
     }
 
-    private function isValidMerchantReference($paymentDetailsResponse, $order)
+    private function isValidMerchantReference($paymentsResponse, $order)
     {
-        $merchantReference = $paymentDetailsResponse['merchantReference'] ?? null;
+        $merchantReference = $paymentsResponse['merchantReference'] ?? null;
         if(!$merchantReference) {
             $this->adyenLogger->error("No merchantReference in the response");
             return false;

--- a/Helper/PaymentResponseHandler.php
+++ b/Helper/PaymentResponseHandler.php
@@ -168,6 +168,18 @@ class PaymentResponseHandler
             return false;
         }
 
+        if(!$this->isValidMerchantReference($paymentDetailsResponse, $order)) {
+            $order->setState(\Magento\Sales\Model\Order::STATE_NEW);
+            $order->save();
+            $order->setActionFlag(\Magento\Sales\Model\Order::ACTION_FLAG_CANCEL, true);
+            $this->dataHelper->cancelOrder($order);
+            $order->addStatusHistoryComment(
+                __('Invalid /payment/details response. Order has been cancelled due to potential fraud'),
+                $order->getStatus()
+            )->save();
+            return false;
+        }
+
         if (!empty($paymentsResponse['resultCode'])) {
             $payment->setAdditionalInformation('resultCode', $paymentsResponse['resultCode']);
         }
@@ -302,6 +314,22 @@ class PaymentResponseHandler
 
                 return false;
         }
+        return true;
+    }
+
+    private function isValidMerchantReference($paymentDetailsResponse, $order)
+    {
+        $merchantReference = $paymentDetailsResponse['merchantReference'] ?? null;
+        if(!$merchantReference) {
+            $this->adyenLogger->error("No merchantReference in the response");
+            return false;
+        }
+
+        if ($order->getIncrementId() !== $merchantReference) {
+            $this->adyenLogger->error("Incorrect merchantReference");
+            return false;
+        }
+
         return true;
     }
 }


### PR DESCRIPTION
**Description**
This PR adds the check for merchant reference to make sure that the merchant reference matches the current order id.

**Tested scenarios**
Payment with Ideal and 3DS2 cards with headful
PaymentDetails endpoint response for 3DS2 card on headless

Fixes  <!-- #-prefixed github issue number -->
