### PR TITLE
[ECP-9526]Unset cc_type for AlternatePaymentMethods

### DIFF
--- a/Helper/Webhook/OfferClosedWebhookHandler.php
+++ b/Helper/Webhook/OfferClosedWebhookHandler.php
@@ -12,6 +12,7 @@
 
 namespace Adyen\Payment\Helper\Webhook;
 
+use Adyen\AdyenException;
 use Adyen\Payment\Helper\Config;
 use Adyen\Payment\Helper\Order;
 use Adyen\Payment\Helper\PaymentMethods;
@@ -55,6 +56,7 @@ class OfferClosedWebhookHandler implements WebhookHandlerInterface
 
     /**
      * @throws LocalizedException
+     * @throws AdyenException
      */
     public function handleWebhook(MagentoOrder $order, Notification $notification, string $transitionState): MagentoOrder
     {
@@ -88,12 +90,14 @@ class OfferClosedWebhookHandler implements WebhookHandlerInterface
         );
 
         if (!$identicalPaymentMethods) {
+            $paymentMethodInstance = $order->getPayment()->getMethodInstance();
             $this->adyenLogger->addAdyenNotification(sprintf(
                 'Payment method of notification %s (%s) does not match the payment method (%s) of order %s',
                 $notification->getId(),
                 $notification->getPaymentMethod(),
                 $order->getIncrementId(),
-                $order->getPayment()->getCcType()
+                $this->paymentMethodsHelper->getAlternativePaymentMethodTxVariant(
+                    $paymentMethodInstance)
             ),
                 [
                     'pspReference' => $notification->getPspreference(),

--- a/Observer/AdyenPaymentMethodDataAssignObserver.php
+++ b/Observer/AdyenPaymentMethodDataAssignObserver.php
@@ -119,10 +119,5 @@ class AdyenPaymentMethodDataAssignObserver extends AbstractDataAssignObserver
             $paymentInfo->setAdditionalInformation($key, $data);
         }
 
-        // Set ccType. If payment method is tokenizable, update additional information
-        if (!empty($additionalData[self::BRAND_CODE])) {
-            $paymentMethod = $additionalData[self::BRAND_CODE];
-            $paymentInfo->setCcType($paymentMethod);
-        }
     }
 }

--- a/Test/Unit/Helper/Webhook/OfferClosedWebhookHandlerTest.php
+++ b/Test/Unit/Helper/Webhook/OfferClosedWebhookHandlerTest.php
@@ -7,6 +7,7 @@ use Adyen\Payment\Helper\Config;
 use Adyen\Payment\Helper\Order;
 use Adyen\Payment\Helper\PaymentMethods;
 use Adyen\Payment\Logger\AdyenLogger;
+use Adyen\Payment\Model\Method\Adapter;
 use Adyen\Payment\Model\Notification;
 use Adyen\Payment\Model\ResourceModel\Order\Payment as OrderPaymentResourceModel;
 use Magento\Sales\Model\Order as MagentoOrder;
@@ -67,20 +68,27 @@ class OfferClosedWebhookHandlerTest extends AbstractAdyenTestCase
     {
         // Create a sample MagentoOrder and Notification
         $order = $this->createMock(MagentoOrder::class);
-        $order->method('getPayment')->willReturn($this->createPartialMock(Payment::class, ['getMethod']));
+        $paymentMethodInstanceMock = $this->createMock(Adapter::class);
+        $order->method('getPayment')->willReturn($this->createPartialMock(Payment::class, ['getMethod','getMethodInstance']));
         $order->getPayment()->method('getMethod')->willReturn('adyen_cc');
+        $order->getPayment()->method('getMethodInstance')->willReturn($paymentMethodInstanceMock);
         $notification = $this->createMock(Notification::class);
 
-        // Mock payment method mismatch
-        $this->paymentMethodsHelper->method('compareOrderAndWebhookPaymentMethods')->with($order,$notification)->willReturn(false);
+        // Mock payment method comparison behavior
+        $this->paymentMethodsHelper->method('compareOrderAndWebhookPaymentMethods')
+            ->with($order, $notification)
+            ->willReturn(false);
 
         // Create an instance of the OfferClosedWebhookHandler
-        $webhookHandler = $this->createOfferClosedWebhookHandler($this->paymentMethodsHelper,null,null,null,null);
+        $webhookHandler = $this->createOfferClosedWebhookHandler($this->paymentMethodsHelper, null, null, null, null);
 
         // Call the handleWebhook method to trigger the exception
         $result = $webhookHandler->handleWebhook($order, $notification, 'PAYMENT_REVIEW');
+
+        // Verify the expected result
         $this->assertEquals($order, $result);
     }
