### PR TITLE
[ECP-9687] Bump Magento dependencies and drop PHP 8.1 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "adyen/module-payment",
   "description": "Official Magento2 Plugin to connect to Payment Service Provider Adyen.",
   "type": "magento2-module",
-  "version": "9.17.1",
+  "version": "10.0.0-rc1",
   "license": "MIT",
   "repositories": [
     {
@@ -11,21 +11,21 @@
     }
   ],
   "require": {
-    "php": ">=8.1",
+    "php": ">=8.2",
     "adyen/php-api-library": "^27.0.0",
     "adyen/php-webhook-module": "^1",
-    "magento/framework": ">=103.0.4",
-    "magento/module-vault": ">=101.2.4",
-    "magento/module-multishipping": ">=100.4.4",
-    "magento/module-graph-ql": ">=100.4.4",
-    "magento/module-instant-purchase": ">=100.4.3",
-    "magento/module-checkout-agreements": ">=100.4.3",
+    "magento/framework": ">=103.0.8",
+    "magento/module-vault": ">=101.2.8",
+    "magento/module-multishipping": ">=100.4.8",
+    "magento/module-graph-ql": ">=100.4.8",
+    "magento/module-instant-purchase": ">=100.4.7",
+    "magento/module-checkout-agreements": ">=100.4.7",
     "ext-json": "*"
   },
   "require-dev": {
-    "phpunit/phpunit": "~9.6.1",
+    "phpunit/phpunit": "^10.5",
     "magento/magento-coding-standard": "*",
-    "squizlabs/php_codesniffer": "~3.11.0"
+    "squizlabs/php_codesniffer": "^3.12.2"
   },
   "autoload": {
     "files": [


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
This PR bumps the Magento 2 composer dependencies according to Magento 2.4.8 and drops PHP 8.1 support.
