### PR TITLE
[ECP-9582] Fix broken Magento compatibility by removing union return type

### DIFF
--- a/Controller/Adminhtml/Configuration/DownloadApplePayDomainAssociationFile.php
+++ b/Controller/Adminhtml/Configuration/DownloadApplePayDomainAssociationFile.php
@@ -13,9 +13,7 @@ namespace Adyen\Payment\Controller\Adminhtml\Configuration;
 
 use Adyen\Payment\Logger\AdyenLogger;
 use Exception;
-use Magento\Framework\App\ResponseInterface;
 use Magento\Framework\Controller\ResultInterface;
-use Magento\Framework\Exception\FileSystemException;
 use Magento\Framework\Filesystem\DirectoryList;
 use Magento\Backend\App\Action\Context;
 use Magento\Framework\Controller\ResultFactory;
@@ -30,7 +28,7 @@ class DownloadApplePayDomainAssociationFile extends Action
     const WELL_KNOWN_PATH = '.well-known';
 
     public function __construct(
-        private readonly Context $context,
+        Context $context,
         private readonly DirectoryList $directoryList,
         private readonly File $fileIo,
         private readonly AdyenLogger $adyenLogger
@@ -39,10 +37,9 @@ class DownloadApplePayDomainAssociationFile extends Action
     }
 
     /**
-     * @return ResultInterface|ResponseInterface
-     * @throws FileSystemException
+     * @return ResultInterface
      */
-    public function execute(): ResultInterface|ResponseInterface
+    public function execute(): ResultInterface
     {
         $redirect = $this->resultFactory->create(ResultFactory::TYPE_REDIRECT);
         $redirect->setUrl($this->_redirect->getRefererUrl());


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->

After introducing a union return type to `DownloadApplePayDomainAssociationFile` class, Magento 2.4.4 and 2.4.5 compatibility of the plugin was broken. Even though union return type is supported on PHP 8, it is not supported by that Magento versions. This PR removes the union return type from the aforementioned class.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- Downloading Apple Pay domain association file

Fixes #2842 