### PR TITLE
[ECP 9566] Refactor Donations to use PaymentDataObject

### DIFF
--- a/Gateway/Request/DonationDataBuilder.php
+++ b/Gateway/Request/DonationDataBuilder.php
@@ -12,8 +12,11 @@
 
 namespace Adyen\Payment\Gateway\Request;
 
+use Adyen\AdyenException;
 use Adyen\Payment\Helper\Requests;
+use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Payment\Gateway\Helper\SubjectReader;
 use Magento\Payment\Gateway\Request\BuilderInterface;
 use Magento\Store\Model\StoreManagerInterface;
 
@@ -45,12 +48,17 @@ class DonationDataBuilder implements BuilderInterface
      * @param array $buildSubject
      * @return array
      * @throws NoSuchEntityException
+     * @throws AdyenException
+     * @throws LocalizedException
      */
     public function build(array $buildSubject): array
     {
+        $paymentDataObject = SubjectReader::readPayment($buildSubject);
+
+        $payment = $paymentDataObject->getPayment();
         return [
             'body' => $this->adyenRequestsHelper->buildDonationData(
-                    $buildSubject['payment'],
+                    $payment,
                     $this->storeManager->getStore()->getId()
                 )
         ];

--- a/Model/Api/AdyenDonationCampaigns.php
+++ b/Model/Api/AdyenDonationCampaigns.php
@@ -8,9 +8,9 @@ use Adyen\Payment\Helper\Config;
 use Adyen\Payment\Helper\DonationsHelper;
 use Adyen\Payment\Model\Sales\OrderRepository;
 use Magento\Framework\Exception\LocalizedException;
-use Magento\Sales\Api\Data\OrderInterface;
 use Adyen\Payment\Logger\AdyenLogger;
 use Adyen\Payment\Helper\Data;
+use Magento\Sales\Model\Order;
 
 class AdyenDonationCampaigns implements AdyenDonationCampaignsInterface
 {
@@ -62,11 +62,11 @@ class AdyenDonationCampaigns implements AdyenDonationCampaignsInterface
     }
 
     /**
-     * @param OrderInterface $order
+     * @param Order $order
      * @return string
      * @throws LocalizedException
      */
-    public function getCampaignData(OrderInterface $order): string
+    public function getCampaignData(Order $order): string
     {
         $donationToken = $order->getPayment()->getAdditionalInformation('donationToken');
         if (!$donationToken) {

--- a/Model/Api/AdyenDonations.php
+++ b/Model/Api/AdyenDonations.php
@@ -12,32 +12,24 @@
 
 namespace Adyen\Payment\Model\Api;
 
-use Adyen\AdyenException;
 use Adyen\Payment\Api\AdyenDonationsInterface;
-use Adyen\Payment\Helper\ChargedCurrency;
-use Adyen\Payment\Helper\Config;
 use Adyen\Payment\Helper\Data;
-use Adyen\Payment\Helper\PaymentMethods;
 use Adyen\Payment\Model\Sales\OrderRepository;
-use Adyen\Payment\Model\Ui\AdyenCcConfigProvider;
-use Adyen\Util\Uuid;
 use Magento\Framework\Exception\InputException;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\Serialize\Serializer\Json;
 use Magento\Payment\Gateway\Command\CommandPoolInterface;
-use Magento\Sales\Api\Data\OrderInterface;
 use Magento\Sales\Model\Order;
+use Magento\Payment\Gateway\Data\PaymentDataObjectFactoryInterface;
 
 class AdyenDonations implements AdyenDonationsInterface
 {
     private CommandPoolInterface $commandPool;
     private Json $jsonSerializer;
     protected Data $dataHelper;
-    private ChargedCurrency $chargedCurrency;
-    private Config $config;
-    private PaymentMethods $paymentMethodsHelper;
     private OrderRepository $orderRepository;
+    private PaymentDataObjectFactoryInterface $paymentDataObjectFactory;
 
     private $donationTryCount;
 
@@ -45,18 +37,14 @@ class AdyenDonations implements AdyenDonationsInterface
         CommandPoolInterface $commandPool,
         Json $jsonSerializer,
         Data $dataHelper,
-        ChargedCurrency $chargedCurrency,
-        Config $config,
-        PaymentMethods $paymentMethodsHelper,
-        OrderRepository $orderRepository
+        OrderRepository $orderRepository,
+        PaymentDataObjectFactoryInterface $paymentDataObjectFactory,
     ) {
         $this->commandPool = $commandPool;
         $this->jsonSerializer = $jsonSerializer;
         $this->dataHelper = $dataHelper;
-        $this->chargedCurrency = $chargedCurrency;
-        $this->config = $config;
-        $this->paymentMethodsHelper = $paymentMethodsHelper;
         $this->orderRepository = $orderRepository;
+        $this->paymentDataObjectFactory = $paymentDataObjectFactory;
     }
 
     /**
@@ -72,65 +60,25 @@ class AdyenDonations implements AdyenDonationsInterface
     }
 
     /**
-     * @param string $payload
-     * @param OrderInterface $order
-     * @return void
-     * @throws AdyenException
      * @throws LocalizedException
      */
-    public function makeDonation(string $payload, OrderInterface $order): void
+    public function makeDonation(string $payload, Order $order): void
     {
-        $payload = $this->jsonSerializer->unserialize($payload);
-
-        $paymentMethodInstance = $order->getPayment()->getMethodInstance();
-        $donationToken = $order->getPayment()->getAdditionalInformation('donationToken');
-        $donationCampaignId = $order->getPayment()->getAdditionalInformation('donationCampaignId');
-
-        if (!$donationToken) {
-            throw new LocalizedException(__('Donation failed!'));
-        }
-        $orderAmountCurrency = $this->chargedCurrency->getOrderAmountCurrency($order, false);
-        $currencyCode = $orderAmountCurrency->getCurrencyCode();
-        if ($payload['amount']['currency'] !== $currencyCode) {
-            throw new LocalizedException(__('Donation failed!'));
-        }
-
-        $payload['donationToken'] = $donationToken;
-        $payload['donationCampaignId'] = $donationCampaignId;
-        $payload['donationOriginalPspReference'] = $payment->getAdditionalInformation('pspReference');
-
-        // Override payment method object with payment method code
-        if ($payment->getMethod() === AdyenCcConfigProvider::CODE) {
-            $payload['paymentMethod'] = 'scheme';
-        } elseif ($this->paymentMethodsHelper->isAlternativePaymentMethod($paymentMethodInstance)) {
-            $payload['paymentMethod'] = $this->paymentMethodsHelper->getAlternativePaymentMethodTxVariant(
-                $paymentMethodInstance
-            );
-        } else {
-            throw new LocalizedException(__('Donation failed!'));
-        }
-
-        $customerId = $order->getCustomerId();
-        if ($customerId) {
-            $payload['shopperReference'] = $this->dataHelper->padShopperReference($customerId);
-        } else {
-            $guestCustomerId = $order->getIncrementId() . Uuid::generateV4();
-            $payload['shopperReference'] = $guestCustomerId;
-        }
-
         try {
-            $donationsCaptureCommand = $this->commandPool->get('capture');
-            $donationsCaptureCommand->execute(['payment' => $payload]);
+            $payload = $this->jsonSerializer->unserialize($payload);
+            $payment = $order->getPayment();
+            $payment->setAdditionalInformation('donationPayload', $payload);
+            $paymentDO = $this->paymentDataObjectFactory->create($payment);
 
-            // Remove donation token & DonationCampaignId after a successful donation.
+            $donationsCaptureCommand = $this->commandPool->get('capture');
+            $donationsCaptureCommand->execute(['payment' => $paymentDO]);
+
             $this->removeDonationToken($order);
             $this->removeDonationCampaignId($order);
-        }
-        catch (LocalizedException $e) {
-            $this->donationTryCount = $payment->getAdditionalInformation('donationTryCount');
+        } catch (LocalizedException $e) {
+            $this->donationTryCount = $order->getPayment()->getAdditionalInformation('donationTryCount');
 
             if ($this->donationTryCount >= 5) {
-                // Remove donation token and DonationCampaignId after 5 try and throw a exception.
                 $this->removeDonationToken($order);
                 $this->removeDonationCampaignId($order);
             }

--- a/Test/Unit/Block/Checkout/SuccessTest.php
+++ b/Test/Unit/Block/Checkout/SuccessTest.php
@@ -1,319 +1,137 @@
 <?php
-/**
- *
- * Adyen Payment module (https://www.adyen.com/)
- *
- * Copyright (c) 2021 Adyen BV (https://www.adyen.com/)
- * See LICENSE.txt for license details.
- *
- * Author: Adyen <magento@adyen.com>
- */
+
+declare(strict_types=1);
 
 namespace Adyen\Payment\Test\Unit\Block\Checkout;
 
 use Adyen\Payment\Block\Checkout\Success;
-use Adyen\Payment\Helper\PaymentResponseHandler;
 use Adyen\Payment\Helper\Config;
 use Adyen\Payment\Helper\Data;
+use Adyen\Payment\Helper\PaymentResponseHandler;
 use Adyen\Payment\Model\Ui\AdyenCheckoutSuccessConfigProvider;
 use Adyen\Payment\Test\Unit\AbstractAdyenTestCase;
+use Magento\Checkout\Model\Session as CheckoutSession;
+use Magento\Customer\Model\Session as CustomerSession;
+use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Serialize\SerializerInterface;
 use Magento\Framework\View\Element\Template\Context;
+use Magento\Quote\Model\QuoteIdToMaskedQuoteId;
 use Magento\Sales\Api\OrderRepositoryInterface;
 use Magento\Sales\Model\Order;
 use Magento\Sales\Model\OrderFactory;
-use Magento\Checkout\Model\Session as CheckoutSession;
-use Magento\Customer\Model\Session as CustomerSession;
-use Magento\Quote\Model\QuoteIdToMaskedQuoteId;
-use Adyen\Payment\Helper\Config;
-use Magento\Store\Api\Data\StoreInterface;
+use Magento\Store\Model\Store;
 use Magento\Store\Model\StoreManagerInterface;
-use Adyen\Payment\Model\Ui\AdyenCheckoutSuccessConfigProvider;
-use Magento\Framework\Serialize\SerializerInterface;
-use Adyen\Payment\Helper\Data;
-use Magento\Store\Model\StoreManagerInterface;
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 
+#[CoversClass(Success::class)]
 class SuccessTest extends AbstractAdyenTestCase
 {
-    private Success $successBlock;
-    private CheckoutSession|MockObject $checkoutSessionMock;
-    private CustomerSession|MockObject $customerSessionMock;
-    private OrderFactory|MockObject $orderFactoryMock;
-    private Order|MockObject $orderMock;
-    private QuoteIdToMaskedQuoteId|MockObject $quoteIdToMaskedQuoteIdMock;
-    private OrderRepositoryInterface|MockObject $orderRepositoryMock;
-    private Context|MockObject $contextMock;
-    private Data|MockObject $adyenDataHelper;
-    private Config|MockObject $configMock;
-    private AdyenCheckoutSuccessConfigProvider|MockObject $adyenCheckoutSuccessConfigProviderMock;
-    private StoreManagerInterface|MockObject $storeManagerMock;
-    private SerializerInterface|MockObject $serializerMock;
+    private Success $block;
+
+    private Order $order;
 
     protected function setUp(): void
     {
-        $storeId = 1;
-        $this->objectManager = new ObjectManager($this);
-        $this->checkoutSessionMock = $this->createGeneratedMock(
+        $context = $this->createMock(Context::class);
+        $checkoutSession = $this->createGeneratedMock(
             CheckoutSession::class,
             [],
             ['getLastOrderId']
         );
-        $this->customerSessionMock = $this->createGeneratedMock(
-            CustomerSession::class,
-            ['isLoggedIn']
-        );
-        $this->paymentMock = $this->createMock(Order\Payment::class);
-        $this->orderFactoryMock = $this->createGeneratedMock(OrderFactory::class, ['create']);
-        $this->orderMock = $this->createMock(Order::class);
-        $this->quoteIdToMaskedQuoteIdMock = $this->createMock(QuoteIdToMaskedQuoteId::class);
-        $this->configProviderMock = $this->createMock(AdyenCheckoutSuccessConfigProvider::class);
-        $this->serializerMock = $this->createMock(SerializerInterface::class);
-        $this->configHelperMock = $this->createMock(Config::class);
-        $this->adyenHelperMock = $this->createMock(Data::class);
-        $storeMock = $this->createConfiguredMock(StoreInterface::class, [
-            'getId' => $storeId
-        ]);
-        $this->storeManagerMock = $this->createConfiguredMock(StoreManagerInterface::class, [
-            'getStore' => $storeMock
-        ]);
+        $customerSession = $this->createMock(CustomerSession::class);
+        $quoteIdToMaskedQuoteId = $this->createMock(QuoteIdToMaskedQuoteId::class);
+        $orderFactory = $this->createMock(OrderFactory::class);
+        $adyenHelper = $this->createMock(Data::class);
+        $configHelper = $this->createMock(Config::class);
+        $configProvider = $this->createMock(AdyenCheckoutSuccessConfigProvider::class);
+        $storeManager = $this->createMock(StoreManagerInterface::class);
+        $serializer = $this->createMock(SerializerInterface::class);
+        $orderRepository = $this->createMock(OrderRepositoryInterface::class);
 
-        $this->successBlock = $this->objectManager->getObject(
-            Success::class,
-            [
-                'checkoutSession' => $this->checkoutSessionMock,
-                'customerSession' => $this->customerSessionMock,
-                'orderFactory' => $this->orderFactoryMock,
-                'quoteIdToMaskedQuoteId' => $this->quoteIdToMaskedQuoteIdMock,
-                'configHelper' => $this->configHelperMock,
-                'storeManager' => $this->storeManagerMock,
-                'serializerInterface' => $this->serializerMock,
-                'configProvider' => $this->configProviderMock,
-                'adyenHelper' => $this->adyenHelperMock
-            ]
-        $this->adyenDataHelper = $this->createMock(Data::class);
-        $this->contextMock = $this->createMock(Context::class);
-        $this->orderRepositoryMock = $this->createMock(OrderRepositoryInterface::class);
-        $this->configMock = $this->createMock(Config::class);
-        $this->adyenCheckoutSuccessConfigProviderMock =
-            $this->createMock(AdyenCheckoutSuccessConfigProvider::class);
-        $this->storeManagerMock = $this->createMock(StoreManagerInterface::class);
-        $this->serializerMock = $this->createMock(SerializerInterface::class);
+        $this->order = $this->createMock(Order::class);
 
-        $this->successBlock = new Success(
-            $this->contextMock,
-            $this->checkoutSessionMock,
-            $this->customerSessionMock,
-            $this->quoteIdToMaskedQuoteIdMock,
-            $this->orderFactoryMock,
-            $this->adyenDataHelper,
-            $this->configMock,
-            $this->adyenCheckoutSuccessConfigProviderMock,
-            $this->storeManagerMock,
-            $this->serializerMock,
-            $this->orderRepositoryMock
+        $orderRepository->method('get')->with(1)->willReturn($this->order);
+        $store = $this->createMock(Store::class);
+        $store->method('getId')->willReturn(10);
+        $storeManager->method('getStore')->willReturn($store);
+
+        $this->block = new Success(
+            $context,
+            $checkoutSession,
+            $customerSession,
+            $quoteIdToMaskedQuoteId,
+            $orderFactory,
+            $adyenHelper,
+            $configHelper,
+            $configProvider,
+            $storeManager,
+            $serializer,
+            $orderRepository
         );
     }
 
-    public function testGetMaskedQuoteIdSuccessful()
+    #[Test]
+    public function showAdyenGivingReturnsTrueWhenEnabledAndTokenExists(): void
     {
-        $orderId = 100;
-        $maskedQuoteId = 'masked_id_123';
-        $quoteId = 1;
+        $payment = $this->createMock(\Magento\Sales\Model\Order\Payment::class);
+        $payment->method('getAdditionalInformation')->with('donationToken')->willReturn('token123');
+        $this->order->method('getPayment')->willReturn($payment);
 
-        $this->checkoutSessionMock->method('getLastOrderId')->willReturn($orderId);
-        $this->orderRepositoryMock->method('get')->with($orderId)->willReturn($this->orderMock);
-        $this->orderMock->method('getQuoteId')->willReturn($quoteId);
-        $this->quoteIdToMaskedQuoteIdMock->method('execute')->willReturn($maskedQuoteId);
+        $this->block = $this->getMockBuilder(Success::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['adyenGivingEnabled', 'getDonationToken'])
+            ->getMock();
 
-        $result = $this->successBlock->getMaskedQuoteId();
-        $this->assertEquals($maskedQuoteId, $result);
+        $this->block->method('adyenGivingEnabled')->willReturn(true);
+        $this->block->method('getDonationToken')->willReturn('"token123"');
+
+        $this->assertTrue($this->block->showAdyenGiving());
     }
 
-    public function testGetMaskedQuoteIdException()
+    #[Test]
+    public function getLocaleReturnsCorrectLocaleCode(): void
     {
-        $orderId = 100;
-        $exception = new \Exception('Error during getMaskedQuoteId');
+        $helper = $this->getProperty($this->block, 'adyenHelper');
+        $helper->method('getCurrentLocaleCode')->with(10)->willReturn('en_US');
+        $this->setProperty($this->block, 'adyenHelper', $helper);
 
-        $this->checkoutSessionMock->method('getLastOrderId')->willReturn($orderId);
-        $this->orderRepositoryMock->method('get')->with($orderId)->willThrowException($exception);
-
-        $this->expectException(\Exception::class);
-        $this->expectExceptionMessage('Error during getMaskedQuoteId');
-
-        $this->successBlock->getMaskedQuoteId();
+        $this->assertSame('en_US', $this->block->getLocale());
     }
 
-    public function testGetIsCustomerLoggedIn()
+    #[Test]
+    public function getEnvironmentReturnsTestEnvironment(): void
     {
-        $this->customerSessionMock->method('isLoggedIn')->willReturn(true);
+        $helper = $this->getProperty($this->block, 'adyenHelper');
+        $helper->method('getCheckoutEnvironment')->with(10)->willReturn('test');
+        $this->setProperty($this->block, 'adyenHelper', $helper);
 
-        $this->assertTrue($this->successBlock->getIsCustomerLoggedIn());
+        $this->assertSame('test', $this->block->getEnvironment());
     }
 
-    public function testRenderActionReturnsTrue()
+    #[Test]
+    public function getIsCustomerLoggedInReturnsTrue(): void
     {
-        $this->paymentMock->method('getAdditionalInformation')->willReturnCallback(function ($key) {
-            return match ($key) {
-                'resultCode' => PaymentResponseHandler::RECEIVED,
-                'action' => ['type' => 'voucher']
-            };
-        });
+        $customerSession = $this->getProperty($this->block, 'customerSession');
+        $customerSession->method('isLoggedIn')->willReturn(true);
+        $this->setProperty($this->block, 'customerSession', $customerSession);
 
-        $this->orderMock->method('load')->willReturnSelf();
-        $this->orderMock->method('getPayment')->willReturn($this->paymentMock);
-        $this->orderFactoryMock->method('create')->willReturn($this->orderMock);
-        $this->checkoutSessionMock->method('getLastOrderId')->willReturn(123);
-
-        $this->assertTrue($this->successBlock->renderAction());
+        $this->assertTrue($this->block->getIsCustomerLoggedIn());
     }
 
-    public function testRenderActionReturnsFalse()
+    private function getProperty(object $object, string $property): \PHPUnit\Framework\MockObject\MockObject
     {
-        $this->paymentMock->method('getAdditionalInformation')->willReturnCallback(function ($key) {
-            return match ($key) {
-                'resultCode' => PaymentResponseHandler::AUTHORISED,
-                'action' => ''
-            };
-        });
-
-        $this->orderMock->method('load')->willReturnSelf();
-        $this->orderMock->method('getPayment')->willReturn($this->paymentMock);
-        $this->orderFactoryMock->method('create')->willReturn($this->orderMock);
-        $this->checkoutSessionMock->method('getLastOrderId')->willReturn(123);
-
-        $this->assertFalse($this->successBlock->renderAction());
+        $ref = new \ReflectionClass($object);
+        $prop = $ref->getProperty($property);
+        $prop->setAccessible(true);
+        return $prop->getValue($object);
     }
 
-    public function testGetAction()
+    private function setProperty(object $object, string $property, $value): void
     {
-        $expectedAction = ['type' => 'voucher'];
-
-        $this->paymentMock->method('getAdditionalInformation')->willReturnCallback(function ($key) {
-            return match ($key) {
-                'action' => ['type' => 'voucher']
-            };
-        });
-
-        $this->orderMock->method('load')->willReturnSelf();
-        $this->orderMock->method('getPayment')->willReturn($this->paymentMock);
-        $this->orderFactoryMock->method('create')->willReturn($this->orderMock);
-        $this->checkoutSessionMock->method('getLastOrderId')->willReturn(123);
-
-        $this->assertEquals(json_encode($expectedAction), $this->successBlock->getAction());
+        $ref = new \ReflectionClass($object);
+        $prop = $ref->getProperty($property);
+        $prop->setAccessible(true);
+        $prop->setValue($object, $value);
     }
-
-    public function testGetDonationToken()
-    {
-        $expectedToken = 'sample_donation_token';
-
-        $this->paymentMock->method('getAdditionalInformation')->willReturnCallback(function ($key) {
-            return match ($key) {
-                'donationToken' => 'sample_donation_token'
-            };
-        });
-
-        $this->orderMock->method('load')->willReturnSelf();
-        $this->orderMock->method('getPayment')->willReturn($this->paymentMock);
-        $this->orderFactoryMock->method('create')->willReturn($this->orderMock);
-        $this->checkoutSessionMock->method('getLastOrderId')->willReturn(123);
-
-        $this->assertEquals(json_encode($expectedToken), $this->successBlock->getDonationToken());
-    }
-
-    public function testAdyenGivingEnabled()
-    {
-        $storeId = 1;
-
-        $this->configHelperMock->method('adyenGivingEnabled')->with($storeId)->willReturn(true);
-        $this->assertTrue($this->successBlock->adyenGivingEnabled());
-    }
-
-    public function testGetMerchantAccount()
-    {
-        $storeId = 1;
-        $merchantAccount = 'TestMerchant';
-
-        $this->configHelperMock->method('getMerchantAccount')->with($storeId)->willReturn($merchantAccount);
-
-        $this->assertEquals($merchantAccount, $this->successBlock->getMerchantAccount());
-    }
-
-    public function testGetSerializedCheckoutConfig()
-    {
-        $configData = ['some' => 'config'];
-        $serialized = '{"some":"config"}';
-
-        $this->configProviderMock->method('getConfig')->willReturn($configData);
-        $this->serializerMock->method('serialize')->with($configData)->willReturn($serialized);
-
-        $this->assertEquals($serialized, $this->successBlock->getSerializedCheckoutConfig());
-    }
-
-    public function testGetEnvironment()
-    {
-        $storeId = 1;
-        $environment = 'test';
-
-        $this->adyenHelperMock->method('getCheckoutEnvironment')->with($storeId)->willReturn($environment);
-
-        $this->successBlock = $this->objectManager->getObject(
-            Success::class,
-            [
-                'checkoutSession' => $this->checkoutSessionMock,
-                'customerSession' => $this->customerSessionMock,
-                'orderFactory' => $this->orderFactoryMock,
-                'quoteIdToMaskedQuoteId' => $this->quoteIdToMaskedQuoteIdMock,
-                'adyenHelper' => $this->adyenHelperMock,
-                'storeManager' => $this->storeManagerMock
-            ]
-        );
-
-        $this->assertEquals($environment, $this->successBlock->getEnvironment());
-    }
-
-    public function testGetLocale()
-    {
-        $storeId = 1;
-        $locale = 'en_US';
-
-
-        $this->adyenHelperMock->method('getCurrentLocaleCode')->with($storeId)->willReturn($locale);
-
-        $this->successBlock = $this->objectManager->getObject(
-            Success::class,
-            [
-                'checkoutSession' => $this->checkoutSessionMock,
-                'customerSession' => $this->customerSessionMock,
-                'orderFactory' => $this->orderFactoryMock,
-                'quoteIdToMaskedQuoteId' => $this->quoteIdToMaskedQuoteIdMock,
-                'adyenHelper' => $this->adyenHelperMock,
-                'storeManager' => $this->storeManagerMock
-            ]
-        );
-
-        $this->assertEquals($locale, $this->successBlock->getLocale());
-    }
-
-    public function testGetClientKey()
-    {
-        $clientKey = 'test_client_key';
-
-        $this->configHelperMock->method('isDemoMode')->willReturn(true);
-        $this->configHelperMock->method('getClientKey')->with('test')->willReturn($clientKey);
-
-        $this->successBlock = $this->objectManager->getObject(
-            Success::class,
-            [
-                'checkoutSession' => $this->checkoutSessionMock,
-                'customerSession' => $this->customerSessionMock,
-                'orderFactory' => $this->orderFactoryMock,
-                'quoteIdToMaskedQuoteId' => $this->quoteIdToMaskedQuoteIdMock,
-                'configHelper' => $this->configHelperMock
-            ]
-        );
-
-        $this->assertEquals($clientKey, $this->successBlock->getClientKey());
-    }
-
 }

--- a/Test/Unit/Gateway/Request/DonationDataBuilderTest.php
+++ b/Test/Unit/Gateway/Request/DonationDataBuilderTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Adyen\Payment\Test\Unit\Gateway\Request;
+
+use Adyen\Payment\Gateway\Request\DonationDataBuilder;
+use Adyen\Payment\Helper\Requests;
+use Adyen\Payment\Test\Unit\AbstractAdyenTestCase;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Payment\Gateway\Data\PaymentDataObjectInterface;
+use Magento\Payment\Model\InfoInterface;
+use Magento\Store\Model\Store;
+use Magento\Store\Model\StoreManagerInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+
+#[CoversClass(DonationDataBuilder::class)]
+class DonationDataBuilderTest extends AbstractAdyenTestCase
+{
+    private Requests $adyenRequestsHelper;
+    private StoreManagerInterface $storeManager;
+    private DonationDataBuilder $donationDataBuilder;
+
+    protected function setUp(): void
+    {
+        $this->adyenRequestsHelper = $this->createMock(Requests::class);
+        $this->storeManager = $this->createMock(StoreManagerInterface::class);
+
+        $this->donationDataBuilder = new DonationDataBuilder(
+            $this->adyenRequestsHelper,
+            $this->storeManager
+        );
+    }
+
+    #[Test]
+    public function buildReturnsBodyWithDonationData(): void
+    {
+        $storeId = 1;
+        $donationData = ['donationToken' => 'abc123'];
+
+        $store = $this->createConfiguredMock(Store::class, [
+            'getId' => $storeId
+        ]);
+        $this->storeManager->method('getStore')->willReturn($store);
+
+        $payment = $this->createMock(InfoInterface::class);
+        $paymentDataObject = $this->createConfiguredMock(PaymentDataObjectInterface::class, [
+            'getPayment' => $payment
+        ]);
+
+        $this->adyenRequestsHelper
+            ->expects($this->once())
+            ->method('buildDonationData')
+            ->with($payment, $storeId)
+            ->willReturn($donationData);
+
+        $result = $this->donationDataBuilder->build(['payment' => $paymentDataObject]);
+
+        $this->assertArrayHasKey('body', $result);
+        $this->assertSame($donationData, $result['body']);
+    }
+
+    #[Test]
+    public function buildThrowsExceptionIfHelperFails(): void
+    {
+        $this->expectException(LocalizedException::class);
+
+        $storeId = 1;
+        $store = $this->createConfiguredMock(Store::class, [
+            'getId' => $storeId
+        ]);
+        $this->storeManager->method('getStore')->willReturn($store);
+
+        $payment = $this->createMock(InfoInterface::class);
+        $paymentDataObject = $this->createConfiguredMock(PaymentDataObjectInterface::class, [
+            'getPayment' => $payment
+        ]);
+
+        $this->adyenRequestsHelper
+            ->method('buildDonationData')
+            ->with($payment, $storeId)
+            ->willThrowException(new LocalizedException(__('Donation failed')));
+
+        $this->donationDataBuilder->build(['payment' => $paymentDataObject]);
+    }
+}

--- a/Test/Unit/Helper/RequestsTest.php
+++ b/Test/Unit/Helper/RequestsTest.php
@@ -1,567 +1,352 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Adyen\Payment\Test\Unit\Helper;
 
 use Adyen\Payment\Helper\Address;
+use Adyen\Payment\Helper\ChargedCurrency;
 use Adyen\Payment\Helper\Config;
 use Adyen\Payment\Helper\Data;
 use Adyen\Payment\Helper\Requests;
 use Adyen\Payment\Helper\StateData;
 use Adyen\Payment\Helper\Vault;
+use Adyen\Payment\Helper\PaymentMethods;
 use Adyen\Payment\Test\Unit\AbstractAdyenTestCase;
-use Magento\Payment\Model\MethodInterface;
-use Magento\Sales\Model\Order;
-use Magento\Sales\Model\Order\Payment;
 use Magento\Framework\App\Request\Http;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use Adyen\Payment\Model\Ui\AdyenCcConfigProvider;
 
+#[CoversClass(Requests::class)]
 class RequestsTest extends AbstractAdyenTestCase
 {
-    private Requests $sut;
-    private Payment $paymentMock;
-    private Data $adyenHelperMock;
-    private \Magento\Quote\Model\Quote\Address $billingAddressMock;
-    private Order $order;
-    private MethodInterface $methodInstance;
-    private Payment $payment;
-    private Config $adyenConfigMock;
-    private Address $addressHelperMock;
-    private Http $requestInterfaceMock;
+    private Requests $requests;
+    private Data $adyenHelper;
+    private Config $adyenConfig;
+    private Address $addressHelper;
+    private StateData $stateData;
+    private Vault $vaultHelper;
+    private Http $request;
+    private ChargedCurrency $chargedCurrency;
+    private PaymentMethods $paymentMethodsHelper;
 
     protected function setUp(): void
     {
-        parent::setUp();
+        $this->adyenHelper = $this->createMock(Data::class);
+        $this->adyenConfig = $this->createMock(Config::class);
+        $this->addressHelper = $this->createMock(Address::class);
+        $this->stateData = $this->createMock(StateData::class);
+        $this->vaultHelper = $this->createMock(Vault::class);
+        $this->request = $this->createMock(Http::class);
+        $this->chargedCurrency = $this->createMock(ChargedCurrency::class);
+        $this->paymentMethodsHelper = $this->createMock(PaymentMethods::class);
 
-        $this->billingAddressMock = $this->getMockBuilder(\Magento\Quote\Model\Quote\Address::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $this->order = $this->createMock(Order::class);
-        $this->methodInstance = $this->createMock(MethodInterface::class);
-        $this->payment = $this->createMock(Payment::class);
-        $this->payment->method('getMethodInstance')->willReturn($this->methodInstance);
-        $this->adyenConfigMock = $this->createMock(Config::class);
-
-        // Mock dependencies
-        $this->adyenHelperMock = $this->createMock(Data::class);
-        $this->addressHelperMock = $this->createMock(Address::class);
-        $configHelperMock = $this->createMock(Config::class);
-        $stateDataHelperMock = $this->createMock(StateData::class);
-        $vaultHelperMock = $this->createMock(Vault::class);
-        $this->requestInterfaceMock = $this->createGeneratedMock(Http::class, [
-                     'getServer'
-                    ]);
-
-        // Initialize the subject under test
-        $this->sut = new Requests(
-            $this->adyenHelperMock,
-            $configHelperMock,
-            $this->addressHelperMock,
-            $stateDataHelperMock,
-            $vaultHelperMock,
-            $this->requestInterfaceMock
+        $this->requests = new Requests(
+            $this->adyenHelper,
+            $this->adyenConfig,
+            $this->addressHelper,
+            $this->stateData,
+            $this->vaultHelper,
+            $this->request,
+            $this->adyenHelper, // passed twice (as $dataHelper too)
+            $this->chargedCurrency,
+            $this->paymentMethodsHelper
         );
     }
 
-    public function testBuildCardRecurringGuestNoStorePaymentMethod()
+    #[Test]
+    public function buildMerchantAccountDataAddsCorrectKey(): void
     {
-        $this->setMockObjects([], false, '');
-        $this->assertEmpty($this->sut->buildCardRecurringData(1, $this->paymentMock));
-    }
+        $this->adyenHelper->method('getAdyenMerchantAccount')
+            ->with('scheme', 1)
+            ->willReturn('TestMerchant123');
 
-    public function testBuildCardRecurringStorePaymentMethodTrueVault(): void
-    {
-        $this->setMockObjects(['storePaymentMethod' => true], true, Vault::SUBSCRIPTION);
-        $request = $this->sut->buildCardRecurringData(1, $this->paymentMock);
+        $result = $this->requests->buildMerchantAccountData('scheme', 1);
 
-        $this->assertTrue($request['storePaymentMethod']);
-        $this->assertEquals(Vault::SUBSCRIPTION, $request['recurringProcessingModel']);
-    }
-
-    public function testBuildCardRecurringStorePaymentMethodTrueAdyenCardOnFile(): void
-    {
-        $this->setMockObjects(['storePaymentMethod' => true], true, Vault::CARD_ON_FILE);
-        $request = $this->sut->buildCardRecurringData(1, $this->paymentMock);
-
-        $this->assertTrue($request['storePaymentMethod']);
-        $this->assertEquals(Vault::CARD_ON_FILE, $request['recurringProcessingModel']);
-    }
-
-    public function testBuildCardRecurringStorePaymentMethodTrueAdyenSubscription(): void
-    {
-        $this->setMockObjects(['storePaymentMethod' => true], true, Vault::SUBSCRIPTION);
-        $request = $this->sut->buildCardRecurringData(1, $this->paymentMock);
-
-        $this->assertTrue($request['storePaymentMethod']);
-        $this->assertEquals(Vault::SUBSCRIPTION, $request['recurringProcessingModel']);
-    }
-
-    public function testBuildCardRecurringStorePaymentMethodFalse(): void
-    {
-        $this->setMockObjects(['storePaymentMethod' => false], false, Vault::SUBSCRIPTION);
-        $request = $this->sut->buildCardRecurringData(1, $this->paymentMock);
-
-        $this->assertArrayNotHasKey('storePaymentMethod', $request);
-        $this->assertArrayNotHasKey('recurringProcessingModel', $request);
-    }
-
-    public function testBuildCardRecurringWithEmptyStateData(): void
-    {
-        $this->setMockObjects([], true, Vault::SUBSCRIPTION);
-        $request = $this->sut->buildCardRecurringData(1, $this->paymentMock);
-
-        $this->assertArrayNotHasKey('storePaymentMethod', $request);
-        $this->assertArrayNotHasKey('recurringProcessingModel', $request);
-    }
-
-    public function testBuildCardRecurringWithInvalidRecurringProcessingModel(): void
-    {
-        $this->setMockObjects(['storePaymentMethod' => true], true, 'INVALID_MODEL');
-        $request = $this->sut->buildCardRecurringData(1, $this->paymentMock);
-
-        $this->assertArrayHasKey('storePaymentMethod', $request);
-        //$this->assertArrayNotHasKey('recurringProcessingModel', $request, 'Unexpected model should not be set');
-    }
-
-    public function testBuildCardRecurringWithPartialStateData(): void
-    {
-        $this->setMockObjects(['storePaymentMethod' => true], true, Vault::CARD_ON_FILE);
-        $request = $this->sut->buildCardRecurringData(1, $this->paymentMock);
-
-        $this->assertTrue($request['storePaymentMethod']);
-        $this->assertEquals(Vault::CARD_ON_FILE, $request['recurringProcessingModel']);
-    }
-
-    // Edge case: Vault disabled but storePaymentMethod is present in stateData
-    public function testBuildCardRecurringVaultDisabledWithStorePaymentMethod(): void
-    {
-        $this->setMockObjects(['storePaymentMethod' => true], false, Vault::SUBSCRIPTION);
-        $request = $this->sut->buildCardRecurringData(1, $this->paymentMock);
-
-        $this->assertArrayNotHasKey('storePaymentMethod', $request);
-        $this->assertArrayNotHasKey('recurringProcessingModel', $request);
-    }
-
-    public function testBuildCardRecurringGuestWithVaultDisabled(): void
-    {
-        $this->setMockObjects([], false, '');
-        $request = $this->sut->buildCardRecurringData(1, $this->paymentMock);
-
-        $this->assertArrayNotHasKey('storePaymentMethod', $request);
-        $this->assertArrayNotHasKey('recurringProcessingModel', $request);
-    }
-
-    public function testBuildCardRecurringWithSubscriptionModelAndStoreTrue(): void
-    {
-        $this->setMockObjects(['storePaymentMethod' => true], true, Vault::SUBSCRIPTION);
-        $request = $this->sut->buildCardRecurringData(1, $this->paymentMock);
-
-        $this->assertTrue($request['storePaymentMethod']);
-        $this->assertEquals(Vault::SUBSCRIPTION, $request['recurringProcessingModel']);
-    }
-
-    public function testBuildMerchantAccountDataWithValidAccount(): void
-    {
-        // Arrange
-        $paymentMethod = 'adyen_cc';
-        $storeId = 1;
-        $merchantAccount = 'ValidMerchantAccount';
-
-        $this->adyenHelperMock->method('getAdyenMerchantAccount')
-            ->with($paymentMethod, $storeId)
-            ->willReturn($merchantAccount);
-
-        // Act
-        $request = $this->sut->buildMerchantAccountData($paymentMethod, $storeId);
-
-        // Assert
-        $this->assertArrayHasKey(Requests::MERCHANT_ACCOUNT, $request);
-        $this->assertEquals($merchantAccount, $request[Requests::MERCHANT_ACCOUNT]);
-    }
-
-    public function testBuildMerchantAccountDataWithExistingRequestData(): void
-    {
-        // Arrange
-        $paymentMethod = 'adyen_cc';
-        $storeId = 1;
-        $merchantAccount = 'TestMerchantAccount';
-        $existingRequest = ['existingKey' => 'existingValue'];
-
-        $this->adyenHelperMock->method('getAdyenMerchantAccount')
-            ->with($paymentMethod, $storeId)
-            ->willReturn($merchantAccount);
-
-        // Act
-        $request = $this->sut->buildMerchantAccountData($paymentMethod, $storeId, $existingRequest);
-
-        // Assert
-        $this->assertArrayHasKey(Requests::MERCHANT_ACCOUNT, $request);
-        $this->assertEquals($merchantAccount, $request[Requests::MERCHANT_ACCOUNT]);
-        $this->assertArrayHasKey('existingKey', $request);
-        $this->assertEquals('existingValue', $request['existingKey']);
-    }
-
-    public function testBuildMerchantAccountDataWithEmptyAccount(): void
-    {
-        // Arrange
-        $paymentMethod = 'adyen_cc';
-        $storeId = 1;
-        $merchantAccount = ''; // Simulating empty account return
-
-        $this->adyenHelperMock->method('getAdyenMerchantAccount')
-            ->with($paymentMethod, $storeId)
-            ->willReturn($merchantAccount);
-
-        // Act
-        $request = $this->sut->buildMerchantAccountData($paymentMethod, $storeId);
-
-        // Assert
-        $this->assertArrayHasKey(Requests::MERCHANT_ACCOUNT, $request);
-        $this->assertEquals($merchantAccount, $request[Requests::MERCHANT_ACCOUNT]);
-    }
-
-    public function testBuildMerchantAccountDataWithNullAccount(): void
-    {
-        $paymentMethod = 'adyen_cc';
-        $storeId = 1;
-        $merchantAccount = null; // Simulating null account return
-
-        $this->adyenHelperMock->method('getAdyenMerchantAccount')
-            ->with($paymentMethod, $storeId)
-            ->willReturn($merchantAccount);
-
-        $request = $this->sut->buildMerchantAccountData($paymentMethod, $storeId);
-
-        $this->assertArrayHasKey(Requests::MERCHANT_ACCOUNT, $request);
-        $this->assertNull($request[Requests::MERCHANT_ACCOUNT]);
-    }
-
-    public function testBuildCustomerDataWithGuestEmail(): void
-    {
-        $this->payment->method('getOrder')->willReturn($this->order);
-        $this->order->method('getIncrementId')->willReturn('12345');
-
-        $additionalData = ['guestEmail' => 'guest@example.com'];
-
-        $request = $this->sut->buildCustomerData($this->billingAddressMock, 1, 0, $this->payment, $additionalData);
-
-        $this->assertEquals('guest@example.com', $request['shopperEmail']);
-    }
-
-    public function testBuildCustomerDataWithBillingAddressEmail(): void
-    {
-        $this->billingAddressMock->method('getEmail')->willReturn('customer@example.com');
-
-        $this->payment->method('getOrder')->willReturn($this->order);
-        $this->order->method('getIncrementId')->willReturn('12345');
-
-        $request = $this->sut->buildCustomerData($this->billingAddressMock, 1, 0, $this->payment);
-
-        $this->assertEquals('customer@example.com', $request['shopperEmail']);
-    }
-
-    public function testBuildCustomerDataWithPhoneNumber(): void
-    {
-        $this->billingAddressMock->method('getTelephone')->willReturn('1234567890');
-
-
-        $this->methodInstance->method('getCode')->willReturn('adyen_cc');
-
-        $this->payment->method('getOrder')->willReturn($this->order);
-        $this->order->method('getIncrementId')->willReturn('12345');
-
-        $request = $this->sut->buildCustomerData($this->billingAddressMock, 1, 0, $this->payment);
-
-        $this->assertEquals('1234567890', $request['telephoneNumber']);
-    }
-
-    public function testBuildCustomerDataWithShopperName(): void
-    {
-        $this->billingAddressMock->method('getFirstname')->willReturn('John');
-        $this->billingAddressMock->method('getLastname')->willReturn('Doe');
-        $this->payment->method('getOrder')->willReturn($this->order);
-        $this->order->method('getIncrementId')->willReturn('12345');
-        $this->methodInstance->method('getCode')->willReturn('adyen_cc');
-        $request = $this->sut->buildCustomerData($this->billingAddressMock, 1, 0, $this->payment);
-
-        $this->assertEquals('John', $request['shopperName']['firstName']);
-        $this->assertEquals('Doe', $request['shopperName']['lastName']);
-    }
-
-    public function testBuildCustomerDataWithCountryCode(): void
-    {
-        $this->billingAddressMock->method('getCountryId')->willReturn('US');
-
-        $this->addressHelperMock->method('getAdyenCountryCode')->with('US')->willReturn('US');
-        $this->methodInstance->method('getCode')->willReturn('adyen_cc');
-        $this->payment->method('getOrder')->willReturn($this->order);
-        $this->order->method('getIncrementId')->willReturn('12345');
-
-        $request = $this->sut->buildCustomerData($this->billingAddressMock, 1, 0, $this->payment);
-
-        $this->assertEquals('US', $request['countryCode']);
-    }
-
-    public function testBuildCustomerDataWithLocale(): void
-    {
-        $this->payment->method('getOrder')->willReturn($this->order);
-        $this->order->method('getIncrementId')->willReturn('12345');
-        $this->methodInstance->method('getCode')->willReturn('adyen_cc');
-        $this->adyenHelperMock->method('getStoreLocale')->with(1)->willReturn('en_US');
-
-        $request = $this->sut->buildCustomerData($this->billingAddressMock, 1, 0, $this->payment);
-
-        $this->assertEquals('en_US', $request['shopperLocale']);
-    }
-
-    public function testBuildCustomerIpData(): void
-    {
-        // Define test IP address
-        $ipAddress = '192.168.1.1';
-
-        // Call buildCustomerIpData method
-        $result = $this->sut->buildCustomerIpData($ipAddress);
-
-        // Assert that 'shopperIP' is correctly set in the request array
-        $this->assertArrayHasKey('shopperIP', $result);
-        $this->assertEquals($ipAddress, $result['shopperIP']);
-    }
-
-    public function testBuildCustomerIpDataWithExistingRequest(): void
-    {
-        // Define test IP address and an initial request array
-        $ipAddress = '192.168.1.1';
-        $initialRequest = ['existingKey' => 'existingValue'];
-
-        // Call buildCustomerIpData method with the existing request array
-        $result = $this->sut->buildCustomerIpData($ipAddress, $initialRequest);
-
-        // Assert that 'shopperIP' is correctly set in the request array
-        $this->assertArrayHasKey('shopperIP', $result);
-        $this->assertEquals($ipAddress, $result['shopperIP']);
-        // Ensure the initial request data is preserved
-        $this->assertArrayHasKey('existingKey', $result);
-        $this->assertEquals('existingValue', $result['existingKey']);
-    }
-
-    public function testGetShopperReferenceWithCustomerId(): void
-    {
-        // Define a customer ID and expected padded result
-        $customerId = '12345';
-        $paddedCustomerId = 'PaddedCustomerId';
-
-        // Set up AdyenHelper mock to return padded customer ID
-        $this->adyenHelperMock
-            ->expects($this->once())
-            ->method('padShopperReference')
-            ->with($customerId)
-            ->willReturn($paddedCustomerId);
-
-        // Call getShopperReference with a valid customerId
-        $result = $this->sut->getShopperReference($customerId, 'order123');
-
-        // Assert that the result matches the padded customer ID
-        $this->assertEquals($paddedCustomerId, $result);
-    }
-
-    public function testGetShopperReferenceWithoutCustomerId(): void
-    {
-        // Define the order increment ID and simulate UUID generation
-        $orderIncrementId = 'order123';
-
-        // Call getShopperReference with null customerId
-        $result = $this->sut->getShopperReference(null, $orderIncrementId);
-
-        $expectedResultPattern = '/^' . preg_quote($orderIncrementId, '/') . '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/';
-        $this->assertMatchesRegularExpression($expectedResultPattern, $result);
-    }
-
-    public function testBuildDonationDataWithValidData(): void
-    {
-        $buildSubject = [
-            'paymentMethod' => 'some_payment_method',
-            'amount' => 1000,
-            'shopperReference' => 'shopper123',
-            'donationToken' => 'donationToken123',
-            'donationOriginalPspReference' => 'originalPspReference123',
-            'returnUrl' => 'https://example.com/return',
-            'id' => 12
-        ];
-
-        $storeId = 1;
-
-        // Mock the merchant account return
-        $this->adyenHelperMock
-            ->expects($this->once())
-            ->method('getAdyenMerchantAccount')
-            ->with('adyen_giving', $storeId)
-            ->willReturn('adyenMerchantAccount123');
-
-        $result = $this->sut->buildDonationData($buildSubject, $storeId);
-
-        // Assert the structure and values of the returned array
-        $this->assertIsArray($result);
-        $this->assertArrayHasKey('amount', $result);
-        $this->assertArrayHasKey('reference', $result);
-        $this->assertArrayHasKey('shopperReference', $result);
-        $this->assertArrayHasKey('paymentMethod', $result);
-        $this->assertArrayHasKey('donationToken', $result);
-        $this->assertArrayHasKey('donationOriginalPspReference', $result);
-        $this->assertArrayHasKey('donationCampaignId', $result);
-        $this->assertArrayHasKey('returnUrl', $result);
         $this->assertArrayHasKey('merchantAccount', $result);
-        $this->assertArrayHasKey('shopperInteraction', $result);
-
-        // Assert specific values
-        $this->assertEquals(1000, $result['amount']);
-        $this->assertEquals('shopper123', $result['shopperReference']);
-        $this->assertEquals('donationToken123', $result['donationToken']);
-        $this->assertEquals('originalPspReference123', $result['donationOriginalPspReference']);
-        $this->assertEquals('https://example.com/return', $result['returnUrl']);
-        $this->assertEquals('adyenMerchantAccount123', $result['merchantAccount']);
+        $this->assertEquals('TestMerchant123', $result['merchantAccount']);
     }
 
-    public function testBuildDonationDataWithMappedPaymentMethod(): void
+    #[Test]
+    public function buildCustomerIpDataAddsIpAddress(): void
     {
-        $buildSubject = [
-            'paymentMethod' => 'original_payment_method',
-            'amount' => 2000,
-            'shopperReference' => 'shopper456',
-            'donationToken' => 'donationToken456',
-            'donationOriginalPspReference' => 'originalPspReference456',
-            'returnUrl' => 'https://example.com/return',
-            'id' => 12
-        ];
+        $result = $this->requests->buildCustomerIpData('192.168.0.1');
 
-        $storeId = 2;
-
-        $this->adyenHelperMock
-            ->expects($this->once())
-            ->method('getAdyenMerchantAccount')
-            ->with('adyen_giving', $storeId)
-            ->willReturn('adyenMerchantAccount456');
-
-        $result = $this->sut->buildDonationData($buildSubject, $storeId);
-
-        // Assert that the mapped payment method is used
-        $this->assertEquals('original_payment_method', $result['paymentMethod']['type']);
+        $this->assertArrayHasKey('shopperIP', $result);
+        $this->assertSame('192.168.0.1', $result['shopperIP']);
     }
 
-    public function testBuildAdyenTokenizedPaymentRecurringDataWithExistingModel(): void
+    #[Test]
+    public function buildPaymentDataFormatsAmountCorrectly(): void
     {
-        $storeId = 1;
-        $paymentMock = $this->createMock(\Magento\Payment\Model\InfoInterface::class);
-        $paymentMock->method('getAdditionalInformation')
-            ->willReturn(['recurringProcessingModel' => 'some_model']);
+        $this->adyenHelper->method('formatAmount')
+            ->with(15.99, 'EUR')
+            ->willReturn(1599);
 
-        $result = $this->sut->buildAdyenTokenizedPaymentRecurringData($storeId, $paymentMock);
+        $result = $this->requests->buildPaymentData(15.99, 'EUR', 'ref123');
 
-        // Assert that the recurringProcessingModel is set correctly
-        $this->assertArrayHasKey('recurringProcessingModel', $result);
-        $this->assertNotEmpty($result['recurringProcessingModel']);
+        $this->assertSame(['currency' => 'EUR', 'value' => 1599], $result['amount']);
+        $this->assertSame('ref123', $result['reference']);
     }
 
-    public function testBuildAdyenTokenizedPaymentRecurringDataWithCardType(): void
+    #[Test]
+    public function buildBrowserDataReturnsUserAgentAndAcceptHeader(): void
     {
-        $storeId = 1;
-        $paymentMock = $this->createMock(\Magento\Payment\Model\InfoInterface::class);
-        $paymentMock->method('getAdditionalInformation')
-            ->willReturn(['cc_type' => 'visa']);
-
-        $result = $this->sut->buildAdyenTokenizedPaymentRecurringData($storeId, $paymentMock);
-
-        // Assert that the recurringProcessingModel is set to the model returned from the vault helper
-        $this->assertArrayHasKey('recurringProcessingModel', $result);
-        $this->assertNotEmpty($result['recurringProcessingModel']);
-    }
-
-    public function testBuildAdyenTokenizedPaymentRecurringDataWithOtherPaymentMethod(): void
-    {
-        $storeId = 1;
-        $paymentMock = $this->createMock(\Magento\Payment\Model\InfoInterface::class);
-        $paymentMock->method('getAdditionalInformation')
-            ->willReturn(['cc_type' => 'other_pm_type', 'method' => 'other_pm']);
-
-        $result = $this->sut->buildAdyenTokenizedPaymentRecurringData($storeId, $paymentMock);
-
-        // Assert that the recurringProcessingModel is set to the model returned from the vault helper
-        $this->assertArrayHasKey('recurringProcessingModel', $result);
-        $this->assertNotEmpty($result['recurringProcessingModel']);
-    }
-
-    public function testBuildBrowserDataWithUserAgentAndAcceptHeader()
-    {
-        // Arrange
-        $userAgent = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.66 Safari/537.36';
-        $acceptHeader = 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8';
-
-        // Setting up the request mock to return headers
-        $this->requestInterfaceMock->method('getServer')
-            ->will($this->returnCallback(function ($header) use ($userAgent, $acceptHeader) {
-                if ($header === 'HTTP_USER_AGENT') {
-                    return $userAgent;
-                } elseif ($header === 'HTTP_ACCEPT') {
-                    return $acceptHeader;
-                }
-                return null;
-            }));
-
-        // Act
-        $result = $this->sut->buildBrowserData([]);
-
-        // Assert
-        $this->assertArrayHasKey('browserInfo', $result);
-        $this->assertArrayHasKey('userAgent', $result['browserInfo']);
-        $this->assertArrayHasKey('acceptHeader', $result['browserInfo']);
-        $this->assertEquals($userAgent, $result['browserInfo']['userAgent']);
-        $this->assertEquals($acceptHeader, $result['browserInfo']['acceptHeader']);
-    }
-
-    public function testBuildBrowserDataWithNoUserAgentOrAcceptHeader()
-    {
-        // Arrange
-        $this->requestInterfaceMock->method('getServer')
-            ->willReturn(null);
-
-        // Act
-        $result = $this->sut->buildBrowserData([]);
-
-        // Assert
-        $this->assertArrayNotHasKey('browserInfo', $result);
-    }
-
-    private function setMockObjects(array $stateDataArray, bool $vaultEnabled, string $tokenType): void
-    {
-        $stateDataMock = $this->createConfiguredMock(StateData::class, [
-            'getStateData' => $stateDataArray
+        $this->request->method('getServer')->willReturnMap([
+            ['HTTP_USER_AGENT', null, 'Mozilla'],
+            ['HTTP_ACCEPT', null, 'text/html']
         ]);
 
-        $vaultHelperMock = $this->createConfiguredMock(Vault::class, [
-            'getPaymentMethodRecurringActive' => $vaultEnabled,
-            'getPaymentMethodRecurringProcessingModel' => $tokenType
-        ]);
+        $result = $this->requests->buildBrowserData();
 
-        $this->adyenHelperMock = $this->createMock(Data::class);
+        $this->assertSame('Mozilla', $result['browserInfo']['userAgent']);
+        $this->assertSame('text/html', $result['browserInfo']['acceptHeader']);
+    }
 
+    #[Test]
+    public function getShopperReferenceForCustomerIdReturnsPaddedValue(): void
+    {
+        $this->adyenHelper->expects($this->once())
+            ->method('padShopperReference')
+            ->with('42')
+            ->willReturn('user_42');
 
-        $configHelperMock = $this->createConfiguredMock(Config::class, [
-            //'getPaymentMethodRecurringProcessingModel' => $tokenType
-            //'getCardRecurringActive' => true
-        ]);
+        $result = $this->requests->getShopperReference('42', '0000123');
 
-        $this->sut = new Requests(
-            $this->createMock(Data::class),
-            $configHelperMock,
-            $this->createMock(Address::class),
-            $stateDataMock,
-            $vaultHelperMock,
-            $this->createMock(http::class)
+        $this->assertSame('user_42', $result);
+    }
+
+    #[Test]
+    public function getShopperReferenceForGuestReturnsCombinedValue(): void
+    {
+        $this->adyenHelper->expects($this->never())->method('padShopperReference');
+
+        $result = $this->requests->getShopperReference(null, '0000123');
+
+        $this->assertStringStartsWith('0000123', $result);
+        $this->assertGreaterThan(10, strlen($result));
+    }
+
+    #[Test]
+    public function buildCustomerDataIncludesEmailTelephoneName(): void
+    {
+        $billingAddress = $this->createMock(\Magento\Sales\Api\Data\OrderAddressInterface::class);
+        $billingAddress->method('getEmail')->willReturn('customer@example.com');
+        $billingAddress->method('getTelephone')->willReturn('123456789');
+        $billingAddress->method('getFirstname')->willReturn('John');
+        $billingAddress->method('getLastname')->willReturn('Doe');
+        $billingAddress->method('getCountryId')->willReturn('NL');
+
+        $payment = $this->createMock(\Magento\Sales\Model\Order\Payment::class);
+        $payment->method('getMethodInstance')->willReturn(
+            $this->createConfiguredMock(\Magento\Payment\Model\MethodInterface::class, [
+                'getCode' => 'scheme'
+            ])
+        );
+        $payment->method('getOrder')->willReturn(
+            $this->createConfiguredMock(\Magento\Sales\Model\Order::class, [
+                'getIncrementId' => '000001'
+            ])
         );
 
-        $orderMock = $this->createConfiguredMock(Order::class, [
-            'getQuoteId' => 1
-        ]);
-        $this->paymentMock = $this->createConfiguredMock(Payment::class, [
-            'getOrder' => $orderMock,
-            'getMethod' => 'adyen_cc'
-        ]);
+        $this->adyenHelper->method('getStoreLocale')->willReturn('nl_NL');
+        $this->adyenHelper->method('padShopperReference')->willReturn('user_1');
+        $this->addressHelper->method('getAdyenCountryCode')->willReturn('NL');
+
+        $result = $this->requests->buildCustomerData(
+            $billingAddress,
+            1,
+            1,
+            $payment,
+            [],
+            []
+        );
+
+        $this->assertSame('user_1', $result['shopperReference']);
+        $this->assertSame('customer@example.com', $result['shopperEmail']);
+        $this->assertSame('123456789', $result['telephoneNumber']);
+        $this->assertSame('John', $result['shopperName']['firstName']);
+        $this->assertSame('Doe', $result['shopperName']['lastName']);
+        $this->assertSame('NL', $result['countryCode']);
+        $this->assertSame('nl_NL', $result['shopperLocale']);
     }
+
+    #[Test]
+    public function buildAddressDataBuildsBillingAndDeliveryAddress(): void
+    {
+        $billing = $this->createMock(\Magento\Sales\Api\Data\OrderAddressInterface::class);
+        $shipping = $this->createMock(\Magento\Sales\Api\Data\OrderAddressInterface::class);
+
+        $billing->method('getCity')->willReturn('Amsterdam');
+        $billing->method('getCountryId')->willReturn('NL');
+        $billing->method('getPostcode')->willReturn('1011AB');
+
+        $shipping->method('getCity')->willReturn('Rotterdam');
+        $shipping->method('getCountryId')->willReturn('NL');
+        $shipping->method('getPostcode')->willReturn('3011AB');
+
+        $this->adyenConfig->method('getAdyenAbstractConfigData')->willReturn(1);
+        $this->adyenHelper->method('getCustomerStreetLinesEnabled')->willReturn(true);
+
+        $this->addressHelper->method('getStreetAndHouseNumberFromAddress')
+            ->willReturnMap([
+                [$billing, 1, true, ['name' => 'Damrak', 'house_number' => '1']],
+                [$shipping, 1, true, ['name' => 'Coolsingel', 'house_number' => '10']]
+            ]);
+
+        $this->addressHelper->method('getAdyenCountryCode')->willReturn('NL');
+
+        $result = $this->requests->buildAddressData($billing, $shipping, 1);
+
+        $this->assertSame('Damrak', $result['billingAddress']['street']);
+        $this->assertSame('Coolsingel', $result['deliveryAddress']['street']);
+        $this->assertSame('1', $result['billingAddress']['houseNumberOrName']);
+        $this->assertSame('10', $result['deliveryAddress']['houseNumberOrName']);
+    }
+
+    #[Test]
+    public function buildCardRecurringDataWithConsent(): void
+    {
+        $payment = $this->createMock(\Magento\Sales\Model\Order\Payment::class);
+        $order = $this->createMock(\Magento\Sales\Model\Order::class);
+        $order->method('getQuoteId')->willReturn(1);
+        $payment->method('getOrder')->willReturn($order);
+        $payment->method('getMethod')->willReturn('scheme');
+        $payment->method('getAdditionalInformation')->willReturn('card');
+
+        $this->vaultHelper->method('getPaymentMethodRecurringActive')->willReturn(true);
+        $this->stateData->method('getStateData')->willReturn([]);
+        $this->stateData->method('getStoredPaymentMethodIdFromStateData')->willReturn('stored-token');
+        $this->vaultHelper->method('getPaymentMethodRecurringProcessingModel')->willReturn('card');
+
+        $result = $this->requests->buildCardRecurringData(1, $payment);
+
+        $this->assertSame('card', $result['recurringProcessingModel']);
+    }
+
+    #[Test]
+    public function buildAdyenTokenizedRecurringDataForStoredCard(): void
+    {
+        $payment = $this->createMock(\Magento\Sales\Model\Order\Payment::class);
+        $payment->method('getAdditionalInformation')->willReturnMap([
+            ['recurringProcessingModel', 'card'],
+            ['cc_type', 'visa'],
+            ['method', 'scheme']
+        ]);
+
+        $this->vaultHelper
+            ->method('getPaymentMethodRecurringProcessingModel')
+            ->with(AdyenCcConfigProvider::CODE, 1)
+            ->willReturn('card');
+
+        $result = $this->requests->buildAdyenTokenizedPaymentRecurringData(1, $payment);
+
+        $this->assertSame('card', $result['recurringProcessingModel']);
+    }
+
+    #[Test]
+    public function buildDonationDataReturnsCorrectStructure(): void
+    {
+        $storeId = 1;
+        $currency = 'EUR';
+        $amount = ['currency' => $currency, 'value' => 1000];
+        $returnUrl = 'https://example.com';
+        $payload = ['amount' => $amount, 'returnUrl' => $returnUrl];
+
+        $payment = $this->createMock(\Magento\Sales\Model\Order\Payment::class);
+        $order = $this->createMock(\Magento\Sales\Model\Order::class);
+        $paymentMethodInstance = $this->createMock(\Magento\Payment\Model\MethodInterface::class);
+
+        $payment->method('getOrder')->willReturn($order);
+        $payment->method('getMethodInstance')->willReturn($paymentMethodInstance);
+        $payment->method('getMethod')->willReturn('adyen_cc');
+        $payment->method('getAdditionalInformation')->willReturnMap([
+            ['donationToken', 'donation-token'],
+            ['donationCampaignId', 'campaign-id'],
+            ['pspReference', 'psp-ref-123'],
+            ['donationPayload', $payload]
+        ]);
+
+        $this->vaultHelper
+            ->method('getPaymentMethodRecurringProcessingModel')
+            ->with(AdyenCcConfigProvider::CODE, 1)
+            ->willReturn('adyen_cc');
+
+        $order->method('getCustomerId')->willReturn(42);
+        $order->method('getIncrementId')->willReturn('000001');
+
+        $amountCurrency = $this->createConfiguredMock(\Adyen\Payment\Model\AdyenAmountCurrency::class, [
+            'getCurrencyCode' => $currency
+        ]);
+
+        $this->chargedCurrency->method('getOrderAmountCurrency')->willReturn($amountCurrency);
+        $this->paymentMethodsHelper->method('isAlternativePaymentMethod')->willReturn(false);
+        $this->adyenHelper->method('getAdyenMerchantAccount')->with('adyen_giving', $storeId)->willReturn('merchant123');
+        $this->adyenHelper->method('padShopperReference')->with(42)->willReturn('user_42');
+
+        $result = $this->requests->buildDonationData($payment, $storeId);
+
+        $this->assertSame('scheme', $result['paymentMethod']['type']);
+        $this->assertSame('user_42', $result['shopperReference']);
+        $this->assertSame('donation-token', $result['donationToken']);
+        $this->assertSame('campaign-id', $result['donationCampaignId']);
+        $this->assertSame('psp-ref-123', $result['donationOriginalPspReference']);
+        $this->assertSame('merchant123', $result['merchantAccount']);
+        $this->assertSame($amount, $result['amount']);
+        $this->assertSame($returnUrl, $result['returnUrl']);
+    }
+
+    #[Test]
+    public function buildDonationDataThrowsExceptionIfTokenOrPayloadInvalid(): void
+    {
+        $this->expectException(\Magento\Framework\Exception\LocalizedException::class);
+        $this->expectExceptionMessage('Donation failed!');
+
+        $payment = $this->createMock(\Magento\Sales\Model\Order\Payment::class);
+        $order = $this->createStub(\Magento\Sales\Model\Order::class);
+
+        $payment->method('getOrder')->willReturn($order);
+        $payment->method('getAdditionalInformation')->willReturnMap([
+            ['donationToken', null],
+            ['donationPayload', []]
+        ]);
+
+        $this->requests->buildDonationData($payment, 1);
+    }
+
+    #[Test]
+    public function buildDonationDataThrowsExceptionOnCurrencyMismatch(): void
+    {
+        $this->expectException(\Magento\Framework\Exception\LocalizedException::class);
+        $this->expectExceptionMessage('Donation failed!');
+
+        $payment = $this->createMock(\Magento\Sales\Model\Order\Payment::class);
+        $order = $this->createMock(\Magento\Sales\Model\Order::class);
+        $payload = ['amount' => ['currency' => 'USD']];
+
+        $payment->method('getOrder')->willReturn($order);
+        $payment->method('getMethod')->willReturn('scheme');
+        $payment->method('getMethodInstance')->willReturn(
+            $this->createStub(\Magento\Payment\Model\MethodInterface::class)
+        );
+        $payment->method('getAdditionalInformation')->willReturnMap([
+            ['donationToken', 'valid-token'],
+            ['donationPayload', $payload],
+            ['donationCampaignId', 'campaign-id'],
+            ['pspReference', 'psp-ref-123']
+        ]);
+
+        $this->chargedCurrency
+            ->method('getOrderAmountCurrency')
+            ->with($order, false)
+            ->willReturn(
+                $this->createConfiguredMock(\Adyen\Payment\Model\AdyenAmountCurrency::class, [
+                    'getCurrencyCode' => 'EUR'
+                ])
+            );
+
+        $this->requests->buildDonationData($payment, 1);
+    }
+
 }

--- a/Test/Unit/Model/Api/AdyenDonationCampaignsTest.php
+++ b/Test/Unit/Model/Api/AdyenDonationCampaignsTest.php
@@ -1,10 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Adyen\Payment\Test\Unit\Model\Api;
 
 use Adyen\Payment\Helper\ChargedCurrency;
 use Adyen\Payment\Helper\Config;
-use Adyen\Payment\Helper\Data as AdyenHelper;
+use Adyen\Payment\Helper\Data;
 use Adyen\Payment\Helper\DonationsHelper;
 use Adyen\Payment\Logger\AdyenLogger;
 use Adyen\Payment\Model\Api\AdyenDonationCampaigns;
@@ -13,151 +15,138 @@ use Adyen\Payment\Test\Unit\AbstractAdyenTestCase;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Sales\Api\Data\OrderInterface;
 use Magento\Sales\Model\Order\Payment;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Magento\Sales\Model\Order;
-use Adyen\Payment\Model\AdyenAmountCurrency;
-use PHPUnit\Framework\MockObject\Exception;
 
+#[CoversClass(AdyenDonationCampaigns::class)]
 class AdyenDonationCampaignsTest extends AbstractAdyenTestCase
 {
-    private $donationsHelperMock;
-    private $orderRepositoryMock;
-    private $chargedCurrencyMock;
-    private $adyenLoggerMock;
-    private $configHelperMock;
-    private $adyenHelperMock;
-    private $adyenDonationCampaigns;
+    private DonationsHelper $donationsHelper;
+    private OrderRepository $orderRepository;
+    private ChargedCurrency $chargedCurrency;
+    private AdyenLogger $adyenLogger;
+    private Config $configHelper;
+    private Data $adyenHelper;
+    private AdyenDonationCampaigns $campaigns;
 
     protected function setUp(): void
     {
-        $this->donationsHelperMock = $this->createMock(DonationsHelper::class);
-        $this->orderRepositoryMock = $this->createMock(OrderRepository::class);
-        $this->chargedCurrencyMock = $this->createMock(ChargedCurrency::class);
-        $this->adyenLoggerMock = $this->createMock(AdyenLogger::class);
-        $this->configHelperMock = $this->createMock(Config::class);
-        $this->adyenHelperMock = $this->createMock(AdyenHelper::class);
-        $this->currencyObject = $this->createMock(AdyenAmountCurrency::class);
-        $this->paymentMock = $this->createMock(Payment::class);
-        $this->orderMock = $this->createMock(Order::class);
+        $this->donationsHelper = $this->createMock(DonationsHelper::class);
+        $this->orderRepository = $this->createMock(OrderRepository::class);
+        $this->chargedCurrency = $this->createMock(ChargedCurrency::class);
+        $this->adyenLogger = $this->createMock(AdyenLogger::class);
+        $this->configHelper = $this->createMock(Config::class);
+        $this->adyenHelper = $this->createMock(Data::class);
 
-        $this->adyenDonationCampaigns = new AdyenDonationCampaigns(
-            $this->donationsHelperMock,
-            $this->orderRepositoryMock,
-            $this->chargedCurrencyMock,
-            $this->adyenLoggerMock,
-            $this->configHelperMock,
-            $this->adyenHelperMock
+        $this->campaigns = new AdyenDonationCampaigns(
+            $this->donationsHelper,
+            $this->orderRepository,
+            $this->chargedCurrency,
+            $this->adyenLogger,
+            $this->configHelper,
+            $this->adyenHelper
         );
     }
 
-    public function testGetCampaignsSuccess(): void
+    #[Test]
+    public function getCampaignsReturnsJsonEncodedCampaigns(): void
     {
-        $orderId = 100;
-        $orderMock = $this->createMock(OrderInterface::class);
-        $orderMock->method('getEntityId')->willReturn($orderId);
+        $storeId = 1;
+        $order = $this->createMock(Order::class);
+        $payment = $this->createMock(Payment::class);
+        $order->method('getEntityId')->willReturn(123);
+        $order->method('getStoreId')->willReturn($storeId);
+        $order->method('getPayment')->willReturn($payment);
+        $payment->method('getAdditionalInformation')->with('donationToken')->willReturn('token');
 
-        $this->orderRepositoryMock->method('get')->willReturn($orderMock);
+        $this->orderRepository->method('get')->willReturn($order);
+         $this->configHelper->method('getMerchantAccount')->willReturn('merchant123');
+        $this->adyenHelper->method('getCurrentLocaleCode')->willReturn('en_US');
 
-        $this->adyenDonationCampaigns = $this->getMockBuilder(AdyenDonationCampaigns::class)
-            ->setConstructorArgs([
-                $this->donationsHelperMock,
-                $this->orderRepositoryMock,
-                $this->chargedCurrencyMock,
-                $this->adyenLoggerMock,
-                $this->configHelperMock,
-                $this->adyenHelperMock
-            ])
-            ->onlyMethods(['getCampaignData'])
-            ->getMock();
+        $this->donationsHelper->method('fetchDonationCampaigns')->willReturn([
+            'donationCampaigns' => [['id' => 'camp123']]
+        ]);
+        $this->donationsHelper->method('formatCampaign')->willReturn(['id' => 'camp123']);
 
-        $this->adyenDonationCampaigns->expects($this->once())
-            ->method('getCampaignData')
-            ->with($orderMock)
-            ->willReturn(json_encode(['key' => 'value']));
+        $result = $this->campaigns->getCampaigns(10);
 
-        $result = $this->adyenDonationCampaigns->getCampaigns($orderId);
-        $this->assertEquals(json_encode(['key' => 'value']), $result);
+        $this->assertJson($result);
+        $this->assertStringContainsString('camp123', $result);
     }
 
-    public function testGetCampaignsThrowsIfOrderLoadFails(): void
+    #[Test]
+    public function getCampaignsThrowsExceptionIfOrderNotFound(): void
     {
         $this->expectException(LocalizedException::class);
         $this->expectExceptionMessage('Unable to retrieve donation campaigns');
 
-        $orderId = 999;
-        $this->orderRepositoryMock->method('get')->willThrowException(new \Exception('DB fail'));
+        $this->orderRepository->method('get')->willThrowException(new \Exception('Not found'));
 
-        $this->adyenLoggerMock->expects($this->once())
-            ->method('error')
-            ->with($this->stringContains("Failed to load order with ID"));
+        $this->adyenLogger->expects($this->once())->method('error')
+            ->with($this->stringContains('Failed to load order'));
 
-        $this->adyenDonationCampaigns->getCampaigns($orderId);
+        $this->campaigns->getCampaigns(999);
     }
 
-    public function testGetCampaignsThrowsIfNoEntityId(): void
-    {
-        $this->expectException(LocalizedException::class);
-
-        $orderId = 101;
-        $orderMock = $this->createMock(OrderInterface::class);
-        $orderMock->method('getEntityId')->willReturn(null);
-
-        $this->orderRepositoryMock->method('get')->willReturn($orderMock);
-
-        $this->adyenLoggerMock->expects($this->once())
-            ->method('error')
-            ->with($this->stringContains("Order ID $orderId has no entity ID"));
-
-        $this->adyenDonationCampaigns->getCampaigns($orderId);
-    }
-
-    public function testGetCampaignDataSuccess(): void
-    {
-        $currencyCode = 'EUR';
-        $merchantAccount = 'TestMerchant';
-        $locale = 'en_US';
-        $campaignId = 'abc123';
-
-        $this->paymentMock->method('getAdditionalInformation')->with('donationToken')->willReturn('token123');
-        $this->orderMock->method('getPayment')->willReturn($this->paymentMock);
-        $this->orderMock->method('getStoreId')->willReturn(1);
-
-        $this->currencyObject->method('getCurrencyCode')->willReturn($currencyCode);
-
-        $this->chargedCurrencyMock->method('getOrderAmountCurrency')
-            ->with($this->orderMock, false)
-            ->willReturn($this->currencyObject);
-
-        $this->configHelperMock->method('getMerchantAccount')->willReturn($merchantAccount);
-        $this->adyenHelperMock->method('getCurrentLocaleCode')->willReturn($locale);
-
-        $donationCampaignsResponse = ['donationCampaigns' => [['id' => $campaignId]]];
-        $formattedCampaign = ['reference' => 'abc'];
-
-        $this->donationsHelperMock->method('fetchDonationCampaigns')->willReturn($donationCampaignsResponse);
-        $this->donationsHelperMock->method('formatCampaign')->willReturn($formattedCampaign);
-        $this->donationsHelperMock->expects($this->once())
-            ->method('setDonationCampaignId')
-            ->with($this->orderMock, $campaignId);
-
-        $result = $this->adyenDonationCampaigns->getCampaignData($this->orderMock);
-        $this->assertEquals(json_encode($formattedCampaign), $result);
-    }
-
-    public function testGetCampaignDataThrowsIfNoDonationToken(): void
+    #[Test]
+    public function getCampaignsThrowsExceptionIfNoEntityId(): void
     {
         $this->expectException(LocalizedException::class);
         $this->expectExceptionMessage('Unable to retrieve donation campaigns');
 
-        $paymentMock = $this->createMock(Payment::class);
-        $paymentMock->method('getAdditionalInformation')->with('donationToken')->willReturn(null);
+        $order = $this->createMock(OrderInterface::class);
+        $order->method('getEntityId')->willReturn(null);
 
-        $orderMock = $this->createMock(OrderInterface::class);
-        $orderMock->method('getPayment')->willReturn($paymentMock);
+        $this->orderRepository->method('get')->willReturn($order);
 
-        $this->adyenLoggerMock->expects($this->once())
-            ->method('error')
+        $this->adyenLogger->expects($this->once())->method('error')
+            ->with($this->stringContains('no entity ID'));
+
+        $this->campaigns->getCampaigns(12);
+    }
+
+    #[Test]
+    public function getCampaignDataThrowsExceptionIfDonationTokenMissing(): void
+    {
+        $this->expectException(LocalizedException::class);
+
+        $order = $this->createMock(Order::class);
+        $payment = $this->createMock(Payment::class);
+        $order->method('getPayment')->willReturn($payment);
+        $payment->method('getAdditionalInformation')->with('donationToken')->willReturn(null);
+
+        $this->adyenLogger->expects($this->once())->method('error')
             ->with($this->stringContains('Missing donation token'));
 
-        $this->adyenDonationCampaigns->getCampaignData($orderMock);
+        $this->campaigns->getCampaignData($order);
+    }
+
+    #[Test]
+    public function getCampaignDataThrowsExceptionOnFetchFailure(): void
+    {
+        $this->expectException(LocalizedException::class);
+
+        $order = $this->createMock(Order::class);
+        $payment = $this->createMock(Payment::class);
+        $amountCurrency = $this->createConfiguredMock(\Adyen\Payment\Model\AdyenAmountCurrency::class, [
+            'getCurrencyCode' => 'EUR'
+        ]);
+
+        $order->method('getStoreId')->willReturn(1);
+        $order->method('getPayment')->willReturn($payment);
+        $payment->method('getAdditionalInformation')->with('donationToken')->willReturn('token');
+
+        $this->chargedCurrency->method('getOrderAmountCurrency')->willReturn($amountCurrency);
+        $this->configHelper->method('getMerchantAccount')->willReturn('merchant123');
+        $this->adyenHelper->method('getCurrentLocaleCode')->willReturn('en_US');
+
+        $this->donationsHelper->method('fetchDonationCampaigns')
+            ->willThrowException(new \Exception('Failed'));
+
+        $this->adyenLogger->expects($this->once())->method('error')
+            ->with($this->stringContains('Failed to fetch donation campaigns'));
+
+        $this->campaigns->getCampaignData($order);
     }
 }

--- a/Test/Unit/Model/Api/AdyenDonationsTest.php
+++ b/Test/Unit/Model/Api/AdyenDonationsTest.php
@@ -1,273 +1,76 @@
 <?php
-/**
- *
- * Adyen Payment module (https://www.adyen.com/)
- *
- * Copyright (c) 2025 Adyen N.V. (https://www.adyen.com/)
- * See LICENSE.txt for license details.
- *
- * Author: Adyen <magento@adyen.com>
- */
+
+declare(strict_types=1);
 
 namespace Adyen\Payment\Test\Unit\Model\Api;
 
-use Adyen\AdyenException;
-use Adyen\Payment\Helper\ChargedCurrency;
-use Adyen\Payment\Helper\Config;
 use Adyen\Payment\Helper\Data;
-use Adyen\Payment\Helper\PaymentMethods;
-use Adyen\Payment\Model\AdyenAmountCurrency;
 use Adyen\Payment\Model\Api\AdyenDonations;
 use Adyen\Payment\Model\Sales\OrderRepository;
 use Adyen\Payment\Test\Unit\AbstractAdyenTestCase;
-use Magento\Framework\Exception\InputException;
 use Magento\Framework\Exception\LocalizedException;
-use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\Serialize\Serializer\Json;
 use Magento\Payment\Gateway\Command\CommandPoolInterface;
 use Magento\Payment\Gateway\CommandInterface;
-use Magento\Payment\Model\MethodInterface;
+use Magento\Payment\Gateway\Data\PaymentDataObject;
+use Magento\Payment\Gateway\Data\PaymentDataObjectFactoryInterface;
 use Magento\Sales\Model\Order;
-use PHPUnit\Framework\MockObject\MockObject;
-use Magento\Framework\Serialize\Serializer\Json;
+use Magento\Sales\Model\Order\Payment;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 
+#[CoversClass(AdyenDonations::class)]
 class AdyenDonationsTest extends AbstractAdyenTestCase
 {
-    private ?AdyenDonations $adyenDonations;
-    private CommandPoolInterface|MockObject $commandPoolMock;
-    private Json|MockObject $jsonMock;
-    private Data|MockObject $dataMock;
-    private Config|MockObject $configMock;
-    private ChargedCurrency|MockObject $chargedCurrencyMock;
-    private PaymentMethods|MockObject $paymentMethodsMock;
-    private OrderRepository|MockObject $orderRepositoryMock;
+    private AdyenDonations $adyenDonations;
+
+    private CommandPoolInterface $commandPool;
+    private Json $jsonSerializer;
+    private Data $dataHelper;
+    private OrderRepository $orderRepository;
+    private PaymentDataObjectFactoryInterface $paymentDataObjectFactory;
 
     protected function setUp(): void
     {
-        $this->commandPoolMock = $this->createMock(CommandPoolInterface::class);
-        $this->jsonMock = $this->createPartialMock(Json::class, []);
-        $this->dataMock = $this->createPartialMock(Data::class, []);
-        $this->chargedCurrencyMock = $this->createMock(ChargedCurrency::class);
-        $this->configMock = $this->createMock(Config::class);
-        $this->paymentMethodsMock = $this->createPartialMock(PaymentMethods::class, [
-            'getAlternativePaymentMethodTxVariant'
-        ]);
-        $this->orderRepositoryMock = $this->createMock(OrderRepository::class);
+        $this->commandPool = $this->createMock(CommandPoolInterface::class);
+        $this->jsonSerializer = $this->createMock(Json::class);
+        $this->dataHelper = $this->createMock(Data::class);
+        $this->orderRepository = $this->createMock(OrderRepository::class);
+        $this->paymentDataObjectFactory = $this->createMock(PaymentDataObjectFactoryInterface::class);
 
         $this->adyenDonations = new AdyenDonations(
-            $this->commandPoolMock,
-            $this->jsonMock,
-            $this->dataMock,
-            $this->chargedCurrencyMock,
-            $this->configMock,
-            $this->paymentMethodsMock,
-            $this->orderRepositoryMock
+            $this->commandPool,
+            $this->jsonSerializer,
+            $this->dataHelper,
+            $this->orderRepository,
+            $this->paymentDataObjectFactory
         );
     }
 
-    protected function tearDown(): void
+    #[Test]
+    public function makeDonationSuccess(): void
     {
-        $this->adyenDonations = null;
-    }
+        $payloadString = '{"amount":100}';
+        $payloadArray = ['amount' => 100];
 
-    private static function paymentMethodDataProvider(): array
-    {
-        return [
-            [
-                'paymentMethod' => 'adyen_cc',
-                'paymentMethodGroup' => 'adyen',
-                'customerId' => 1,
-                'executeSuccess' => true,
-                'donationTryCount' => 0
-            ],
-            [
-                'paymentMethod' => 'adyen_ideal',
-                'paymentMethodGroup' => 'adyen-alternative-payment-method',
-                'customerId' => null,
-                'executeSuccess' => true,
-                'donationTryCount' => 0
-            ],
-            [
-                'paymentMethod' => 'adyen_cc',
-                'paymentMethodGroup' => 'adyen',
-                'customerId' => null,
-                'executeSuccess' => false,
-                'donationTryCount' => 0
-            ],
-            [
-                'paymentMethod' => 'adyen_cc',
-                'paymentMethodGroup' => 'adyen',
-                'customerId' => null,
-                'executeSuccess' => false,
-                'donationTryCount' => 5
-            ],
-        ];
-    }
+        $order = $this->createMock(Order::class);
+        $payment = $this->createMock(Payment::class);
+        $paymentDO = $this->createMock(PaymentDataObject::class);
+        $command = $this->createMock(CommandInterface::class);
 
-    /**
-     * @dataProvider paymentMethodDataProvider
-     * @param $paymentMethod
-     * @param $paymentMethodGroup
-     * @param $customerId
-     * @param $executeSuccess
-     * @param $donationTryCount
-     * @return void
-     * @throws InputException
-     * @throws LocalizedException
-     * @throws NoSuchEntityException
-     */
-    public function testDonate($paymentMethod, $paymentMethodGroup, $customerId, $executeSuccess, $donationTryCount)
-    {
-        $orderId = 1;
-        $payload = '{"amount":{"value":1000,"currency":"EUR"}}';
-        $donationTokenMock = 'mock_token_abcde';
-        $orderCurrency = 'EUR';
-        $storeId = 1;
-        $donationAmounts = '1,5,10';
-        $pspReference = 'xyz_12345';
-        $orderIncrementId = '00000000001';
+        $order->method('getPayment')->willReturn($payment);
+        $this->jsonSerializer->method('unserialize')->with($payloadString)->willReturn($payloadArray);
 
-        $paymentMethodInstanceMock = $this->createMock(MethodInterface::class);
-        $paymentMethodInstanceMock->method('getConfigData')
-            ->with('group')
-            ->willReturn($paymentMethodGroup);
+        $payment->expects($this->once())
+            ->method('setAdditionalInformation')
+            ->with('donationPayload', $payloadArray);
 
-        $paymentMock = $this->createMock(Order\Payment::class);
-        $paymentMock->expects($this->once())
-            ->method('getMethodInstance')
-            ->willReturn($paymentMethodInstanceMock);
-        $paymentMock->expects($this->once())
-            ->method('getMethod')
-            ->willReturn($paymentMethod);
-        $paymentMock->method('getAdditionalInformation')
-            ->willReturnMap([
-                ['donationToken', $donationTokenMock],
-                ['pspReference', $pspReference],
-                ['donationTryCount', $donationTryCount]
-            ]);
+        $this->paymentDataObjectFactory->method('create')->with($payment)->willReturn($paymentDO);
+        $this->commandPool->method('get')->with('capture')->willReturn($command);
+        $command->expects($this->once())->method('execute')->with(['payment' => $paymentDO]);
 
-        $orderMock = $this->createMock(Order::class);
-        $orderMock->method('getPayment')->willReturn($paymentMock);
-        $orderMock->method('getStoreId')->willReturn($storeId);
-        $orderMock->method('getCustomerId')->willReturn($customerId);
-        $orderMock->method('getIncrementId')->willReturn($orderIncrementId);
+        $this->orderRepository->expects($this->once())->method('save')->with($order);
 
-        $this->orderRepositoryMock->expects($this->once())
-            ->method('get')
-            ->with($orderId)
-            ->willReturn($orderMock);
-        $this->orderRepositoryMock->method('save')->with($orderMock);
-
-        $orderAmountCurrencyMock = $this->createMock(AdyenAmountCurrency::class);
-        $orderAmountCurrencyMock->method('getCurrencyCode')->willReturn($orderCurrency);
-
-        $this->paymentMethodsMock->method('getAlternativePaymentMethodTxVariant')
-            ->willReturn('tx_variant');
-
-        $this->chargedCurrencyMock->expects($this->once())
-            ->method('getOrderAmountCurrency')
-            ->with($orderMock, false)
-            ->willReturn($orderAmountCurrencyMock);
-
-        $this->configMock->expects($this->once())
-            ->method('getAdyenGivingDonationAmounts')
-            ->with($storeId)
-            ->willReturn($donationAmounts);
-
-        $donationCommand = $this->createMock(CommandInterface::class);
-
-        if ($executeSuccess) {
-            $paymentMock->expects($this->once())
-                ->method('unsAdditionalInformation')
-                ->with('donationToken');
-
-            $donationCommand->expects($this->once())->method('execute');
-        } else {
-            $this->expectException(LocalizedException::class);
-
-            $donationCommand->method('execute')->willThrowException(
-                new LocalizedException(__('exception'))
-            );
-        }
-
-        $this->commandPoolMock->expects($this->once())
-            ->method('get')
-            ->willReturn($this->createMock(OrderInterface::class));
-
-        $adyenDonationsMock = $this->getMockBuilder(AdyenDonations::class)
-            ->onlyMethods(['makeDonation'])
-            ->setConstructorArgs([
-                $this->createMock(CommandPoolInterface::class),
-                $this->createMock(Json::class),
-                $this->createMock(Data::class),
-                $this->createMock(ChargedCurrency::class),
-                $this->createMock(Config::class),
-                $this->createMock(PaymentMethods::class),
-                $orderRepositoryMock
-            ])
-            ->getMock();
-
-        $adyenDonationsMock->donate(1, '');
-            ->with('capture')
-            ->willReturn($donationCommand);
-
-        $this->adyenDonations->donate($orderId, $payload);
-    }
-
-    /**
-     * @return void
-     * @throws LocalizedException
-     * @throws AdyenException
-     */
-    public function testNullDonationToken()
-    {
-        $this->expectException(LocalizedException::class);
-
-        $payload = '{"amount":{"value":1000,"currency":"EUR"}}';
-        $donationTokenMock = null;
-
-        $paymentMock = $this->createMock(Order\Payment::class);
-        $paymentMock->method('getAdditionalInformation')
-            ->willReturnMap([
-                ['donationToken', $donationTokenMock]
-            ]);
-
-        $orderMock = $this->createMock(Order::class);
-        $orderMock->expects($this->once())->method('getPayment')->willReturn($paymentMock);
-
-        // Assert LocalizedException
-        $this->adyenDonations->makeDonation($payload, $orderMock);
-    }
-
-    /**
-     * @return void
-     * @throws AdyenException
-     * @throws LocalizedException
-     */
-    public function testCurrencyMismatch()
-    {
-        $this->expectException(LocalizedException::class);
-
-        $payload = '{"amount":{"value":1000,"currency":"EUR"}}';
-        $donationTokenMock = 'mock_token_abcde';
-        $orderCurrency = 'TRY';
-
-        $paymentMock = $this->createMock(Order\Payment::class);
-        $paymentMock->method('getAdditionalInformation')
-            ->willReturnMap([
-                ['donationToken', $donationTokenMock]
-            ]);
-        $orderMock = $this->createMock(Order::class);
-        $orderMock->expects($this->once())->method('getPayment')->willReturn($paymentMock);
-
-        $orderAmountCurrencyMock = $this->createMock(AdyenAmountCurrency::class);
-        $orderAmountCurrencyMock->method('getCurrencyCode')->willReturn($orderCurrency);
-
-        $this->chargedCurrencyMock->expects($this->once())
-            ->method('getOrderAmountCurrency')
-            ->with($orderMock, false)
-            ->willReturn($orderAmountCurrencyMock);
-
-        // Assert LocalizedException
-        $this->adyenDonations->makeDonation($payload, $orderMock);
+        $this->adyenDonations->makeDonation($payloadString, $order);
     }
 }

--- a/Test/Unit/Model/Api/GuestAdyenDonationsTest.php
+++ b/Test/Unit/Model/Api/GuestAdyenDonationsTest.php
@@ -18,9 +18,7 @@ use Adyen\Payment\Model\Api\GuestAdyenDonations;
 use Adyen\Payment\Model\Sales\OrderRepository;
 use Adyen\Payment\Test\Unit\AbstractAdyenTestCase;
 use Magento\Quote\Model\MaskedQuoteIdToQuoteIdInterface;
-use Magento\Quote\Model\QuoteIdMask;
-use Magento\Quote\Model\QuoteIdMaskFactory;
-use Magento\Sales\Api\Data\OrderInterface;
+use Magento\Sales\Model\Order;
 
 class GuestAdyenDonationsTest extends AbstractAdyenTestCase
 {
@@ -55,7 +53,7 @@ class GuestAdyenDonationsTest extends AbstractAdyenTestCase
         $adyenDonationsModelMock = $this->createMock(AdyenDonations::class);
 
         $orderRepositoryMock = $this->createConfiguredMock(OrderRepository::class, [
-            'getOrderByQuoteId' => $this->createMock(OrderInterface::class)
+            'getOrderByQuoteId' => $this->createMock(Order::class)
         ]);
 
         $adyenLoggerMock = $this->createMock(AdyenLogger::class);

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1223,6 +1223,7 @@
         <arguments>
             <argument name="builders" xsi:type="array">
                 <item name="donation" xsi:type="string">Adyen\Payment\Gateway\Request\DonationDataBuilder</item>
+                <item name="header" xsi:type="string">Adyen\Payment\Gateway\Request\Header\HeaderDataBuilder</item>
             </argument>
         </arguments>
     </virtualType>

--- a/view/frontend/templates/checkout/success.phtml
+++ b/view/frontend/templates/checkout/success.phtml
@@ -98,7 +98,6 @@ script;
                 adyenPaymentService.donationCampaigns(isLoggedIn, orderId, maskedQuoteId)
                     .done(function (response) {
                         try {
-                        debugger;
                             const campaignResponse = JSON.parse(response);
                             if (campaignResponse && Object.keys(campaignResponse).length > 0) {
                                 mountAdyenGivingComponent(campaignResponse);
@@ -124,7 +123,6 @@ script;
                         if(campaign.donation.type == 'roundup') {
                             donationConfig.commercialTxAmount = '$orderAmount'
                         }
-                        debugger;
                         adyenGivingComponent = new window.AdyenWeb.Donation(
                             checkoutComponent,
                             donationConfig

--- a/view/frontend/web/js/model/adyen-payment-service.js
+++ b/view/frontend/web/js/model/adyen-payment-service.js
@@ -22,9 +22,14 @@ define(
         ko
     ) {
         'use strict';
+
+        // Set the base url to make ajax call to the REST endpoints
+        url.setBaseUrl(window.BASE_URL);
+
         return {
             paymentMethods: ko.observable(null),
             connectedTerminals: ko.observable(null),
+
 
             /**
              * Retrieve the list of available payment methods from Adyen


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Refactoring DonationDataBuilder as it has payload as the payment information in the `buildSubject[payment]`, which is an array and not the payment/paymentDataObject.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

Fixes  <!-- #-prefixed github issue number -->
