### PR TITLE
Removing reference to removed Class

### DIFF
--- a/Block/Customer/CardRenderer.php
+++ b/Block/Customer/CardRenderer.php
@@ -13,7 +13,6 @@ namespace Adyen\Payment\Block\Customer;
 
 use Adyen\Payment\Helper\Vault;
 use Adyen\Payment\Model\Ui\AdyenCcConfigProvider;
-use Adyen\Payment\Model\Ui\AdyenHppConfigProvider;
 use Adyen\Payment\Helper\Data;
 use Magento\Framework\View\Element\Template;
 use Magento\Vault\Api\Data\PaymentTokenInterface;

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1790,12 +1790,6 @@
             <argument name="checkoutSession" xsi:type="object">Magento\Checkout\Model\Session\Proxy</argument>
         </arguments>
     </type>
-    <type name="Adyen\Payment\Model\Ui\AdyenHppConfigProvider">
-        <arguments>
-            <argument name="session" xsi:type="object">Magento\Checkout\Model\Session\Proxy</argument>
-            <argument name="customerSession" xsi:type="object">Magento\Customer\Model\Session\Proxy</argument>
-        </arguments>
-    </type>
     <virtualType name="AdyenPaymentAffirmFacade" type="Adyen\Payment\Model\Method\Adapter">
         <arguments>
             <argument name="code" xsi:type="string">adyen_affirm</argument>


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
In the plugin (version 9), the class `Adyen\Payment\Model\Ui\AdyenHppConfigProvider` has been removed, but is still being referenced in the `Adyen/Block/Customer/CardRenderer.php` and defined as a type in the DI configuration (`etc/di.xml`). 

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

Fixes  <!-- #-prefixed github issue number -->
