### PR TITLE
[ECP-9630] Make external platform integrator field configurable

### DIFF
--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -59,6 +59,7 @@ class Config
     const XML_THREEDS_FLOW = 'threeds_flow';
     const XML_REMOVE_PROCESSED_WEBHOOKS = 'remove_processed_webhooks';
     const XML_PROCESSED_WEBHOOK_REMOVAL_TIME = 'processed_webhook_removal_time';
+    const XML_PLATFORM_INTEGRATOR = 'platform_integrator';
 
     protected ScopeConfigInterface $scopeConfig;
     private EncryptorInterface $encryptor;
@@ -589,6 +590,20 @@ class Config
             Config::XML_ADYEN_CC_VAULT,
             $storeId,
             true
+        );
+    }
+
+    /**
+     * Returns the name of the platform integrator
+     *
+     * @return string|null
+     */
+    public function getPlatformIntegratorName(): ?string
+    {
+        return $this->getConfigData(
+            Config::XML_PLATFORM_INTEGRATOR,
+            Config::XML_ADYEN_ABSTRACT_PREFIX,
+            null
         );
     }
 

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -937,12 +937,15 @@ class Data extends AbstractHelper
         }
 
         $client = $this->createAdyenClient();
+
         $client->setApplicationName(self::APPLICATION_NAME);
         $client->setXApiKey($apiKey);
-
         $client->setMerchantApplication($this->getModuleName(), $this->getModuleVersion());
+
         $platformData = $this->getMagentoDetails();
-        $client->setExternalPlatform($platformData['name'], $platformData['version'], 'Adyen');
+        $platformIntegrator = $this->configHelper->getPlatformIntegratorName() ?? '';
+        $client->setExternalPlatform($platformData['name'], $platformData['version'], $platformIntegrator);
+
         if ($isDemo) {
             $client->setEnvironment(Environment::TEST);
         } else {

--- a/Test/Unit/Controller/Return/IndexTest.php
+++ b/Test/Unit/Controller/Return/IndexTest.php
@@ -189,7 +189,7 @@ class IndexTest extends AbstractAdyenTestCase
             $this->redirectMock->expects($this->once())->method('redirect')->with(
                 $this->contextResponseMock,
                 $returnPath,
-                $redirectResponse ? ['_query' => ['utm_nooverride' => '1']] : []
+                []
             );
         }
 

--- a/Test/Unit/Helper/ConfigTest.php
+++ b/Test/Unit/Helper/ConfigTest.php
@@ -206,4 +206,23 @@ class ConfigTest extends AbstractAdyenTestCase
         $this->assertIsInt($result);
         $this->assertEquals(90, $result);
     }
+
+    public function testGetPlatformIntegratorName()
+    {
+        $mockIntegratorName = 'Galaxy Invaders Tech Co.';
+
+        $path = sprintf(
+            "%s/%s/%s",
+            Config::XML_PAYMENT_PREFIX,
+            Config::XML_ADYEN_ABSTRACT_PREFIX,
+            Config::XML_PLATFORM_INTEGRATOR
+        );
+
+        $this->scopeConfigMock->expects($this->once())
+            ->method('getValue')
+            ->with($path, ScopeInterface::SCOPE_STORE, null)
+            ->willReturn($mockIntegratorName);
+
+        $this->assertEquals($mockIntegratorName, $this->configHelper->getPlatformIntegratorName());
+    }
 }

--- a/etc/adminhtml/system/adyen_testing_performance.xml
+++ b/etc/adminhtml/system/adyen_testing_performance.xml
@@ -77,5 +77,19 @@
                 This field determines the number of days after which processed webhooks will be removed by a cronjob. Note: Setting less than a reasonable number of days might reduce the desired visibility of webhooks in the Webhooks Overview.
             </tooltip>
         </field>
+        <field id="has_platform_integrator" translate="label" type="select" sortOrder="70" showInDefault="1">
+            <label>Managed by a system integrator</label>
+            <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+            <tooltip></tooltip>
+            <config_path>payment/adyen_abstract/has_platform_integrator</config_path>
+        </field>
+        <field id="platform_integrator" translate="label" type="text" sortOrder="80" showInDefault="1">
+            <label>Name of the system integrator</label>
+            <depends>
+                <field id="has_platform_integrator">1</field>
+            </depends>
+            <tooltip></tooltip>
+            <config_path>payment/adyen_abstract/platform_integrator</config_path>
+        </field>
     </group>
 </include>


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
This PR introduces a new configuration field to make `applicationInfon.external_platform_integrator` field in the API calls configurable instead of sending `Adyen` by default.

In order to configure this field, set `Managed by a system integrator` config field to `Yes` and fill out `Name of the system integrator` configuration field manually.

![Screenshot 2025-05-22 at 16 29 34](https://github.com/user-attachments/assets/66830b80-b6ca-402a-9a18-f01f5d67e0d7)

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- Completing a payment w/wo the platform integrator field

![Screenshot 2025-05-22 at 16 06 21](https://github.com/user-attachments/assets/0d47c755-7095-46da-9611-b607cae1ec61)

![Screenshot 2025-05-22 at 16 04 01](https://github.com/user-attachments/assets/b2b1b68f-30e9-472d-8856-502b6f00d5d0)
