### PR TITLE
[EPC-9193] Set base_amount_authorized after processing authorisation webhook

### DIFF
--- a/Helper/Webhook/AuthorisationWebhookHandler.php
+++ b/Helper/Webhook/AuthorisationWebhookHandler.php
@@ -14,7 +14,6 @@ namespace Adyen\Payment\Helper\Webhook;
 
 use Adyen\Payment\Helper\AdyenOrderPayment;
 use Adyen\Payment\Helper\CaseManagement;
-use Adyen\Payment\Helper\ChargedCurrency;
 use Adyen\Payment\Helper\Config;
 use Adyen\Payment\Helper\Invoice;
 use Adyen\Payment\Helper\Order as OrderHelper;
@@ -36,7 +35,6 @@ class AuthorisationWebhookHandler implements WebhookHandlerInterface
      * @param CaseManagement $caseManagementHelper
      * @param SerializerInterface $serializer
      * @param AdyenLogger $adyenLogger
-     * @param ChargedCurrency $chargedCurrency
      * @param Config $configHelper
      * @param Invoice $invoiceHelper
      * @param PaymentMethods $paymentMethodsHelper
@@ -48,7 +46,6 @@ class AuthorisationWebhookHandler implements WebhookHandlerInterface
         private readonly CaseManagement $caseManagementHelper,
         private readonly SerializerInterface $serializer,
         private readonly AdyenLogger $adyenLogger,
-        private readonly ChargedCurrency $chargedCurrency,
         private readonly Config $configHelper,
         private readonly Invoice $invoiceHelper,
         private readonly PaymentMethods $paymentMethodsHelper,
@@ -109,14 +106,13 @@ class AuthorisationWebhookHandler implements WebhookHandlerInterface
             if ($notification->getPaymentMethod() != "adyen_boleto" && !$order->getEmailSent()) {
                 $this->orderHelper->sendOrderMail($order);
             }
+
+            // Set authorized amount in sales_order_payment
+            $order->getPayment()->setAmountAuthorized($order->getGrandTotal());
+            $order->getPayment()->setBaseAmountAuthorized($order->getBaseGrandTotal());
         } else {
             $this->orderHelper->addWebhookStatusHistoryComment($order, $notification);
         }
-
-        // Set authorized amount in sales_order_payment
-        $orderAmountCurrency = $this->chargedCurrency->getOrderAmountCurrency($order, false);
-        $orderAmount = $orderAmountCurrency->getAmount();
-        $order->getPayment()->setAmountAuthorized($orderAmount);
 
         if ($notification->getPaymentMethod() == "c_cash" &&
             $this->configHelper->getConfigData('create_shipment', 'adyen_cash', $order->getStoreId())

--- a/Test/Unit/Helper/Webhook/AuthorisationWebhookHandlerTest.php
+++ b/Test/Unit/Helper/Webhook/AuthorisationWebhookHandlerTest.php
@@ -34,10 +34,10 @@ class AuthorisationWebhookHandlerTest extends AbstractAdyenTestCase
     protected function setUp(): void
     {
         parent::setUp();
+
         $this->orderMock = $this->createOrder();
         $this->adyenOrderPaymentMock = $this->createMock(AdyenOrderPayment::class);
         $this->orderAmountCurrency = $this->createMock(AdyenAmountCurrency::class);
-        $this->chargedCurrencyMock = $this->createMock(ChargedCurrency::class);
         $this->notificationMock = $this->createMock(Notification::class);
         $this->orderMock = $this->createMock(Order::class);
         $this->orderHelperMock = $this->createMock(OrderHelper::class);
@@ -66,13 +66,6 @@ class AuthorisationWebhookHandlerTest extends AbstractAdyenTestCase
     public function testHandleWebhook(): void
     {
         // Set up expectations for mock objects
-        $orderAmountCurrency = new AdyenAmountCurrency(
-            10.33,
-            'EUR',
-            null,
-            null,
-            10.33
-        );
         $storeId = 1;
         $paymentMock = $this->createConfiguredMock(Order\Payment::class, [
             'getMethod' => 'adyen_cc'
@@ -87,9 +80,7 @@ class AuthorisationWebhookHandlerTest extends AbstractAdyenTestCase
         $paymentMethodsHelperMock = $this->createConfiguredMock(PaymentMethods::class, [
             'isAutoCapture' => true
         ]);
-        $mockChargedCurrency = $this->createConfiguredMock(ChargedCurrency::class, [
-            'getOrderAmountCurrency' => $orderAmountCurrency
-        ]);
+
 
         $transitionState = PaymentStates::STATE_PAID;
 
@@ -102,7 +93,6 @@ class AuthorisationWebhookHandlerTest extends AbstractAdyenTestCase
             null,
             null,
             null,
-            $mockChargedCurrency,
             null,
             null,
             $paymentMethodsHelperMock,
@@ -142,10 +132,6 @@ class AuthorisationWebhookHandlerTest extends AbstractAdyenTestCase
             $orderAmount
         );
 
-        $mockChargedCurrency = $this->createConfiguredMock(ChargedCurrency::class, [
-            'getOrderAmountCurrency' => $this->orderAmountCurrency
-        ]);
-
         // Create mock instances for Order and Notification
         $paymentMock = $this->createMock(Order::class);
         $storeId = 1;
@@ -177,7 +163,6 @@ class AuthorisationWebhookHandlerTest extends AbstractAdyenTestCase
             null,
             null,
             null,
-            $mockChargedCurrency,
             null,
             null,
             $paymentMethodsMock,
@@ -291,7 +276,6 @@ class AuthorisationWebhookHandlerTest extends AbstractAdyenTestCase
             null,
             null,
             null,
-            null,
             $cartRepositoryMock
         );
 
@@ -397,7 +381,6 @@ class AuthorisationWebhookHandlerTest extends AbstractAdyenTestCase
         $mockCaseManagementHelper = null,
         $mockSerializer = null,
         $mockAdyenLogger = null,
-        $mockChargedCurrency = null,
         $mockConfigHelper = null,
         $mockInvoiceHelper = null,
         $mockPaymentMethodsHelper = null,
@@ -423,10 +406,6 @@ class AuthorisationWebhookHandlerTest extends AbstractAdyenTestCase
             $mockAdyenLogger = $this->createMock(AdyenLogger::class);
         }
 
-        if (is_null($mockChargedCurrency)) {
-            $mockChargedCurrency = $this->createMock(ChargedCurrency::class);
-        }
-
         if (is_null($mockConfigHelper)) {
             $mockConfigHelper = $this->createMock(Config::class);
         }
@@ -449,7 +428,6 @@ class AuthorisationWebhookHandlerTest extends AbstractAdyenTestCase
             $mockCaseManagementHelper,
             $mockSerializer,
             $mockAdyenLogger,
-            $mockChargedCurrency,
             $mockConfigHelper,
             $mockInvoiceHelper,
             $mockPaymentMethodsHelper,


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Magento has two fields on `sales_order_payment` table to indicate the total authorized amount of the order. From which, the one reserved for base authorized amount is not filled correctly by the plugin. This PR updates how the plugin sets `amount_authorized` and `base_amount_authorized` fields of `sales_order_payment` table.

This fields are populated after the full amount is authorized considering the partial payments as well.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
Authorize the payments with the following test cases
- `charged_currency` is `display`, order is placed with the base currency
- `charged_currency` is `display`, order is placed with an alternative currency
- `charged_currency` is `base`, order is placed with an alternative currency