### PR TITLE
[ECP-8665] PaymentStatus endpoint shouldn't return full additionalData

### DIFF
--- a/Helper/PaymentResponseHandler.php
+++ b/Helper/PaymentResponseHandler.php
@@ -117,16 +117,11 @@ class PaymentResponseHandler
                     "action" => $action
                 ];
             case self::PRESENT_TO_SHOPPER:
-                return [
-                    "isFinal" => true,
-                    "resultCode" => $resultCode,
-                    "action" => $action
-                ];
             case self::RECEIVED:
                 return [
                     "isFinal" => true,
                     "resultCode" => $resultCode,
-                    "additionalData" => $additionalData
+                    "action" => $action
                 ];
             default:
                 return [

--- a/Helper/PaymentResponseHandler.php
+++ b/Helper/PaymentResponseHandler.php
@@ -95,8 +95,7 @@ class PaymentResponseHandler
 
     public function formatPaymentResponse(
         string $resultCode,
-        array $action = null,
-        array $additionalData = null
+        array $action = null
     ): array {
         switch ($resultCode) {
             case self::AUTHORISED:

--- a/Model/Api/AdyenOrderPaymentStatus.php
+++ b/Model/Api/AdyenOrderPaymentStatus.php
@@ -61,8 +61,7 @@ class AdyenOrderPaymentStatus implements AdyenOrderPaymentStatusInterface
 
         return json_encode($this->paymentResponseHandler->formatPaymentResponse(
             $additionalInformation['resultCode'],
-            !empty($additionalInformation['action']) ? $additionalInformation['action'] : null,
-            !empty($additionalInformation['additionalData']) ? $additionalInformation['additionalData'] : null
+            !empty($additionalInformation['action']) ? $additionalInformation['action'] : null
         ));
     }
 }

--- a/Test/Unit/Helper/PaymentResponseHandlerTest.php
+++ b/Test/Unit/Helper/PaymentResponseHandlerTest.php
@@ -193,16 +193,15 @@ class PaymentResponseHandlerTest extends AbstractAdyenTestCase
     public function testFormatPaymentResponseForOfflinePayments()
     {
         $resultCode = PaymentResponseHandler::RECEIVED;
-        $additionalData = ['action' => ['voucher']];
-
+        $action = ['type' => 'voucher'];
         $expectedResult = [
             "isFinal" => true,
             "resultCode" => $resultCode,
-            "additionalData" => $additionalData
+            "action" => $action
         ];
 
         // Execute method of the tested class
-        $result = $this->paymentResponseHandler->formatPaymentResponse($resultCode, null, $additionalData);
+        $result = $this->paymentResponseHandler->formatPaymentResponse($resultCode, $action, null);
 
         // Assert conditions
         $this->assertEquals($expectedResult, $result);

--- a/Test/Unit/Helper/PaymentResponseHandlerTest.php
+++ b/Test/Unit/Helper/PaymentResponseHandlerTest.php
@@ -201,7 +201,7 @@ class PaymentResponseHandlerTest extends AbstractAdyenTestCase
         ];
 
         // Execute method of the tested class
-        $result = $this->paymentResponseHandler->formatPaymentResponse($resultCode, $action, null);
+        $result = $this->paymentResponseHandler->formatPaymentResponse($resultCode, $action);
 
         // Assert conditions
         $this->assertEquals($expectedResult, $result);


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
[PaymentResponseHandler](https://github.com/Adyen/adyen-magento2/blob/develop/Helper/PaymentResponseHandler.php) returns full additionalData field of the payment for RECEIVED result code. However, frontend doesn't need that information and only need action object within the whole information block.
Refactoring the logic to not send or receive additionalData
**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

Fixes  <!-- #-prefixed github issue number -->
