### PR TITLE
[ECP-9450-v8] Implement configurable 3DS2 authentication flow

### DIFF
--- a/Gateway/Request/CheckoutDataBuilder.php
+++ b/Gateway/Request/CheckoutDataBuilder.php
@@ -16,6 +16,7 @@ use Adyen\Payment\Helper\Config;
 use Adyen\Payment\Helper\Data;
 use Adyen\Payment\Helper\StateData;
 use Adyen\Payment\Helper\OpenInvoice;
+use Adyen\Payment\Model\Config\Source\ThreeDSFlow;
 use Adyen\Payment\Model\Ui\AdyenBoletoConfigProvider;
 use Adyen\Payment\Model\Ui\AdyenPayByLinkConfigProvider;
 use Adyen\Payment\Observer\AdyenCcDataAssignObserver;
@@ -216,7 +217,8 @@ class CheckoutDataBuilder implements BuilderInterface
             unset($requestBody['installments']);
         }
 
-        $requestBody['additionalData']['allow3DS2'] = true;
+        $requestBody['additionalData']['allow3DS2'] =
+            $this->configHelper->getThreeDSFlow($storeId) === ThreeDSFlow::THREEDS_NATIVE;
 
         if (isset($requestBodyPaymentMethod)) {
             $requestBody['paymentMethod'] = $requestBodyPaymentMethod;

--- a/Gateway/Request/RecurringVaultDataBuilder.php
+++ b/Gateway/Request/RecurringVaultDataBuilder.php
@@ -14,6 +14,7 @@ namespace Adyen\Payment\Gateway\Request;
 use Adyen\Payment\Helper\Config;
 use Adyen\Payment\Helper\StateData;
 use Adyen\Payment\Helper\Vault;
+use Adyen\Payment\Model\Config\Source\ThreeDSFlow;
 use Adyen\Payment\Model\Ui\AdyenCcConfigProvider;
 use Adyen\Payment\Model\Ui\AdyenHppConfigProvider;
 use Adyen\Payment\Model\Ui\AdyenOneclickConfigProvider;
@@ -82,7 +83,8 @@ class RecurringVaultDataBuilder implements BuilderInterface
          */
         if ($paymentMethod->getCode() === AdyenCcConfigProvider::CC_VAULT_CODE ||
             $paymentMethod->getCode() === AdyenOneclickConfigProvider::CODE) {
-            $requestBody['additionalData']['allow3DS2'] = true;
+            $requestBody['additionalData']['allow3DS2'] =
+                $this->configHelper->getThreeDSFlow($order->getStoreId()) === ThreeDSFlow::THREEDS_NATIVE;
             $requestBody['paymentMethod']['holderName'] = $details['cardHolderName'] ?? null;
         }
 

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -50,6 +50,7 @@ class Config
     const XML_CONFIGURATION_MODE = 'configuration_mode';
     const XML_ADYEN_POS_CLOUD = 'adyen_pos_cloud';
     const XML_WEBHOOK_NOTIFICATION_PROCESSOR = 'webhook_notification_processor';
+    const XML_THREEDS_FLOW = 'threeds_flow';
 
     /**
      * @var ScopeConfigInterface
@@ -540,6 +541,21 @@ class Config
         return $this->getConfigData(
             self::XML_CONFIGURATION_MODE,
             self::XML_ADYEN_ABSTRACT_PREFIX,
+            $storeId
+        );
+    }
+
+    /**
+     * Returns the preferred ThreeDS authentication type for card and card vault payments.
+     *
+     * @param int|null $storeId
+     * @return string
+     */
+    public function getThreeDSFlow(int $storeId = null): string
+    {
+        return $this->getConfigData(
+            self::XML_THREEDS_FLOW,
+            self::XML_ADYEN_CC,
             $storeId
         );
     }

--- a/Model/Config/Source/ThreeDSFlow.php
+++ b/Model/Config/Source/ThreeDSFlow.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2024 Adyen N.V. (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\Payment\Model\Config\Source;
+
+use Magento\Framework\Data\OptionSourceInterface;
+
+class ThreeDSFlow implements OptionSourceInterface
+{
+    const THREEDS_NATIVE = 'native';
+    const THREEDS_REDIRECT = 'redirect';
+
+    /**
+     * @return array
+     */
+    public function toOptionArray(): array
+    {
+        return [
+            ['value' => self::THREEDS_NATIVE, 'label' => __('Native 3D Secure 2')],
+            ['value' => self::THREEDS_REDIRECT, 'label' => __('Redirect 3D Secure 2')],
+        ];
+    }
+}

--- a/etc/adminhtml/system/adyen_cc.xml
+++ b/etc/adminhtml/system/adyen_cc.xml
@@ -47,8 +47,13 @@
             <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
             <config_path>payment/adyen_cc/enable_click_to_pay</config_path>
         </field>
+        <field id="threeds_flow" translate="label" type="select" sortOrder="70" showInDefault="1" showInWebsite="1">
+            <label>3D Secure 2 authentication flow</label>
+            <source_model>Adyen\Payment\Model\Config\Source\ThreeDSFlow</source_model>
+            <config_path>payment/adyen_cc/threeds_flow</config_path>
+        </field>
         <group id="adyen_cc_advanced_settings" translate="label" showInDefault="1" showInWebsite="1" showInStore="1"
-               sortOrder="60">
+               sortOrder="80">
             <label>Installments Setup</label>
             <frontend_model>Magento\Config\Block\System\Config\Form\Fieldset</frontend_model>
             <field id="enable_installments" translate="label" type="select" sortOrder="10" showInDefault="1"
@@ -74,7 +79,7 @@
                 <config_path>payment/adyen_cc/installments</config_path>
             </field>
         </group>
-        <group id="adyen_cc_country_specific" translate="label" showInDefault="1" showInWebsite="1" sortOrder="70">
+        <group id="adyen_cc_country_specific" translate="label" showInDefault="1" showInWebsite="1" sortOrder="90">
             <label>Country Specific Settings</label>
             <frontend_model>Magento\Config\Block\System\Config\Form\Fieldset</frontend_model>
             <field id="allowspecific" translate="label" type="allowspecific" sortOrder="10" showInDefault="1"

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -54,6 +54,7 @@
                 <can_cancel>1</can_cancel>
                 <can_authorize_vault>1</can_authorize_vault>
                 <can_capture_vault>1</can_capture_vault>
+                <threeds_flow>native</threeds_flow>
                 <group>adyen</group>
             </adyen_cc>
             <adyen_cc_vault>


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
This pull request introduces a new field to configure native and redirect methods for 3D Secure 2 card payment authentications. 

This has become a necessity after Adobe has introduces strict CSP ruling on payment pages to comply with PCI DSS 4.0 requirements. This requirement enforces our merchants to add all of the 3D Secure 2 domain names to their CSP allowlist. Therefore, this PR enables our merchants to fall back [3D Secure 2 Redirect](https://docs.adyen.com/online-payments/3d-secure/redirect-3ds2/) authentication if they are not able to add domains to their allow lists.

![Screenshot 2024-11-14 at 13 35 14](https://github.com/user-attachments/assets/d2b5616b-fe39-4aac-a1c6-44ed456b83e5)

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- Card payments with 3D Secure 2 with native and redirect flows configured from the plugin configuration.