### PR TITLE
[ECP-9598] Bump Github Actions Artifacts version to V4 on E2E workflow

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -133,7 +133,7 @@ jobs:
 
       - name: Archive test result artifacts
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: html-report
           path: test-report


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Github deprecated artifacts action version 3 and this causes immediate cancellation on E2E test workflow. This PR bumps the action version to v4 to tackle this issue. 

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- Successful build of E2E workflow