+
 
     public function testHandleWebhookReturnsOrderWhenCapturedPaymentsExist()
     {

--- a/Test/Unit/Observer/AdyenPaymentMethodDataAssignObserverTest.php
+++ b/Test/Unit/Observer/AdyenPaymentMethodDataAssignObserverTest.php
@@ -1,0 +1,160 @@
+<?php
+declare(strict_types=1);
+
+namespace Adyen\Payment\Test\Unit\Observer;
+
+use Adyen\Payment\Helper\StateData;
+use Adyen\Payment\Helper\Util\CheckoutStateDataValidator;
+use Adyen\Payment\Helper\Util\DataArrayValidator;
+use Adyen\Payment\Helper\Vault;
+use Adyen\Payment\Model\ResourceModel\StateData\Collection;
+use Adyen\Payment\Observer\AdyenPaymentMethodDataAssignObserver;
+use Adyen\Payment\Test\Unit\AbstractAdyenTestCase;
+use Magento\Framework\Event;
+use Magento\Framework\Event\Observer;
+use Magento\Payment\Model\InfoInterface;
+use Magento\Payment\Observer\AbstractDataAssignObserver;
+use Magento\Quote\Api\Data\PaymentInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use \Magento\Framework\DataObject;
+use Magento\Quote\Model\Quote\Payment;
+
+class AdyenPaymentMethodDataAssignObserverTest extends AbstractAdyenTestCase
+{
+    private MockObject $checkoutStateDataValidator;
+    private MockObject $stateDataCollection;
+    private MockObject $stateData;
+    private MockObject $vaultHelper;
+    private AdyenPaymentMethodDataAssignObserver $observer;
+
+    protected function setUp(): void
+    {
+        $this->checkoutStateDataValidator = $this->createMock(CheckoutStateDataValidator::class);
+        $this->stateDataCollection = $this->createMock(Collection::class);
+        $this->stateData = $this->createMock(StateData::class);
+        $this->vaultHelper = $this->createMock(Vault::class);
+        $this->paymentInfo = $this->createMock(Payment::class);
+        $this->observer = new AdyenPaymentMethodDataAssignObserver(
+            $this->checkoutStateDataValidator,
+            $this->stateDataCollection,
+            $this->stateData,
+            $this->vaultHelper
+        );
+    }
+
+    public function testExecuteWithNoAdditionalData()
+    {
+        $dataObject = new DataObject();
+        $paymentInfo = $this->createMock(Payment::class);
+        $observer = $this->getPreparedObserverWithMap([
+            [AbstractDataAssignObserver::DATA_CODE, $dataObject],
+            [AbstractDataAssignObserver::MODEL_CODE, $paymentInfo],
+        ]);
+
+        $this->observer->execute($observer);
+    }
+
+    public function testExecuteWithValidAdditionalData()
+    {
+        $additionalData = [
+            'brand_code' => 'visa',
+            'stateData' => json_encode(['paymentMethod' => ['type' => 'scheme']]),
+            'recurringProcessingModel' => 'Subscription',
+        ];
+
+        $dataObject = new DataObject([
+            PaymentInterface::KEY_ADDITIONAL_DATA => $additionalData,
+        ]);
+
+
+
+        $observer = $this->getPreparedObserverWithMap([
+            [AbstractDataAssignObserver::DATA_CODE, $dataObject],
+            [AbstractDataAssignObserver::MODEL_CODE, $this->paymentInfo],
+        ]);
+        $this->paymentInfo->expects($this->once())->method('unsAdditionalInformation')->with('cc_type');
+
+        $this->paymentInfo->method('getData')
+            ->with('quote_id')
+            ->willReturn(1);
+
+        $this->vaultHelper->expects($this->once())
+            ->method('validateRecurringProcessingModel')
+            ->with('Subscription')
+            ->willReturn(true);
+
+        $this->paymentInfo->expects($this->exactly(2))->method('setAdditionalInformation');
+
+        // Execute the observer logic
+        $this->observer->execute($observer);
+    }
+
+    public function testExecuteWithInvalidRecurringProcessingModel()
+    {
+        $additionalData = [
+            'brand_code' => 'visa',
+            'stateData' => json_encode(['paymentMethod' => ['type' => 'scheme']]),
+            'recurringProcessingModel' => 'invalid',
+        ];
+
+        $dataObject = new \Magento\Framework\DataObject([
+            PaymentInterface::KEY_ADDITIONAL_DATA => $additionalData,
+        ]);
+
+        $this->paymentInfo->expects($this->atLeastOnce())
+            ->method('unsAdditionalInformation')
+            ->withConsecutive(['cc_type'], ['recurringProcessingModel']);
+
+        $this->paymentInfo->expects($this->any())->method('getData')
+            ->with('quote_id')->willReturn(123);
+
+        $observer = $this->getPreparedObserverWithMap([
+            [AbstractDataAssignObserver::DATA_CODE, $dataObject],
+            [AbstractDataAssignObserver::MODEL_CODE, $this->paymentInfo],
+        ]);
+
+        $this->vaultHelper->expects($this->once())->method('validateRecurringProcessingModel')
+            ->with('invalid')->willReturn(false);
+
+        $this->observer->execute($observer);
+    }
+
+    public function testExecuteWithStateDataFromDatabase()
+    {
+        $this->paymentInfo->expects($this->any())->method('getData')
+            ->with('quote_id')->willReturn(123);
+
+        $dataObject = new \Magento\Framework\DataObject();
+        $observer = $this->getPreparedObserverWithMap([
+            [AbstractDataAssignObserver::DATA_CODE, $dataObject],
+            [AbstractDataAssignObserver::MODEL_CODE, $this->paymentInfo],
+        ]);
+
+        $this->observer->execute($observer);
+    }
+
+    /**
+     * @param array $returnMap
+     * @return MockObject|Observer
+     */
+    private function getPreparedObserverWithMap(array $returnMap): Observer|MockObject
+    {
+        $observer = $this->getMockBuilder(Observer::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $event = $this->getMockBuilder(Event::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $observer->expects(static::atLeastOnce())
+            ->method('getEvent')
+            ->willReturn($event);
+        $event->expects(static::atLeastOnce())
+            ->method('getDataByKey')
+            ->willReturnMap(
+                $returnMap
+            );
+
+        return $observer;
+    }
+}


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Currently, Alternate payment methods are also populating under the cc_type entry with the value of BRAND_CODE in the DB which is not correct.
This PR aims to remove populating cc_type for Alternative Payment Methods
**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

Fixes  <!-- #-prefixed github issue number -->
