### PR TITLE
[ECP-9450] Introduce ref param for pull_request_target event triggered workflows

### DIFF
--- a/.github/workflows/graphql-test.yml
+++ b/.github/workflows/graphql-test.yml
@@ -23,6 +23,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - name: Install Magento
         run: docker compose -f .github/docker-compose.yml run --rm web make magento

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
           fetch-depth: 0
 
       - name: Use PHP ${{ matrix.php-version }}

--- a/.github/workflows/mftf-test.yml
+++ b/.github/workflows/mftf-test.yml
@@ -28,6 +28,8 @@ jobs:
       ADMIN_URLEXT: admin
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - name: Start services
         run: docker compose -f .github/docker-compose.yml -f .github/docker-compose.mftf.yml up -d

--- a/.github/workflows/restapi-test.yml
+++ b/.github/workflows/restapi-test.yml
@@ -23,6 +23,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - name: Install Magento
         run: docker compose -f .github/docker-compose.yml run --rm web make magento


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
This PR introduces a fix to update checked out branch for external contributors. With the new `ref` param, `pull_request_target` event will check out the pull request's branch instead of target branch.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- Workflows should check out pull request's branch instead of `main` if a PR is created by an external contributor.