### PR TITLE
[ECP-9570] Fix broken E2E tests for webhook cases

### DIFF
--- a/.github/Makefile
+++ b/.github/Makefile
@@ -41,7 +41,7 @@ configure: n98-magerun2.phar
 	bin/magento config:set payment/adyen_abstract/merchant_account "${ADYEN_MERCHANT}"
 	bin/magento config:set payment/adyen_abstract/notifications_ip_check 0
 	bin/magento config:set payment/adyen_abstract/payment_authorized 'processing'
-	bin/magento config:set payment/adyen_abstract/payment_pre_authorized 'pending_payment'
+	bin/magento config:set payment/adyen_abstract/payment_pre_authorized 'adyen_authorized'
 	bin/magento config:set payment/adyen_abstract/capture_mode 'manual'
 	bin/magento config:set payment/adyen_abstract/paypal_capture_mode 0
 	bin/magento config:set payment/adyen_abstract/recurring_configuration '{"adyen_cc":{"name":"Cards","enabled":"1","recurringProcessingModel":"CardOnFile"},"adyen_sepadirectdebit":{"name":"SEPA Direct Debit","enabled":"1","recurringProcessingModel":"CardOnFile"}}'


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Configuration value for `pre-authorization` order state has been updated according to manual capture scenarios. 

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- E2E test cases