### PR TITLE
[ECP-9476]Updating Paybylink description for Magento Orders

### DIFF
--- a/Gateway/Request/DescriptionDataBuilder.php
+++ b/Gateway/Request/DescriptionDataBuilder.php
@@ -29,13 +29,7 @@ class DescriptionDataBuilder implements BuilderInterface
         $payment = $paymentDataObject->getPayment();
         /** @var Order $order */
         $order = $payment->getOrder();
-
-        $request['body']['description'] = __(
-            'Order %1 from %2',
-            $order->getIncrementId(),
-            $order->getStore()->getGroup()->getName()
-        );
-
+        $request['body']['description'] = 'Order ' . $order->getIncrementId() . ' from ' . $order->getStore()->getGroup()->getName();
         return $request;
     }
 }


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
This PR solves an issue where the description in the pay by link created from Magento admin order is diplaying {} instead of the usual value that used to have `Order XXXXXX00 from Main Website Store` on the payment screen for the customer facing.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

Fixes  <!-- #-prefixed github issue number -->
