### PR TITLE
[ECP-9623] Installment Feature Not Working with Saved Credit Cards

### DIFF
--- a/Gateway/Request/RecurringVaultDataBuilder.php
+++ b/Gateway/Request/RecurringVaultDataBuilder.php
@@ -20,6 +20,7 @@ use Magento\Payment\Gateway\Data\PaymentDataObject;
 use Magento\Payment\Gateway\Helper\SubjectReader;
 use Magento\Payment\Gateway\Request\BuilderInterface;
 use Magento\Vault\Api\Data\PaymentTokenFactoryInterface;
+use Adyen\Payment\Observer\AdyenCcDataAssignObserver;
 
 class RecurringVaultDataBuilder implements BuilderInterface
 {
@@ -95,6 +96,14 @@ class RecurringVaultDataBuilder implements BuilderInterface
                 $paymentMethod->getProviderCode(),
                 $order->getStoreId()
             );
+        }
+
+        $numberOfInstallments = $payment->getAdditionalInformation(
+            AdyenCcDataAssignObserver::NUMBER_OF_INSTALLMENTS
+        );
+
+        if (!empty($numberOfInstallments)) {
+            $requestBody['installments']['value'] = (int) $numberOfInstallments;
         }
 
         return [

--- a/view/frontend/web/js/view/payment/method-renderer/adyen-cc-vault-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-cc-vault-method.js
@@ -259,8 +259,9 @@ define([
                 additional_data: {
                     stateData: stateData,
                     public_hash: this.publicHash,
-                    numberOfInstallments: this.installment(),
-                    frontendType: 'default'
+                    'number_of_installments': self.installment(),
+                    frontendType: 'default',
+                    'cc_type': self.getCcCodeByAltCode(self.getCardType())
                 },
             };
         },


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
When using the Adyen module complete a payment with an already saved credit card, the installment feature does not work as expected. The user can select the installment options during checkout, but even if, for example, 5 installments are chosen, the payment is finalized as a single installment (1x).

This issue does not occur when the user manually enters the credit card details during checkout. It only happens when using a saved card, where the card information is preloaded, and the installment options are then presented.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

Fixes  <!-- #-prefixed github issue number -->
#2845 
