### PR TITLE
Migrating `allow3DS2` to `nativeThreeDS` on `/payments` request

### DIFF
--- a/Gateway/Request/CheckoutDataBuilder.php
+++ b/Gateway/Request/CheckoutDataBuilder.php
@@ -210,8 +210,9 @@ class CheckoutDataBuilder implements BuilderInterface
             unset($requestBody['installments']);
         }
 
+        $threeDSFlow = $this->configHelper->getThreeDSFlow($order->getStoreId());
         $requestBody['authenticationData']['threeDSRequestData']['nativeThreeDS'] =
-            $this->configHelper->getThreeDSFlow($storeId);
+            $threeDSFlow === 'native' ? 'preferred' : 'disabled';
 
         return [
             'body' => $requestBody

--- a/Gateway/Request/CheckoutDataBuilder.php
+++ b/Gateway/Request/CheckoutDataBuilder.php
@@ -210,8 +210,8 @@ class CheckoutDataBuilder implements BuilderInterface
             unset($requestBody['installments']);
         }
 
-        $requestBody['additionalData']['allow3DS2'] =
-            $this->configHelper->getThreeDSFlow($storeId) === ThreeDSFlow::THREEDS_NATIVE;
+        $requestBody['authenticationData']['threeDSRequestData']['nativeThreeDS'] =
+            $this->configHelper->getThreeDSFlow($storeId);
 
         return [
             'body' => $requestBody

--- a/Gateway/Request/CheckoutDataBuilder.php
+++ b/Gateway/Request/CheckoutDataBuilder.php
@@ -212,7 +212,9 @@ class CheckoutDataBuilder implements BuilderInterface
 
         $threeDSFlow = $this->configHelper->getThreeDSFlow($order->getStoreId());
         $requestBody['authenticationData']['threeDSRequestData']['nativeThreeDS'] =
-            $threeDSFlow === 'native' ? 'preferred' : 'disabled';
+            $threeDSFlow === ThreeDSFlow::THREEDS_NATIVE ?
+                ThreeDSFlow::THREEDS_PREFERRED :
+                ThreeDSFlow::THREEDS_DISABLED;
 
         return [
             'body' => $requestBody

--- a/Gateway/Request/RecurringVaultDataBuilder.php
+++ b/Gateway/Request/RecurringVaultDataBuilder.php
@@ -67,8 +67,8 @@ class RecurringVaultDataBuilder implements BuilderInterface
          * Due to new VISA compliance requirements, holderName is added to the payments call
          */
         if ($paymentMethod->getCode() === AdyenCcConfigProvider::CC_VAULT_CODE) {
-            $requestBody['additionalData']['allow3DS2'] =
-                $this->configHelper->getThreeDSFlow($order->getStoreId()) === ThreeDSFlow::THREEDS_NATIVE;
+            $requestBody['authenticationData']['threeDSRequestData']['nativeThreeDS'] =
+                $this->configHelper->getThreeDSFlow($order->getStoreId());
             $requestBody['paymentMethod']['holderName'] = $details['cardHolderName'] ?? null;
         }
 

--- a/Gateway/Request/RecurringVaultDataBuilder.php
+++ b/Gateway/Request/RecurringVaultDataBuilder.php
@@ -65,9 +65,14 @@ class RecurringVaultDataBuilder implements BuilderInterface
                 $requestBody = $this->stateData->getStateData($order->getQuoteId());
             }
 
-        if ($paymentMethod->getCode() === AdyenCcConfigProvider::CC_VAULT_CODE) {
+            /*
+             * `allow3DS: true` flag is required to trigger the native 3DS challenge.
+             * Otherwise, shopper will be redirected to the issuer for challenge.
+             */
             $requestBody['authenticationData']['threeDSRequestData']['nativeThreeDS'] =
                 $this->configHelper->getThreeDSFlow($order->getStoreId());
+
+            // Due to new VISA compliance requirements, holderName is added to the payments call
             $requestBody['paymentMethod']['holderName'] = $details['cardHolderName'] ?? null;
         }  else {
             // Build base request for alternative payment methods for regular checkout and Instant Purchase

--- a/Gateway/Request/RecurringVaultDataBuilder.php
+++ b/Gateway/Request/RecurringVaultDataBuilder.php
@@ -71,7 +71,9 @@ class RecurringVaultDataBuilder implements BuilderInterface
              */
             $threeDSFlow = $this->configHelper->getThreeDSFlow($order->getStoreId());
             $requestBody['authenticationData']['threeDSRequestData']['nativeThreeDS'] =
-                $threeDSFlow === 'native' ? 'preferred' : 'disabled';
+                $threeDSFlow === ThreeDSFlow::THREEDS_NATIVE ?
+                    ThreeDSFlow::THREEDS_PREFERRED :
+                    ThreeDSFlow::THREEDS_DISABLED;
 
             // Due to new VISA compliance requirements, holderName is added to the payments call
             $requestBody['paymentMethod']['holderName'] = $details['cardHolderName'] ?? null;

--- a/Gateway/Request/RecurringVaultDataBuilder.php
+++ b/Gateway/Request/RecurringVaultDataBuilder.php
@@ -69,8 +69,9 @@ class RecurringVaultDataBuilder implements BuilderInterface
              * `allow3DS: true` flag is required to trigger the native 3DS challenge.
              * Otherwise, shopper will be redirected to the issuer for challenge.
              */
+            $threeDSFlow = $this->configHelper->getThreeDSFlow($order->getStoreId());
             $requestBody['authenticationData']['threeDSRequestData']['nativeThreeDS'] =
-                $this->configHelper->getThreeDSFlow($order->getStoreId());
+                $threeDSFlow === 'native' ? 'preferred' : 'disabled';
 
             // Due to new VISA compliance requirements, holderName is added to the payments call
             $requestBody['paymentMethod']['holderName'] = $details['cardHolderName'] ?? null;

--- a/Model/Config/Source/ThreeDSFlow.php
+++ b/Model/Config/Source/ThreeDSFlow.php
@@ -15,8 +15,8 @@ use Magento\Framework\Data\OptionSourceInterface;
 
 class ThreeDSFlow implements OptionSourceInterface
 {
-    const THREEDS_NATIVE = 'native';
-    const THREEDS_REDIRECT = 'redirect';
+    const THREEDS_NATIVE = 'preferred';
+    const THREEDS_REDIRECT = 'disabled';
 
     /**
      * @return array

--- a/Model/Config/Source/ThreeDSFlow.php
+++ b/Model/Config/Source/ThreeDSFlow.php
@@ -17,6 +17,8 @@ class ThreeDSFlow implements OptionSourceInterface
 {
     const THREEDS_NATIVE = 'native';
     const THREEDS_REDIRECT = 'redirect';
+    const THREEDS_PREFERRED = 'preferred';
+    const THREEDS_DISABLED = 'disabled';
 
     /**
      * @return array

--- a/Model/Config/Source/ThreeDSFlow.php
+++ b/Model/Config/Source/ThreeDSFlow.php
@@ -15,8 +15,8 @@ use Magento\Framework\Data\OptionSourceInterface;
 
 class ThreeDSFlow implements OptionSourceInterface
 {
-    const THREEDS_NATIVE = 'preferred';
-    const THREEDS_REDIRECT = 'disabled';
+    const THREEDS_NATIVE = 'native';
+    const THREEDS_REDIRECT = 'redirect';
 
     /**
      * @return array

--- a/Test/Unit/Gateway/Request/CheckoutDataBuilderTest.php
+++ b/Test/Unit/Gateway/Request/CheckoutDataBuilderTest.php
@@ -78,6 +78,6 @@ class CheckoutDataBuilderTest extends AbstractAdyenTestCase
 
         $request = $this->checkoutDataBuilder->build($buildSubject);
 
-        $this->assertTrue($request['body']['additionalData']['allow3DS2']);
+        $this->assertArrayHasKey('nativeThreeDS', $request['body']['authenticationData']['threeDSRequestData']);
     }
 }

--- a/Test/Unit/Gateway/Request/RecurringVaultDataBuilderTest.php
+++ b/Test/Unit/Gateway/Request/RecurringVaultDataBuilderTest.php
@@ -86,7 +86,7 @@ class RecurringVaultDataBuilderTest extends AbstractAdyenTestCase
         $this->assertIsArray($request);
         $this->assertArrayHasKey('recurringProcessingModel', $request['body']);
         if ($expect3dsFlag) {
-            $this->assertArrayHasKey('allow3DS2', $request['body']['additionalData']);
+            $this->assertArrayHasKey('nativeThreeDS', $request['body']['authenticationData']['threeDSRequestData']);
         }
     }
 

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -61,7 +61,7 @@
                 <can_authorize_vault>1</can_authorize_vault>
                 <can_capture_vault>1</can_capture_vault>
                 <supports_recurring>1</supports_recurring>
-                <threeds_flow>preferred</threeds_flow>
+                <threeds_flow>native</threeds_flow>
                 <group>adyen</group>
             </adyen_cc>
             <adyen_cc_vault>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -61,7 +61,7 @@
                 <can_authorize_vault>1</can_authorize_vault>
                 <can_capture_vault>1</can_capture_vault>
                 <supports_recurring>1</supports_recurring>
-                <threeds_flow>native</threeds_flow>
+                <threeds_flow>preferred</threeds_flow>
                 <group>adyen</group>
             </adyen_cc>
             <adyen_cc_vault>


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
As Checkout API has deprecated usage of [allow3DS2](https://docs.adyen.com/api-explorer/Checkout/71/post/payments#request-additionalData-listOfValues-allow3DS2) under additionalData on V69 and recommends using [nativeThreeDS](https://docs.adyen.com/api-explorer/Checkout/71/post/payments#request-authenticationData-threeDSRequestData-nativeThreeDS) flag instead.
This PR introduces the `nativeThreeDS` flag in the Payments request.
<!-- Please provide a description of the changes proposed in the Pull Request -->

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

Fixes  <!-- #-prefixed github issue number -->
