### PR TITLE
[ECP-9656] Add dateOfBirth field to /payments requests

### DIFF
--- a/Helper/Requests.php
+++ b/Helper/Requests.php
@@ -124,7 +124,7 @@ class Requests extends AbstractHelper
         }
 
         // TODO:: Can be implemented for guests after https://github.com/magento/magento2/issues/14509 is resolved.
-        if ($customerId !== 0) {
+        if ($customerId) {
             $customer = $this->customerRepository->getById($customerId);
             $dob = $customer->getDob();
 


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
`dateOfBirth` field is required for Adyen's new featured product Uplift. This PR adds the date of birth of a logged-in shopper to `/payments` API call.

This implementation can be extend later to cover guest shoppers after the issue [#14509](https://github.com/magento/magento2/issues/14509) is resolved on Magento 2 repository.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
Payment attempts for
- Logged-in shoppers w/wo valid date of birth
- Guest shoppers