### PR TITLE
[ECP-9559] Populate the shopper form fields of Onex 4X, 6X, 10X and 12X

### DIFF
--- a/etc/frontend/di.xml
+++ b/etc/frontend/di.xml
@@ -121,6 +121,10 @@
                 <item name="adyen_applepay" xsi:type="string">Adyen_Payment/js/view/payment/method-renderer/adyen-applepay-method</item>
                 <item name="adyen_boleto" xsi:type="string">Adyen_Payment/js/view/payment/method-renderer/adyen-boleto-method</item>
                 <item name="adyen_facilypay_3x" xsi:type="string">Adyen_Payment/js/view/payment/method-renderer/adyen-facilypay-3x-method</item>
+                <item name="adyen_facilypay_4x" xsi:type="string">Adyen_Payment/js/view/payment/method-renderer/adyen-facilypay-method</item>
+                <item name="adyen_facilypay_6x" xsi:type="string">Adyen_Payment/js/view/payment/method-renderer/adyen-facilypay-method</item>
+                <item name="adyen_facilypay_10x" xsi:type="string">Adyen_Payment/js/view/payment/method-renderer/adyen-facilypay-method</item>
+                <item name="adyen_facilypay_12x" xsi:type="string">Adyen_Payment/js/view/payment/method-renderer/adyen-facilypay-method</item>
                 <item name="adyen_googlepay" xsi:type="string">Adyen_Payment/js/view/payment/method-renderer/adyen-googlepay-method</item>
                 <item name="adyen_paypal" xsi:type="string">Adyen_Payment/js/view/payment/method-renderer/adyen-paypal-method</item>
                 <item name="adyen_giftcard" xsi:type="string">Adyen_Payment/js/view/payment/method-renderer/adyen-giftcard-method</item>

--- a/view/frontend/web/js/view/payment/method-renderer/adyen-facilypay-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-facilypay-method.js
@@ -2,13 +2,10 @@
  *
  * Adyen Payment module (https://www.adyen.com/)
  *
- * Copyright (c) 2023 Adyen NV (https://www.adyen.com/)
+ * Copyright (c) 2024 Adyen N.V. (https://www.adyen.com/)
  * See LICENSE.txt for license details.
  *
  * Author: Adyen <magento@adyen.com>
- *
- * @deprecated This file will be removed on V10. Use `adyen-facilypay-method.js` instead.
- *
  */
 define(
     [
@@ -34,7 +31,6 @@ define(
                 if (!!customerData.dob){
                     shopperDateOfBirth = customerData.dob;
                 }
-
 
                 if (!!customerData.email) {
                     email = customerData.email;


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Oney/Facilypay requires some additional information on the payment method component. However, the majority of this data overlaps with the information that the shopper fills out on shipping information page of the checkout.

Introducing missing custom method renderers modifies the component configuration object and pre-populates the form fields.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- Oney payments happy flow