### PR TITLE
[ECP-9685] Start using Magento 2.4.8 on automated test pipelines

### DIFF
--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -39,8 +39,8 @@ RUN apt-get update \
         cron \
         unzip
 
-RUN docker-php-ext-configure gd --with-freetype --with-jpeg
-RUN docker-php-ext-install -j$(nproc) bcmath gd intl pdo_mysql simplexml soap sockets xsl zip
+RUN docker-php-ext-configure gd --with-freetype --with-jpeg ftp --with-openssl-dir=/usr
+RUN docker-php-ext-install -j$(nproc) bcmath gd intl pdo_mysql simplexml soap sockets xsl zip ftp
 RUN a2enmod ssl
 RUN a2ensite default-ssl.conf #can be removed if not needed
 WORKDIR /var/www/html

--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -39,7 +39,8 @@ RUN apt-get update \
         cron \
         unzip
 
-RUN docker-php-ext-configure gd --with-freetype --with-jpeg ftp --with-openssl-dir=/usr
+RUN docker-php-ext-configure gd --with-freetype --with-jpeg
+RUN docker-php-ext-configure ftp --with-openssl-dir=/usr
 RUN docker-php-ext-install -j$(nproc) bcmath gd intl pdo_mysql simplexml soap sockets xsl zip ftp
 RUN a2enmod ssl
 RUN a2ensite default-ssl.conf #can be removed if not needed

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       matrix:
         php-version: ["8.3"]
-        magento-version: ["2.4.7-p2"]
+        magento-version: ["2.4.8"]
     runs-on:
       group: larger-runners
       labels: ubuntu-latest-8-cores

--- a/.github/workflows/graphql-test.yml
+++ b/.github/workflows/graphql-test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         php-version: ["8.2"]
-        magento-version: ["2.4.6-p7"]
+        magento-version: ["2.4.8"]
     runs-on: ubuntu-latest
     timeout-minutes: 25
     env:

--- a/.github/workflows/mftf-test.yml
+++ b/.github/workflows/mftf-test.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         include:
           - php-version: '8.3'
-            magento-version: '2.4.7-p2'
+            magento-version: '2.4.8'
     runs-on: ubuntu-latest
     timeout-minutes: 25
     env:

--- a/.github/workflows/restapi-test.yml
+++ b/.github/workflows/restapi-test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         php-version: [8.3]
-        magento-version: [2.4.7-p2]
+        magento-version: [2.4.8]
     runs-on: ubuntu-latest
     timeout-minutes: 25
     env:


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
This PR upgrades the Magento version used on the automated test pipelines.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- Github workflows