### PR TITLE
fix: Sort Search Result when fetching Order by Quote ID

### DIFF
--- a/Model/Sales/OrderRepository.php
+++ b/Model/Sales/OrderRepository.php
@@ -16,6 +16,7 @@ use Magento\Framework\Api\FilterBuilder;
 use Magento\Framework\Api\Search\FilterGroupBuilder;
 use Magento\Framework\Api\SearchCriteria\CollectionProcessorInterface;
 use Magento\Framework\Api\SearchCriteriaBuilder;
+use Magento\Framework\Api\SortOrderBuilder;
 use Magento\Framework\Serialize\Serializer\Json as JsonSerializer;
 use Magento\Payment\Api\Data\PaymentAdditionalInfoInterfaceFactory;
 use Magento\Sales\Api\Data\OrderExtensionFactory;
@@ -28,6 +29,7 @@ use Magento\Tax\Api\OrderTaxManagementInterface;
 class OrderRepository extends SalesOrderRepository
 {
     private SearchCriteriaBuilder $searchCriteriaBuilder;
+    private SortOrderBuilder $sortOrderBuilder;
     private FilterBuilder $filterBuilder;
     private FilterGroupBuilder $filterGroupBuilder;
 
@@ -35,6 +37,7 @@ class OrderRepository extends SalesOrderRepository
         SearchCriteriaBuilder $searchCriteriaBuilder,
         FilterBuilder $filterBuilder,
         FilterGroupBuilder $filterGroupBuilder,
+        SortOrderBuilder $sortOrderBuilder,
         Metadata $metadata,
         SearchResultFactory $searchResultFactory,
         CollectionProcessorInterface $collectionProcessor = null,
@@ -56,6 +59,7 @@ class OrderRepository extends SalesOrderRepository
         );
 
         $this->searchCriteriaBuilder = $searchCriteriaBuilder;
+        $this->sortOrderBuilder = $sortOrderBuilder;
         $this->filterBuilder = $filterBuilder;
         $this->filterGroupBuilder = $filterGroupBuilder;
     }
@@ -68,9 +72,13 @@ class OrderRepository extends SalesOrderRepository
             ->create();
 
         $quoteIdFilterGroup = $this->filterGroupBuilder->setFilters([$quoteIdFilter])->create();
+        $sortOrder = $this->sortOrderBuilder->setField('entity_id')
+            ->setDescendingDirection();
 
         $searchCriteria = $this->searchCriteriaBuilder
             ->setFilterGroups([$quoteIdFilterGroup])
+            ->setSortOrders([$sortOrder])
+            ->setPageSize(1)
             ->create();
 
         $orders = $this->getList($searchCriteria)->getItems();


### PR DESCRIPTION
**Description**
Multiple orders might exist for the same Quote. We should be using the most recent Order when dealing with the Payment.

**Tested scenarios**
1. Create a Quote
2. Place the Order using this Quote with POS
3. Reactivate the Quote
4. Place another Order using this Quote with POS

Fixes #2823
