### PR TITLE
[ECP-9640] Fix Click to Pay triggering OTP again after authentication 

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/adyen-cc-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-cc-method.js
@@ -189,6 +189,7 @@ define(
                 let allInstallments = this.getAllInstallments();
 
                 let componentConfig = {
+                    showPayButton: false,
                     enableStoreDetails: this.getEnableStoreDetails(),
                     brands: this.getBrands(),
                     hasHolderName: adyenConfiguration.getHasHolderName(),
@@ -197,6 +198,10 @@ define(
                     onChange: function(state, component) {
                         self.placeOrderAllowed(!!state.isValid);
                         self.storeCc = !!state.data.storePaymentMethod;
+                    },
+                    // Required for Click to Pay
+                    onSubmit: function () {
+                        self.placeOrder();
                     },
                     // Keep onBrand as is until checkout component supports installments
                     onBrand: function(state) {


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
After successfully authorising and obtaining the cards from Visa & Master Card, `Click to Pay` component triggers OTP again. However, the expected behaviour is either redirecting the shopper to the success page or showing 3DS2 authentication modal. 

This PR fixes the issue that triggers the OTP after clicking `Pay` button and let shoppers to complete payments successfully using Adyen Click to Pay.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- Click to Pay happy and unhappy flow