### PR TITLE
[ECP-9597] Add company name and taxId to the /payments request for B2B payment methods

### DIFF
--- a/Gateway/Request/CompanyDataBuilder.php
+++ b/Gateway/Request/CompanyDataBuilder.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2025 Adyen N.V. (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\Payment\Gateway\Request;
+
+use Magento\Payment\Gateway\Data\PaymentDataObject;
+use Magento\Payment\Gateway\Helper\SubjectReader;
+use Magento\Payment\Gateway\Request\BuilderInterface;
+use Magento\Sales\Model\Order;
+
+class CompanyDataBuilder implements BuilderInterface
+{
+    public function build(array $buildSubject): array
+    {
+        /** @var PaymentDataObject $paymentDataObject */
+        $paymentDataObject = SubjectReader::readPayment($buildSubject);
+        $payment = $paymentDataObject->getPayment();
+        /** @var Order $order */
+        $order = $payment->getOrder();
+        $billingAddress = $order->getBillingAddress();
+        $company = [];
+
+        if (!empty($billingAddress->getVatId())) {
+            $company['taxId'] = $billingAddress->getVatId();
+        }
+
+        if (!empty($billingAddress->getCompany())) {
+            $company['name'] = $billingAddress->getCompany();
+        }
+
+        return [
+            'body' => [
+                'company' => $company
+            ]
+        ];
+    }
+}

--- a/Test/Unit/Gateway/Request/CompanyDataBuilderTest.php
+++ b/Test/Unit/Gateway/Request/CompanyDataBuilderTest.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2025 Adyen N.V. (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\Payment\Test\Gateway\Request;
+
+use Adyen\Payment\Gateway\Request\CompanyDataBuilder;
+use Adyen\Payment\Test\Unit\AbstractAdyenTestCase;
+use Magento\Payment\Gateway\Data\PaymentDataObject;
+use Magento\Sales\Api\Data\OrderAddressInterface;
+use Magento\Sales\Model\Order;
+use Magento\Sales\Model\Order\Payment;
+
+class CompanyDataBuilderTest extends AbstractAdyenTestCase
+{
+    /**
+     * @return void
+     */
+    function testBuild()
+    {
+        $companyName = 'Adyen';
+        $vatId = 'NL-123456789';
+
+        $billingAddressMock = $this->createMock(OrderAddressInterface::class);
+        $billingAddressMock->expects($this->exactly(2))
+            ->method('getCompany')
+            ->willReturn('Adyen');
+        $billingAddressMock->expects($this->exactly(2))
+            ->method('getVatId')
+            ->willReturn($vatId);
+
+        $orderMock = $this->createMock(Order::class);
+        $orderMock->expects($this->once())
+            ->method('getBillingAddress')
+            ->willReturn($billingAddressMock);
+
+        $paymentMock = $this->createMock(Payment::class);
+        $paymentMock->method('getOrder')->willReturn($orderMock);
+
+        $buildSubject = [
+            'payment' => $this->createConfiguredMock(PaymentDataObject::class, [
+                'getPayment' => $paymentMock
+            ])
+        ];
+
+        $builder = new CompanyDataBuilder();
+        $result = $builder->build($buildSubject);
+
+        $this->assertEquals(['body' => ['company' => ['name' => $companyName, 'taxId' => $vatId]]], $result);
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1081,6 +1081,7 @@
                 <item name="origin" xsi:type="string">Adyen\Payment\Gateway\Request\OriginDataBuilder</item>
                 <item name="header" xsi:type="string">Adyen\Payment\Gateway\Request\Header\HeaderDataBuilder</item>
                 <item name="giftcard" xsi:type="string">Adyen\Payment\Gateway\Request\GiftcardDataBuilder</item>
+                <item name="company" xsi:type="string">Adyen\Payment\Gateway\Request\CompanyDataBuilder</item>
             </argument>
         </arguments>
     </virtualType>
@@ -1098,6 +1099,7 @@
                 <item name="shopperinteraction" xsi:type="string">Adyen\Payment\Gateway\Request\ShopperInteractionDataBuilder</item>
                 <item name="channel" xsi:type="string">Adyen\Payment\Gateway\Request\ChannelDataBuilder</item>
                 <item name="origin" xsi:type="string">Adyen\Payment\Gateway\Request\OriginDataBuilder</item>
+                <item name="company" xsi:type="string">Adyen\Payment\Gateway\Request\CompanyDataBuilder</item>
             </argument>
         </arguments>
     </virtualType>
@@ -1114,6 +1116,7 @@
                 <item name="description" xsi:type="string">Adyen\Payment\Gateway\Request\DescriptionDataBuilder</item>
                 <item name="transaction" xsi:type="string">Adyen\Payment\Gateway\Request\CheckoutDataBuilder</item>
                 <item name="header" xsi:type="string">Adyen\Payment\Gateway\Request\Header\HeaderDataBuilder</item>
+                <item name="company" xsi:type="string">Adyen\Payment\Gateway\Request\CompanyDataBuilder</item>
             </argument>
         </arguments>
     </virtualType>
@@ -1135,6 +1138,7 @@
                 <item name="shopperinteraction" xsi:type="string">Adyen\Payment\Gateway\Request\ShopperInteractionDataBuilder</item>
                 <item name="header" xsi:type="string">Adyen\Payment\Gateway\Request\Header\HeaderDataBuilder</item>
                 <item name="giftcard" xsi:type="string">Adyen\Payment\Gateway\Request\GiftcardDataBuilder</item>
+                <item name="company" xsi:type="string">Adyen\Payment\Gateway\Request\CompanyDataBuilder</item>
             </argument>
         </arguments>
     </virtualType>
@@ -1155,6 +1159,7 @@
                 <item name="shopperinteraction" xsi:type="string">Adyen\Payment\Gateway\Request\ShopperInteractionDataBuilder</item>
                 <item name="header" xsi:type="string">Adyen\Payment\Gateway\Request\Header\HeaderDataBuilder</item>
                 <item name="giftcard" xsi:type="string">Adyen\Payment\Gateway\Request\GiftcardDataBuilder</item>
+                <item name="company" xsi:type="string">Adyen\Payment\Gateway\Request\CompanyDataBuilder</item>
             </argument>
         </arguments>
     </virtualType>
@@ -1206,6 +1211,7 @@
                 <item name="channel" xsi:type="string">Adyen\Payment\Gateway\Request\ChannelDataBuilder</item>
                 <item name="origin" xsi:type="string">Adyen\Payment\Gateway\Request\OriginDataBuilder</item>
                 <item name="giftcard" xsi:type="string">Adyen\Payment\Gateway\Request\GiftcardDataBuilder</item>
+                <item name="company" xsi:type="string">Adyen\Payment\Gateway\Request\CompanyDataBuilder</item>
             </argument>
         </arguments>
     </virtualType>
@@ -1226,6 +1232,7 @@
                 <item name="channel" xsi:type="string">Adyen\Payment\Gateway\Request\ChannelDataBuilder</item>
                 <item name="origin" xsi:type="string">Adyen\Payment\Gateway\Request\OriginDataBuilder</item>
                 <item name="giftcard" xsi:type="string">Adyen\Payment\Gateway\Request\GiftcardDataBuilder</item>
+                <item name="company" xsi:type="string">Adyen\Payment\Gateway\Request\CompanyDataBuilder</item>
             </argument>
         </arguments>
     </virtualType>
@@ -1254,6 +1261,7 @@
                 <item name="channel" xsi:type="string">Adyen\Payment\Gateway\Request\ChannelDataBuilder</item>
                 <item name="origin" xsi:type="string">Adyen\Payment\Gateway\Request\OriginDataBuilder</item>
                 <item name="giftcard" xsi:type="string">Adyen\Payment\Gateway\Request\GiftcardDataBuilder</item>
+                <item name="company" xsi:type="string">Adyen\Payment\Gateway\Request\CompanyDataBuilder</item>
             </argument>
         </arguments>
     </virtualType>


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Some B2B payment like Billy requires company information optionally. This PR introduces a new data builder for `/payments` API payload to add company name and VAT if they are present in the billing address object.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- Complete Billy payment and confirm these fields are reflected to Klarna page.