### PR TITLE
[ECP-9493]ApplePay and GooglePay -Terms & Conditions checkbox validation

### DIFF
--- a/Model/Ui/AdyenGenericConfigProvider.php
+++ b/Model/Ui/AdyenGenericConfigProvider.php
@@ -18,6 +18,7 @@ use Magento\Checkout\Model\ConfigProviderInterface;
 use Magento\Framework\App\RequestInterface;
 use Magento\Framework\UrlInterface;
 use Magento\Store\Model\StoreManagerInterface;
+use Magento\CheckoutAgreements\Model\AgreementsConfigProvider;
 
 class AdyenGenericConfigProvider implements ConfigProviderInterface
 {
@@ -28,6 +29,7 @@ class AdyenGenericConfigProvider implements ConfigProviderInterface
     protected RequestInterface $request;
     protected UrlInterface $url;
     private Config $adyenConfigHelper;
+    private AgreementsConfigProvider $agreementsConfigProvider;
     /**
      * This data member will be passed to the js frontend. It will be used to map the method code (adyen_ideal) to the
      * corresponding txVariant (ideal). The txVariant will then be used to instantiate the component
@@ -45,6 +47,7 @@ class AdyenGenericConfigProvider implements ConfigProviderInterface
         StoreManagerInterface $storeManager,
         RequestInterface $request,
         UrlInterface $url,
+        AgreementsConfigProvider $agreementsConfigProvider,
         array $txVariants = [],
         array $customMethodRenderers = []
     ) {
@@ -53,6 +56,7 @@ class AdyenGenericConfigProvider implements ConfigProviderInterface
         $this->storeManager = $storeManager;
         $this->request = $request;
         $this->url = $url;
+        $this->agreementsConfigProvider = $agreementsConfigProvider;
         $this->txVariants = $txVariants;
         $this->customMethodRenderers = $customMethodRenderers;
     }
@@ -88,6 +92,7 @@ class AdyenGenericConfigProvider implements ConfigProviderInterface
             'checkout/onepage/success',
             ['_secure' => $this->request->isSecure()]
         );
+        $config['payment']['adyen']['agreementsConfig'] = $this->agreementsConfigProvider->getConfig();
 
         return $config;
     }

--- a/view/frontend/web/js/model/adyen-configuration.js
+++ b/view/frontend/web/js/model/adyen-configuration.js
@@ -42,6 +42,9 @@ define(
             getCustomerStreetLinesEnabled: function () {
                 return window.checkoutConfig.payment.customerStreetLinesEnabled;
             },
+            getAgreementsConfig: function () {
+                return window.checkoutConfig.payment.adyen.agreementsConfig;
+            }
         };
     },
 );

--- a/view/frontend/web/js/view/payment/method-renderer/adyen-applepay-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-applepay-method.js
@@ -31,7 +31,7 @@ define(
                         amount: paymentMethodsExtraInfo[paymentMethod.type].configuration.amount
                     }
                 );
-                googlePayConfiguration.onClick = function(resolve,reject) {
+                applePayConfiguration.onClick = function(resolve, reject) {
                     if (self.validate()) {
                         resolve();
                     } else {

--- a/view/frontend/web/js/view/payment/method-renderer/adyen-applepay-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-applepay-method.js
@@ -23,6 +23,7 @@ define(
             },
             buildComponentConfiguration: function (paymentMethod, paymentMethodsExtraInfo) {
                 let baseComponentConfiguration = this._super();
+                let self = this;
                 let applePayConfiguration = Object.assign(baseComponentConfiguration,
                     {
                         showPayButton: true,
@@ -30,6 +31,13 @@ define(
                         amount: paymentMethodsExtraInfo[paymentMethod.type].configuration.amount
                     }
                 );
+                googlePayConfiguration.onClick = function(resolve,reject) {
+                    if (self.validate()) {
+                        resolve();
+                    } else {
+                        reject();
+                    }
+                }
 
                 return applePayConfiguration;
             },

--- a/view/frontend/web/js/view/payment/method-renderer/adyen-googlepay-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-googlepay-method.js
@@ -9,12 +9,16 @@
  */
 define(
     [
+        'jquery',
         'Magento_Checkout/js/model/quote',
         'Adyen_Payment/js/view/payment/method-renderer/adyen-pm-method',
+        'Adyen_Payment/js/model/adyen-configuration',
     ],
-    function(
+    function (
+        $,
         quote,
         adyenPaymentMethod,
+        adyenConfiguration
     ) {
         return adyenPaymentMethod.extend({
             placeOrderButtonVisible: false,
@@ -23,12 +27,20 @@ define(
             },
             buildComponentConfiguration: function (paymentMethod, paymentMethodsExtraInfo) {
                 let baseComponentConfiguration = this._super();
-
+                let self = this;
                 let googlePayConfiguration = Object.assign(baseComponentConfiguration, paymentMethodsExtraInfo[paymentMethod.type].configuration);
+
                 googlePayConfiguration.showPayButton = true;
 
-                return googlePayConfiguration
+                googlePayConfiguration.onClick = function(resolve,reject) {
+                    if (self.validate()) {
+                        resolve();
+                    } else {
+                        reject();
+                    }
+                }
+                return googlePayConfiguration;
             }
-        })
+        });
     }
 );

--- a/view/frontend/web/js/view/payment/method-renderer/adyen-googlepay-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-googlepay-method.js
@@ -9,16 +9,12 @@
  */
 define(
     [
-        'jquery',
         'Magento_Checkout/js/model/quote',
         'Adyen_Payment/js/view/payment/method-renderer/adyen-pm-method',
-        'Adyen_Payment/js/model/adyen-configuration',
     ],
     function (
-        $,
         quote,
-        adyenPaymentMethod,
-        adyenConfiguration
+        adyenPaymentMethod
     ) {
         return adyenPaymentMethod.extend({
             placeOrderButtonVisible: false,
@@ -28,7 +24,10 @@ define(
             buildComponentConfiguration: function (paymentMethod, paymentMethodsExtraInfo) {
                 let baseComponentConfiguration = this._super();
                 let self = this;
-                let googlePayConfiguration = Object.assign(baseComponentConfiguration, paymentMethodsExtraInfo[paymentMethod.type].configuration);
+                let googlePayConfiguration = Object.assign(
+                        baseComponentConfiguration,
+                        paymentMethodsExtraInfo[paymentMethod.type].configuration
+                    );
 
                 googlePayConfiguration.showPayButton = true;
 

--- a/view/frontend/web/js/view/payment/method-renderer/adyen-pm-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-pm-method.js
@@ -149,7 +149,9 @@ define(
             },
 
             handleOnFailure: function(error, component) {
-                this.isPlaceOrderAllowed(true);
+
+                paymentComponentStates().setIsPlaceOrderAllowed(this.getMethodCode(), true);
+
                 fullScreenLoader.stopLoader();
                 errorProcessor.process(error, this.currentMessageContainer);
             },


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
Wallet payment methods such as ApplePay and GooglePay do not trigger the Terms and Conditions checkbox validation. When Terms and Conditions are enabled from Magento configuration, these wallet payment methods bypass the default form validation, as they mount their own "Place Order" buttons.
This PR solves the issue of Validating Terms & Conditions for ApplePay and GooglePay 
<!-- Please provide a description of the changes proposed in the Pull Request -->

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

Fixes  <!-- #-prefixed github issue number -->
