### PR TITLE
[ECP-9589] Installment Feature Not Working

### DIFF
--- a/view/frontend/web/template/payment/cc-form.html
+++ b/view/frontend/web/template/payment/cc-form.html
@@ -93,7 +93,7 @@
                 <!-- ko if: (hasInstallments())-->
 
                 <div class="field required"
-                     data-bind="attr: {id: getCode() + '_installments_div'}, visible: installments().length > 0">
+                    data-bind="attr: {id: getCode() + '_installments_div'},visible: installments() && Array.isArray(installments()) && installments().length > 0">
                     <label data-bind="attr: {for: getCode() + '_installments'}" class="label">
                         <span><!-- ko text: $t('Installments')--><!-- /ko --></span>
                     </label>

--- a/view/frontend/web/template/payment/cc-vault-form.html
+++ b/view/frontend/web/template/payment/cc-vault-form.html
@@ -74,7 +74,7 @@
         <!-- ko if: (hasInstallments())-->
 
         <div class="field required"
-             data-bind="attr: {id: getCode() + '_installments_div'}, visible: installments().length > 0">
+            data-bind="attr: {id: getCode() + '_installments_div'}, visible: installments() && Array.isArray(installments()) && installments().length > 0">
             <label data-bind="attr: {for: getCode() + '_installments'}" class="label">
                 <span><!-- ko text: $t('Installments')--><!-- /ko --></span>
             </label>

--- a/view/frontend/web/template/payment/pos-cloud-form.html
+++ b/view/frontend/web/template/payment/pos-cloud-form.html
@@ -76,7 +76,7 @@
 
             <!-- ko if: (hasInstallments())-->
             <div class="field required"
-                 data-bind="attr: {id: getCode() + '_installments_div'}, visible: installments().length > 0">
+                data-bind="attr: {id: getCode() + '_installments_div'}, visible: installments() && Array.isArray(installments()) && installments().length > 0">
                 <label data-bind="attr: {for: getCode() + '_installments'}" class="label">
                     <span><!-- ko text: $t('Installments')--><!-- /ko --></span>
                 </label>


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
When selecting the credit card payment method, the button to complete the order and installment payment is not displayed. 
This PR aims to address the issue by actually checking if the `installments` is an array and then only execute `.length`

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

Fixes  <!-- #-prefixed github issue number -->
#2853 
#2862 