### PR TITLE
[EPC-9585] Fix Amazon Pay button translation and locale

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/adyen-amazonpay-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-amazonpay-method.js
@@ -12,12 +12,14 @@ define(
         'Magento_Checkout/js/model/quote',
         'Adyen_Payment/js/view/payment/method-renderer/adyen-pm-method',
         'Adyen_Payment/js/model/adyen-checkout',
+        'Adyen_Payment/js/model/adyen-configuration',
         'mage/url'
     ],
     function(
         quote,
         adyenPaymentMethod,
         adyenCheckout,
+        adyenConfiguration,
         urlBuilder
     ) {
         const amazonSessionKey = 'amazonCheckoutSessionId';
@@ -55,6 +57,7 @@ define(
                 baseComponentConfiguration.productType = 'PayAndShip';
                 baseComponentConfiguration.checkoutMode = 'ProcessOrder';
                 baseComponentConfiguration.showPayButton = true;
+                baseComponentConfiguration.locale = adyenConfiguration.getLocale();
 
                 // Redirect shoppers to the cart page if they cancel the payment on Amazon Pay hosted page.
                 baseComponentConfiguration.cancelUrl = urlBuilder.build('checkout/cart');


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Amazon Pay requires a separate `locale` field in the component configuration. Missing locale field causes the button to fallback to the default language.

This PR adds `locale` configuration field to Amazon Pay component to load the correct button translation and redirect shopper to the correct region.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- Amazon Pay using German shopper locale