### PR TITLE
[ECP-9480] Setting cc_type value for Carte Bancaire

### DIFF
--- a/Gateway/Response/CheckoutPaymentsDetailsHandler.php
+++ b/Gateway/Response/CheckoutPaymentsDetailsHandler.php
@@ -56,6 +56,15 @@ class CheckoutPaymentsDetailsHandler implements HandlerInterface
             $payment->setCcTransId($response['pspReference']);
             $payment->setLastTransId($response['pspReference']);
 
+            //set CC Type
+            $ccType = $payment->getAdditionalInformation('cc_type');
+
+            if (!empty($response['additionalData']['paymentMethod']) && $ccType == null) {
+                $ccType = $response['additionalData']['paymentMethod'];
+                $payment->setAdditionalInformation('cc_type', $ccType);
+                $payment->setCcType($ccType);
+            }
+
             // set transaction
             $payment->setTransactionId($response['pspReference']);
         }

--- a/Helper/PaymentMethods.php
+++ b/Helper/PaymentMethods.php
@@ -54,6 +54,7 @@ class PaymentMethods extends AbstractHelper
     const ADYEN_ONE_CLICK = 'adyen_oneclick';
     const ADYEN_PAY_BY_LINK = 'adyen_pay_by_link';
     const ADYEN_PREFIX = 'adyen_';
+    const ADYEN_CC_VAULT = 'adyen_cc_vault';
     const METHODS_WITH_BRAND_LOGO = [
         "giftcard"
     ];
@@ -958,7 +959,7 @@ class PaymentMethods extends AbstractHelper
 
         // Returns if the payment method is wallet like wechatpayWeb, amazonpay, applepay, paywithgoogle
         $isWalletPaymentMethod = $this->isWalletPaymentMethod($paymentMethodInstance);
