### PR TITLE
Fix Controller\Index::isResponseAlreadyProcessed() check with empty comment

### DIFF
--- a/Controller/Return/Index.php
+++ b/Controller/Return/Index.php
@@ -208,7 +208,7 @@ class Index extends Action
 
         foreach ($history as $status) {
             $comment = $status->getComment();
-            if (str_contains($comment, $pspReference) !== false) {
+            if (str_contains((string)$comment, $pspReference) !== false) {
                 return true;
             }
         }


### PR DESCRIPTION
**Description**

The PR fix the following error : 

> Deprecated Functionality: str_contains(): Passing null to parameter #1 ($haystack) of type string is deprecated in /Users/ansoumane/www/omega-corporate/vendor/adyen/module-payment/Controller/Return/Index.php on line 213

In some case, the order comment can be null : 

![Capture d’écran du 2024-10-22 10-34-44](https://github.com/user-attachments/assets/071be386-0946-4331-9d33-a81995a90cc9)

Fixes  #2775
