### PR TITLE
[ECP-8375] Fix broken invoicing in the cases of using base currency as charged_currency

### DIFF
--- a/Helper/Invoice.php
+++ b/Helper/Invoice.php
@@ -334,9 +334,11 @@ class Invoice extends AbstractHelper
             }
         }
 
+        $invoiceChargedCurrency = $this->chargedCurrencyHelper->getInvoiceAmountCurrency($invoice);
+
         $invoiceAmountCents = $this->adyenDataHelper->formatAmount(
-            $invoice->getGrandTotal(),
-            $invoice->getOrderCurrencyCode()
+            $invoiceChargedCurrency->getAmount(),
+            $invoiceChargedCurrency->getCurrencyCode()
         );
 
         $invoiceCapturedAmountCents = $this->adyenDataHelper->formatAmount(

--- a/Test/Unit/Helper/InvoiceTest.php
+++ b/Test/Unit/Helper/InvoiceTest.php
@@ -168,8 +168,11 @@ class InvoiceTest extends AbstractAdyenTestCase
         $adyenAmountCurrencyMock->method('getAmount')->willReturn(10);
         $adyenAmountCurrencyMock->method('getCurrencyCode')->willReturn('EUR');
 
+        $invoiceAmountCurrency = $this->createMock(AdyenAmountCurrency::class);
+
         $chargedCurrencyMock = $this->createMock(ChargedCurrency::class);
         $chargedCurrencyMock->method('getOrderAmountCurrency')->willReturn($adyenAmountCurrencyMock);
+        $chargedCurrencyMock->method('getInvoiceAmountCurrency')->willReturn($invoiceAmountCurrency);
 
         $invoiceHelper = $this->createInvoiceHelper(
             $contextMock,
@@ -277,6 +280,17 @@ class InvoiceTest extends AbstractAdyenTestCase
             ],
         ]);
 
+        $invoiceAmountCurrency = $this->createMock(AdyenAmountCurrency::class);
+        $invoiceAmountCurrency->expects($this->once())
+            ->method('getAmount')
+            ->willReturn(1000);
+        $invoiceAmountCurrency->expects($this->once())
+            ->method('getCurrencyCode')
+            ->willReturn('EUR');
+
+        $chargedCurrencyMock = $this->createMock(ChargedCurrency::class);
+        $chargedCurrencyMock->method('getInvoiceAmountCurrency')->willReturn($invoiceAmountCurrency);
+
         $invoiceHelper = $this->createInvoiceHelper(
             null,
             null,
@@ -286,7 +300,13 @@ class InvoiceTest extends AbstractAdyenTestCase
             null,
             null,
             null,
-            $adyenInvoiceCollectionMock
+            $adyenInvoiceCollectionMock,
+            null,
+            null,
+            null,
+            null,
+            null,
+            $chargedCurrencyMock
         );
 
         $invoiceMock = $this->createConfiguredMock(InvoiceModel::class, [


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
The plugin is using `isFullInvoiceAmountManuallyCaptured()` to determine if the full amount is captured or not. This bug affects the comparison if the plugin uses `base` currency as the `charged_currency`. 

This fix implements the usage of `AdyenAmountCurrency` class for the invoice amounts, which checks the configuration to determine the `charged_currency` before using `getGrandTotal()` or `getBaseGrandTotal()`.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- Manual capture invoicing
- Auto capture invoicing

Fixes #1955 
