### PR TITLE
Allowing CSP headers for GooglePay

### DIFF
--- a/etc/csp_whitelist.xml
+++ b/etc/csp_whitelist.xml
@@ -4,26 +4,31 @@
         <policy id="script-src">
             <values>
                 <value id="adyen" type="host">*.adyen.com</value>
+                <value id="googlepay" type="host">pay.google.com</value>
             </values>
         </policy>
         <policy id="frame-src">
             <values>
                 <value id="adyen" type="host">*.adyen.com</value>
+                <value id="googlepay" type="host">pay.google.com</value>
             </values>
         </policy>
         <policy id="img-src">
             <values>
                 <value id="adyen" type="host">*.adyen.com</value>
+                <value id="googlepay" type="host">pay.google.com</value>
             </values>
         </policy>
         <policy id="connect-src">
             <values>
                 <value id="adyen" type="host">*.adyen.com</value>
+                <value id="googlepay" type="host">pay.google.com</value>
             </values>
         </policy>
         <policy id="form-action">
             <values>
                 <value id="adyen" type="host">*.adyen.com</value>
+                <value id="googlepay" type="host">pay.google.com</value>
             </values>
         </policy>
     </policies>


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Gpay button is not being displayed on some versions of Magento2 checkout after the security patch release by Magento2  to comply with PCI 4.0 requirements.
More info can be found:
- CSP for Adobe [Here](https://developer.adobe.com/commerce/php/development/security/content-security-policies/)
- Related [Release Notes](https://experienceleague.adobe.com/en/docs/commerce-operations/release/notes/security-patches/2-4-4-patches)
- 
**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

Fixes  <!-- #-prefixed github issue number -->
