### PR TITLE
[ECP-9592] Remove utm_nooverride parameter from the return URLs

### DIFF
--- a/Controller/Return/Index.php
+++ b/Controller/Return/Index.php
@@ -124,8 +124,8 @@ class Index extends Action
 
                 // Add OrderIncrementId to redirect parameters for headless support.
                 $redirectParams = $this->configHelper->getAdyenAbstractConfigData('custom_success_redirect_path', $storeId)
-                    ? ['_query' => ['utm_nooverride' => '1', 'order_increment_id' => $this->order->getIncrementId()]]
-                    : ['_query' => ['utm_nooverride' => '1']];
+                    ? ['_query' => ['order_increment_id' => $this->order->getIncrementId()]]
+                    : [];
                 $this->_redirect($successPath, $redirectParams);
             } else {
                 $this->adyenLogger->addAdyenResult(
@@ -140,7 +140,7 @@ class Index extends Action
                 $this->session->restoreQuote();
                 $this->messageManager->addError(__('Your payment failed, Please try again later'));
 
-                $this->_redirect($failPath, ['_query' => ['utm_nooverride' => '1']]);
+                $this->_redirect($failPath);
             }
         } else {
             $this->_redirect($this->configHelper->getAdyenAbstractConfigData('return_path', $storeId));


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
This PR removes the legacy `utm_nooverride` for Google Analytics tracking.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- Redirect payment methods happy flow

Fixes #2846 
