### PR TITLE
[ECP-9534] Success page displayed if payment is canceled

### DIFF
--- a/Controller/Return/Index.php
+++ b/Controller/Return/Index.php
@@ -152,11 +152,6 @@ class Index extends Action
             // Make paymentsDetails call to validate the payment
             $request["details"] = $redirectResponse;
             $paymentsDetailsResponse = $this->paymentsDetailsHelper->initiatePaymentDetails($order, $request);
-
-            if ($this->isResponseAlreadyProcessed($order, $paymentsDetailsResponse)) {
-                $this->adyenLogger->addAdyenResult('Duplicate response detected. Skipping processing.');
-                return true;
-            }
         } catch (Exception $e) {
             $paymentsDetailsResponse['error'] = $e->getMessage();
         }
@@ -193,27 +188,6 @@ class Index extends Action
         }
 
         return $order;
-    }
-
-    private function isResponseAlreadyProcessed(Order $order, array $paymentsDetailsResponse): bool
-    {
-        $pspReference = $paymentsDetailsResponse['pspReference'] ?? null;
-        $merchantReference = $paymentsDetailsResponse['merchantReference'] ?? null;
-
-        if (!$pspReference || !$merchantReference) {
-            return false;
-        }
-
-        $history = $order->getStatusHistories();
-
-        foreach ($history as $status) {
-            $comment = $status->getComment();
-            if (str_contains($comment, $pspReference) !== false) {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     /**

--- a/Test/Unit/Controller/Return/IndexTest.php
+++ b/Test/Unit/Controller/Return/IndexTest.php
@@ -136,8 +136,7 @@ class IndexTest extends AbstractAdyenTestCase
                 'orderId' => PHP_INT_MAX,
                 'expectedException' => null,
                 'multishipping' => false,
-                'orderStatusHistory' => ['Payment received'],
-                'isDuplicate' => false
+                'orderStatusHistory' => ['Payment received']
             ],
             [
                 'redirectResponse' => [
@@ -154,8 +153,7 @@ class IndexTest extends AbstractAdyenTestCase
                 'orderId' => 'ORDER123',
                 'expectedException' => null,
                 'multishipping' => false,
-                'orderStatusHistory' => ['PSP reference: PSP123456789'],
-                'isDuplicate' => true
+                'orderStatusHistory' => ['PSP reference: PSP123456789']
             ],
         ];
     }
@@ -171,8 +169,7 @@ class IndexTest extends AbstractAdyenTestCase
         $orderId,
         $expectedException,
         $multishipping,
-        $orderStatusHistory,
-        $isDuplicate
+        $orderStatusHistory
     ) {
         // Set up order status history
         $orderStatusHistoryCollectionMock = $this->createMock(OrderStatusHistoryCollection::class);
@@ -209,24 +206,13 @@ class IndexTest extends AbstractAdyenTestCase
         $this->orderEntityMock->method('getIncrementId')->willReturn($orderId);
         $this->paymentsDetailsHelperMock->method('initiatePaymentDetails')
             ->willReturn($paymentsDetailsResponse);
+        $this->adyenLoggerMock->expects($this->once())
+            ->method('addAdyenResult')
+            ->with('Processing redirect response');
+        $this->paymentResponseHandlerMock->expects($this->once())
+            ->method('handlePaymentsDetailsResponse')
+            ->willReturn($responseHandlerResult);
 
-        if ($isDuplicate) {
-            $this->adyenLoggerMock->expects($this->exactly(2))
-                ->method('addAdyenResult')
-                ->withConsecutive(
-                    ['Processing redirect response'],
-                    ['Duplicate response detected. Skipping processing.']
-                );
-            $this->paymentResponseHandlerMock->expects($this->never())
-                ->method('handlePaymentsDetailsResponse');
-        } else {
-            $this->adyenLoggerMock->expects($this->once())
-                ->method('addAdyenResult')
-                ->with('Processing redirect response');
-            $this->paymentResponseHandlerMock->expects($this->once())
-                ->method('handlePaymentsDetailsResponse')
-                ->willReturn($responseHandlerResult);
-        }
 
         $this->indexControllerMock->execute();
     }


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
[isResponseAlreadyProcessed()](https://github.com/Adyen/adyen-magento2/blob/2f2d1241f5257834a471ffbef2d5e0f7ad962cc4/Controller/Return/Index.php#L198) method has been introduces to solve issues related the duplicate /payments/details API calls. However, relying on the order comment history is not a robust solution. Moreover, this solution has a bug reported in the given Github Issue.
The end goal of [ECP-9261](https://youtrack.is.adyen.com/issue/ECP-9261/Merchant-looking-for-Devs-confirmation-to-apply-workaround-Magento-9.2.0-for-orders-updated-wrongly-to-Pending-status-instead-of) (where `isResponseAlreadyProcessed()` was introduced) was preventing order state change after making duplicate `/payments/details` call. This issue has already handled in [this PR](https://github.com/Adyen/adyen-magento2/pull/2709), so we can get rid of `isResponseAlreadyProcessed()`

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

Fixes  <!-- #-prefixed github issue number -->
#2777 
#2775 