-        $isCardPaymentMethod = $order->getPayment()->getMethod() === 'adyen_cc' || $order->getPayment()->getMethod() === 'adyen_oneclick';
+        $isCardPaymentMethod = $order->getPayment()->getMethod() === self::ADYEN_CC || $order->getPayment()->getMethod() === self::ADYEN_ONE_CLICK;
 
         // If it is a wallet method OR a card OR the methods match exactly, return true
         if ($isWalletPaymentMethod || $isCardPaymentMethod || strcmp($notificationPaymentMethod, $orderPaymentMethod) === 0) {

--- a/Helper/PaymentResponseHandler.php
+++ b/Helper/PaymentResponseHandler.php
@@ -221,9 +221,8 @@ class PaymentResponseHandler
         $ccType = $payment->getAdditionalInformation('cc_type');
 
         if (!empty($paymentsDetailsResponse['additionalData']['paymentMethod']) &&
-            !is_null($ccType) &&
-            $isWalletPaymentMethod &&
-            $isCardPaymentMethod
+            is_null($ccType) &&
+            ($isWalletPaymentMethod || $isCardPaymentMethod)
         ) {
             $ccType = $paymentsDetailsResponse['additionalData']['paymentMethod'];
             $payment->setAdditionalInformation('cc_type', $ccType);

--- a/Helper/PaymentResponseHandler.php
+++ b/Helper/PaymentResponseHandler.php
@@ -12,7 +12,6 @@
 namespace Adyen\Payment\Helper;
 
 use Adyen\Model\Checkout\CancelOrderRequest;
-use Adyen\Payment\Helper\Config;
 use Adyen\Payment\Logger\AdyenLogger;
 use Adyen\Payment\Model\ResourceModel\PaymentResponse\CollectionFactory as PaymentResponseCollectionFactory;
 use Exception;
@@ -24,7 +23,6 @@ use Magento\Sales\Model\Order\Status\HistoryFactory;
 use Magento\Sales\Model\OrderRepository;
 use Magento\Sales\Model\ResourceModel\Order;
 use Magento\Sales\Model\Order as OrderModel;
-use Adyen\Payment\Helper\Data;
 use Magento\Framework\Mail\Exception\InvalidArgumentException;
 use Adyen\Client;
 
@@ -65,6 +63,7 @@ class PaymentResponseHandler
     private StateData $stateDataHelper;
     private PaymentResponseCollectionFactory $paymentResponseCollectionFactory;
     private Config $configHelper;
+    private PaymentMethods $paymentMethodsHelper;
 
     public function __construct(
         AdyenLogger $adyenLogger,
@@ -77,7 +76,8 @@ class PaymentResponseHandler
         HistoryFactory $orderHistoryFactory,
         StateData $stateDataHelper,
         PaymentResponseCollectionFactory $paymentResponseCollectionFactory,
-        Config $configHelper
+        Config $configHelper,
+        PaymentMethods $paymentMethodsHelper
     ) {
         $this->adyenLogger = $adyenLogger;
         $this->vaultHelper = $vaultHelper;
@@ -90,6 +90,7 @@ class PaymentResponseHandler
         $this->stateDataHelper = $stateDataHelper;
         $this->paymentResponseCollectionFactory = $paymentResponseCollectionFactory;
         $this->configHelper = $configHelper;
+        $this->paymentMethodsHelper = $paymentMethodsHelper;
     }
 
     public function formatPaymentResponse(
@@ -159,6 +160,12 @@ class PaymentResponseHandler
         $this->adyenLogger->addAdyenResult('Updating the order');
         $payment = $order->getPayment();
 
+        //Check magento Payment Method
+        $paymentMethodInstance = $payment->getMethodInstance();
+        $isWalletPaymentMethod = $this->paymentMethodsHelper->isWalletPaymentMethod($paymentMethodInstance);
+        $isCardPaymentMethod = $payment->getMethod() === PaymentMethods::ADYEN_CC ||
+            $payment->getMethod() === PaymentMethods::ADYEN_CC_VAULT;
+
         $authResult = $paymentsDetailsResponse['authResult'] ?? $paymentsDetailsResponse['resultCode'] ?? null;
         if (is_null($authResult)) {
             // In case the result is unknown we log the request and don't update the history
@@ -213,7 +220,11 @@ class PaymentResponseHandler
 
         $ccType = $payment->getAdditionalInformation('cc_type');
 
-        if (!empty($paymentsDetailsResponse['additionalData']['paymentMethod']) && $ccType == null) {
+        if (!empty($paymentsDetailsResponse['additionalData']['paymentMethod']) &&
+            !is_null($ccType) &&
+            $isWalletPaymentMethod &&
+            $isCardPaymentMethod
+        ) {
             $ccType = $paymentsDetailsResponse['additionalData']['paymentMethod'];
             $payment->setAdditionalInformation('cc_type', $ccType);
             $payment->setCcType($ccType);

--- a/Helper/PaymentResponseHandler.php
+++ b/Helper/PaymentResponseHandler.php
@@ -211,6 +211,14 @@ class PaymentResponseHandler
             $payment->setAdditionalInformation('donationToken', $paymentsDetailsResponse['donationToken']);
         }
 
+        $ccType = $payment->getAdditionalInformation('cc_type');
+
+        if (!empty($paymentsDetailsResponse['additionalData']['paymentMethod']) && $ccType == null) {
+            $ccType = $paymentsDetailsResponse['additionalData']['paymentMethod'];
+            $payment->setAdditionalInformation('cc_type', $ccType);
+            $payment->setCcType($ccType);
+        }
+
         // Handle recurring details
         $this->vaultHelper->handlePaymentResponseRecurringDetails($payment, $paymentsDetailsResponse);
 

--- a/Test/Unit/Gateway/Response/CheckoutPaymentsDetailsHandlerTest.php
+++ b/Test/Unit/Gateway/Response/CheckoutPaymentsDetailsHandlerTest.php
@@ -109,13 +109,15 @@ class CheckoutPaymentsDetailsHandlerTest extends AbstractAdyenTestCase
                 ]
             ],
             1 => [
-                'additionalData' => [],
+                'additionalData' => [
+                    'paymentMethod' => 'VI',
+                ],
                 'amount' => [],
                 'resultCode' => 'Authorised',
                 'pspReference' => 'ABC12345',
                 'paymentMethod' => [
                     'name' => 'card',
-                    'type' => 'CreditCard',
+                    'type' => 'VI',
                 ]
             ]
         ];
@@ -145,6 +147,22 @@ class CheckoutPaymentsDetailsHandlerTest extends AbstractAdyenTestCase
             ->expects($this->once())
             ->method('setTransactionId')
             ->with('ABC12345');
+
+        $this->paymentMock
+            ->expects($this->once())
+            ->method('getAdditionalInformation')
+            ->with('cc_type')
+            ->willReturn(null);
+
+        $this->paymentMock
+            ->expects($this->once())
+            ->method('setAdditionalInformation')
+            ->with('cc_type', 'VI');
+
+        $this->paymentMock
+            ->expects($this->once())
+            ->method('setCcType')
+            ->with('VI');
 
         $this->applyGenericMockExpectations();
 


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
When using a Cartes Bancaire card to complete the payments, the `cc_type` in the `sales_order_payment` table is null. This is the case for a normal non co branded CB card and with co-branded when selecting CB. Other card payments add `cc_type` correctly.
This PR aims to add the correct `cc_type` to the database table if it is null or not set already.
<!-- Please provide a description of the changes proposed in the Pull Request -->

**Tested scenarios**
- Tested the correct value for non co branded CB card and with co-branded when selecting CB, and other redirect payment methods.
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

Fixes  <!-- #-prefixed github issue number -->
