### PR TITLE
Feat: Use async pos payments main

### DIFF
--- a/Gateway/Http/Client/TransactionPosCloud.php
+++ b/Gateway/Http/Client/TransactionPosCloud.php
@@ -21,7 +21,7 @@ use Magento\Payment\Gateway\Http\ClientInterface;
 use Magento\Payment\Gateway\Http\TransferInterface;
 use Magento\Store\Model\StoreManagerInterface;
 
-class TransactionPosCloudSync implements ClientInterface
+class TransactionPosCloud implements ClientInterface
 {
     protected int $storeId;
     protected mixed $timeout;
@@ -60,9 +60,15 @@ class TransactionPosCloudSync implements ClientInterface
         $request = $transferObject->getBody();
         $service = $this->adyenHelper->createAdyenPosPaymentService($this->client);
 
-        $this->adyenHelper->logRequest($request, '', '/sync');
+        $this->adyenHelper->logRequest($request, '', '/async');
         try {
-            $response = $service->runTenderSync($request);
+            if (!empty($request['SaleToPOIRequest']['PaymentRequest'])) {
+                // Use async for payment requests
+                // Note: Async requests do not have a response
+                $response = $service->runTenderAsync($request) ?? ['async' => true];
+            } else {
+                $response = $service->runTenderSync($request);
+            }
         } catch (AdyenException $e) {
             //Not able to perform a payment
             $this->adyenLogger->addAdyenDebug($response['error'] = $e->getMessage());

--- a/Gateway/Request/PosCloudBuilder.php
+++ b/Gateway/Request/PosCloudBuilder.php
@@ -18,7 +18,7 @@ use Adyen\Payment\Helper\PointOfSale;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Payment\Gateway\Helper\SubjectReader;
 use Magento\Payment\Gateway\Request\BuilderInterface;
-use Magento\Sales\Model\Order;
+use Magento\Sales\Model\Order\Payment;
 
 class PosCloudBuilder implements BuilderInterface
 {
@@ -33,27 +33,6 @@ class PosCloudBuilder implements BuilderInterface
 
     public function build(array $buildSubject): array
     {
-        $paymentDataObject = SubjectReader::readPayment($buildSubject);
-
-        $payment = $paymentDataObject->getPayment();
-        $order = $payment->getOrder();
-
-        $request['body'] = $this->buildPosRequest(
-            $order,
-            $payment->getAdditionalInformation('terminal_id'),
-            $payment->getAdditionalInformation('funding_source'),
-            $payment->getAdditionalInformation('number_of_installments'),
-        );
-
-        return $request;
-    }
-
-    private function buildPosRequest(
-        Order $order,
-        string $terminalId,
-        ?string $fundingSource,
-        ?string $numberOfInstallments
-    ): array {
         // Validate JSON that has just been parsed if it was in a valid format
         if (json_last_error() !== JSON_ERROR_NONE) {
             throw new LocalizedException(
@@ -61,11 +40,53 @@ class PosCloudBuilder implements BuilderInterface
             );
         }
 
-        $poiId = $terminalId;
+        $paymentDataObject = SubjectReader::readPayment($buildSubject);
+        $payment = $paymentDataObject->getPayment();
+        if (!$payment instanceof Payment) {
+            throw new LocalizedException(__('Expecting instance of ' . Payment::class));
+        }
+        if ($payment->hasAdditionalInformation('pos_request')) {
+            // POS status request
+            $request['body'] = $this->buildPosStatusRequest($payment);
+        } else {
+            // New POS request
+            $request['body'] = $this->buildPosRequest($payment);
+            $payment->setAdditionalInformation('pos_request', $payment->getAdditionalInformation('terminal_id'));
+        }
+
+        return $request;
+    }
+
+    private function buildPosStatusRequest(Payment $payment): array {
+        $request = [
+            'SaleToPOIRequest' => [
+                'MessageHeader' => [
+                    'MessageType' => 'Request',
+                    'MessageClass' => 'Service',
+                    'MessageCategory' => 'TransactionStatus',
+                    'SaleID' => 'Magento2Cloud',
+                    'POIID' => $payment->getAdditionalInformation('pos_request'),
+                    'ProtocolVersion' => '3.0',
+                    'ServiceID' => $this->getServiceId($payment),
+                ],
+                'TransactionStatusRequest' => [
+                    'ReceiptReprintFlag' => false,
+                ],
+            ],
+        ];
+        $request['SaleToPOIRequest']['MessageHeader']['MessageCategory'] = 'TransactionStatus';
+
+        return $request;
+    }
+
+    private function buildPosRequest(Payment $payment) {
+        $order = $payment->getOrder();
+        $poiId = $payment->getAdditionalInformation('terminal_id');
+        $fundingSource = $payment->getAdditionalInformation('funding_source');
+        $numberOfInstallments = $payment->getAdditionalInformation('number_of_installments');
         $transactionType = \Adyen\TransactionType::NORMAL;
         $amountCurrency = $this->chargedCurrency->getOrderAmountCurrency($order);
 
-        $serviceID = date("dHis");
         $timeStamper = date("Y-m-d") . "T" . date("H:i:s+00:00");
 
         $request = [
@@ -79,7 +100,7 @@ class PosCloudBuilder implements BuilderInterface
                             'SaleID' => 'Magento2Cloud',
                             'POIID' => $poiId,
                             'ProtocolVersion' => '3.0',
-                            'ServiceID' => $serviceID
+                            'ServiceID' => $this->getServiceId($payment),
                         ],
                     'PaymentRequest' =>
                         [
@@ -136,5 +157,10 @@ class PosCloudBuilder implements BuilderInterface
         }
 
         return $this->pointOfSale->addSaleToAcquirerData($request, $order);
+    }
+
+    private function getServiceId(Payment $payment): string
+    {
+        return substr(sha1(uniqid($payment->getOrder()->getIncrementId(), true)), 0, 10);
     }
 }

--- a/Model/Api/AdyenPosCloud.php
+++ b/Model/Api/AdyenPosCloud.php
@@ -15,6 +15,7 @@ use Adyen\Payment\Api\AdyenPosCloudInterface;
 use Adyen\Payment\Logger\AdyenLogger;
 use Adyen\Payment\Model\Sales\OrderRepository;
 use Exception;
+use Magento\Framework\Exception\LocalizedException;
 use Magento\Payment\Gateway\Command\CommandPoolInterface;
 use Magento\Sales\Api\Data\OrderInterface;
 use Magento\Payment\Gateway\Data\PaymentDataObjectFactoryInterface;
@@ -57,6 +58,6 @@ class AdyenPosCloud implements AdyenPosCloudInterface
 
         // Pending POS payment, add a short delay to avoid a flood of requests
         sleep(2);
-        throw new Exception('In Progress');
+        throw new LocalizedException(__('Status: %1', 'In Progress'));
     }
 }

