### PR TITLE
[ECP-9684] Fix OrderRepository constructor to support M2.4.8

### DIFF
--- a/Model/Sales/OrderRepository.php
+++ b/Model/Sales/OrderRepository.php
@@ -25,6 +25,7 @@ use Magento\Sales\Api\Data\OrderSearchResultInterfaceFactory as SearchResultFact
 use Magento\Sales\Model\OrderRepository as SalesOrderRepository;
 use Magento\Sales\Model\ResourceModel\Metadata;
 use Magento\Tax\Api\OrderTaxManagementInterface;
+use Magento\Sales\Model\Order\ShippingAssignmentBuilder;
 
 class OrderRepository extends SalesOrderRepository
 {
@@ -41,21 +42,21 @@ class OrderRepository extends SalesOrderRepository
         Metadata $metadata,
         SearchResultFactory $searchResultFactory,
         CollectionProcessorInterface $collectionProcessor = null,
-        OrderExtensionFactory $orderExtensionFactory = null,
         OrderTaxManagementInterface $orderTaxManagement = null,
         PaymentAdditionalInfoInterfaceFactory $paymentAdditionalInfoFactory = null,
         JsonSerializer $serializer = null,
-        JoinProcessorInterface $extensionAttributesJoinProcessor = null
+        JoinProcessorInterface $extensionAttributesJoinProcessor = null,
+        ShippingAssignmentBuilder $shippingAssignmentBuilder = null
     ) {
         parent::__construct(
             $metadata,
             $searchResultFactory,
             $collectionProcessor,
-            $orderExtensionFactory,
             $orderTaxManagement,
             $paymentAdditionalInfoFactory,
             $serializer,
-            $extensionAttributesJoinProcessor
+            $extensionAttributesJoinProcessor,
+            $shippingAssignmentBuilder
         );
 
         $this->searchCriteriaBuilder = $searchCriteriaBuilder;


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Since, Adobe refactored the constructor arguments of [OrderRepository](https://github.com/magento/magento2/blob/94b8544e82fd84d1443060cddb5481b7fd462de2/app/code/Magento/Sales/Model/OrderRepository.php#L91). Due to these changes, our extension of this class has been affected.

This breaking change affects CLI commands and the setup:upgrade and di:compile commands fail.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

Fixes  <!-- #-prefixed github issue number -->
