### PR TITLE
[ECP-9506] Fix /payments response handling if an exception is thrown

### DIFF
--- a/Gateway/Http/Client/TransactionPayment.php
+++ b/Gateway/Http/Client/TransactionPayment.php
@@ -162,6 +162,11 @@ class TransactionPayment implements ClientInterface
             $this->adyenHelper->logResponse($responseData);
         } catch (AdyenException $e) {
             $this->adyenHelper->logAdyenException($e);
+
+            $responseObj['error'] = $e->getMessage();
+            $responseObj['errorCode'] = $e->getAdyenErrorCode();
+
+            $responseCollection[] = $responseObj;
         }
 
         return $responseCollection;

--- a/Gateway/Validator/CheckoutResponseValidator.php
+++ b/Gateway/Validator/CheckoutResponseValidator.php
@@ -62,6 +62,10 @@ class CheckoutResponseValidator extends AbstractValidator
         // Extract all the payment responses
         $responseCollection = $validationSubject['response'];
         unset($validationSubject['response']);
+
+        // hasOnlyGiftCards is needed later but cannot be processed as a response
+        unset($responseCollection['hasOnlyGiftCards']);
+
         // Assign the remaining items to $commandSubject
         $commandSubject = $validationSubject;
 
@@ -69,8 +73,6 @@ class CheckoutResponseValidator extends AbstractValidator
             throw new ValidatorException(__("No responses were provided"));
         }
 
-        // hasOnlyGiftCards is needed later but cannot be processed as a response
-        unset($responseCollection['hasOnlyGiftCards']);
         foreach ($responseCollection as $thisResponse) {
             $responseSubject = array_merge($commandSubject, ['response' => $thisResponse]);
             $this->validateResponse($responseSubject);
@@ -90,11 +92,12 @@ class CheckoutResponseValidator extends AbstractValidator
 
         $payment->setAdditionalInformation('3dActive', false);
 
-        // validate result
+        // Handle empty result for unexpected cases
         if (empty($response['resultCode'])) {
             $this->handleEmptyResultCode($response);
         }
 
+        // Handle the `/payments` response
         $this->validateResult($response, $payment);
     }
 


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
This PR fixes the `/payments` response handling if an exception is thrown while sending the HTTP request.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- Test a case where Checkout API throws 500 internal error