--- a/Model/Api/AdyenPosCloud.php
+++ b/Model/Api/AdyenPosCloud.php
@@ -14,6 +14,7 @@ namespace Adyen\Payment\Model\Api;
 use Adyen\Payment\Api\AdyenPosCloudInterface;
 use Adyen\Payment\Logger\AdyenLogger;
 use Adyen\Payment\Model\Sales\OrderRepository;
+use Exception;
 use Magento\Payment\Gateway\Command\CommandPoolInterface;
 use Magento\Sales\Api\Data\OrderInterface;
 use Magento\Payment\Gateway\Data\PaymentDataObjectFactoryInterface;
@@ -50,5 +51,12 @@ class AdyenPosCloud implements AdyenPosCloudInterface
         $paymentDataObject = $this->paymentDataObjectFactory->create($payment);
         $posCommand = $this->commandPool->get('authorize');
         $posCommand->execute(['payment' => $paymentDataObject]);
+        if (!$payment->hasAdditionalInformation('pos_request')) {
+            return;
+        }
+
+        // Pending POS payment, add a short delay to avoid a flood of requests
+        sleep(2);
+        throw new Exception('In Progress');
     }
 }

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -991,7 +991,7 @@
         <arguments>
             <argument name="requestBuilder" xsi:type="object">AdyenPaymentPosCloudAuthorizeRequest</argument>
             <argument name="transferFactory" xsi:type="object">Adyen\Payment\Gateway\Http\TransferFactory</argument>
-            <argument name="client" xsi:type="object">Adyen\Payment\Gateway\Http\Client\TransactionPosCloudSync</argument>
+            <argument name="client" xsi:type="object">Adyen\Payment\Gateway\Http\Client\TransactionPosCloud</argument>
             <argument name="validator" xsi:type="object">PosCloudResponseValidator</argument>
             <argument name="handler" xsi:type="object">AdyenPaymentPosCloudResponseHandlerComposite</argument>
         </arguments>
@@ -1780,7 +1780,7 @@
             <argument name="checkoutSession" xsi:type="object">Magento\Checkout\Model\Session\Proxy</argument>
         </arguments>
     </type>
-    <type name="Adyen\Payment\Gateway\Http\Client\TransactionPosCloudSync">
+    <type name="Adyen\Payment\Gateway\Http\Client\TransactionPosCloud">
         <arguments>
             <argument name="session" xsi:type="object">Magento\Checkout\Model\Session\Proxy</argument>
         </arguments>


### PR DESCRIPTION
**Description**
Using an asynchronous call to initiate POS payment request, followed by synchronous status calls. Polls every ~2 seconds for the status until it's final.

**Tested scenarios**
1. Place order
2. Start POS payment
  a. Cancel payment, check result (OK)
  b. Approve payment, check result (OK)

I've created functional tests for our PWA platform. Didn't test the Magento frontend. Since it's already checking for the ["In Progress" string](https://github.com/Adyen/adyen-magento2/blob/cacef78df4de40d7970c4291cd438769840d0567/view/frontend/web/js/view/payment/method-renderer/adyen-pos-cloud-method.js#L116) if the POS payment request fails, it should be working. Please add the necessary unit / functional tests if desired.

We could exchange the status requests for a request with a more reasonable timeout (e.g. 30 seconds) which gives a response as soon as the notification has been received by the webhook, or when it hits the timeout (in which case the client should retry). This would eliminate the 2 seconds delay and provide a quicker response. Since this requires more changes, I have left it at that for now.

_Note: If I would have implemented the Adyen (POS) API directly in a custom module things would probably have been organized a bit different in order to create a more robust solution ([see comments in the created issue](https://github.com/Adyen/adyen-magento2/issues/2867#issuecomment-2615389332))._

Fixes  #2867
