### PR TITLE
[ECP-9580] Fix missing idempotencyExtraData key issue in capture requests

### DIFF
--- a/Gateway/Http/Client/TransactionCapture.php
+++ b/Gateway/Http/Client/TransactionCapture.php
@@ -72,8 +72,6 @@ class TransactionCapture implements ClientInterface
     {
         $request = $transferObject->getBody();
         $headers = $transferObject->getHeaders();
-        $idempotencyKeyExtraData = $headers['idempotencyExtraData'];
-        unset($headers['idempotencyExtraData']);
         $clientConfig = $transferObject->getClientConfig();
 
         $client = $this->adyenHelper->initializeAdyenClientWithClientConfig($clientConfig);
@@ -85,6 +83,9 @@ class TransactionCapture implements ClientInterface
         if (array_key_exists(self::MULTIPLE_AUTHORIZATIONS, $request)) {
             return $this->placeMultipleCaptureRequests($service, $request, $requestOptions);
         }
+
+        $idempotencyKeyExtraData = $request['idempotencyExtraData'];
+        unset($request['idempotencyExtraData']);
 
         $idempotencyKey = $this->idempotencyHelper->generateIdempotencyKey(
             $request,

--- a/Gateway/Request/CaptureDataBuilder.php
+++ b/Gateway/Request/CaptureDataBuilder.php
@@ -109,7 +109,10 @@ class CaptureDataBuilder implements BuilderInterface
         $requestBody = [
             "amount" => $modificationAmount,
             "reference" => $payment->getOrder()->getIncrementId(),
-            "paymentPspReference" => $pspReference
+            "paymentPspReference" => $pspReference,
+            "idempotencyExtraData" => [
+                'totalInvoiced' => $payment->getOrder()->getTotalInvoiced() ?? 0
+            ]
         ];
 
         //Check additionaldata
@@ -119,11 +122,6 @@ class CaptureDataBuilder implements BuilderInterface
         }
         $request['body'] = $requestBody;
         $request['clientConfig'] = ["storeId" => $payment->getOrder()->getStoreId()];
-        $request['headers'] = [
-            'idempotencyExtraData' => [
-                'totalInvoiced' => $payment->getOrder()->getTotalInvoiced() ?? 0
-            ]
-        ];
 
         return $request;
     }

--- a/Test/Unit/Gateway/Http/Client/TransactionCaptureTest.php
+++ b/Test/Unit/Gateway/Http/Client/TransactionCaptureTest.php
@@ -43,11 +43,12 @@ class TransactionCaptureTest extends AbstractAdyenTestCase
             'amount' => ['value' => 100, 'currency' => 'USD'],
             'paymentPspReference' => 'testPspReference',
             'applicationInfo' => $applicationInfo,
+            'idempotencyExtraData' => ['someData']
         ];
 
         $this->transferObject = $this->createConfiguredMock(TransferInterface::class, [
             'getBody' => $this->request,
-            'getHeaders' => ['idempotencyExtraData' => ['someData']],
+            'getHeaders' => [],
             'getClientConfig' => []
         ]);
     }
@@ -63,10 +64,13 @@ class TransactionCaptureTest extends AbstractAdyenTestCase
         $this->adyenHelper->method('buildRequestHeaders')->willReturn([]);
         $this->adyenHelper->expects($this->once())->method('logRequest');
 
+        $trimmedRequest = $this->request;
+        unset($trimmedRequest['idempotencyExtraData']);
+
         $this->idempotencyHelper->expects($this->once())
             ->method('generateIdempotencyKey')
             ->with(
-                $this->request,
+                $trimmedRequest,
                 $this->equalTo(['someData'])
             )
             ->willReturn($expectedIdempotencyKey);


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Missing `idempotencyExtraData` key in multiple capture request header causes array key not found exception in the plugin. In order to fix this issue, `idempotencyExtraData` is set on the request builder and consumed from the correct object in the HTTP client.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- Partial captures
- Single captures
