### PR TITLE
[ECP-9651] Implement data collection outside of checkout

### DIFF
--- a/Block/Default/DataCollection.php
+++ b/Block/Default/DataCollection.php
@@ -3,7 +3,7 @@
  *
  * Adyen Payment module (https://www.adyen.com/)
  *
- * Copyright (c) 2021 Adyen BV (https://www.adyen.com/)
+ * Copyright (c) 2025 Adyen N.V. (https://www.adyen.com/)
  * See LICENSE.txt for license details.
  *
  * Author: Adyen <magento@adyen.com>
@@ -11,9 +11,46 @@
 
 namespace Adyen\Payment\Block\Default;
 
+use Adyen\Payment\Helper\Config;
+use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\View\Element\Template;
+use Magento\Framework\View\Element\Template\Context;
 
 class DataCollection extends Template
 {
+    public function __construct(
+        private readonly Config $configHelper,
+        Context $context,
+        array $data = []
+    ) {
+        parent::__construct($context, $data);
+    }
 
+    /**
+     * Returns the environment based on the demo mode.
+     *
+     * @return string
+     * @throws NoSuchEntityException
+     */
+    public function getEnvironment(): string
+    {
+        $isDemoMode = $this->configHelper->isDemoMode(
+            $this->_storeManager->getStore()->getId()
+        );
+
+        return $isDemoMode ? 'test' : 'live';
+    }
+
+    /**
+     * Checks whether the data collection feature is enabled or not.
+     *
+     * @return bool
+     * @throws NoSuchEntityException
+     */
+    public function isEnabled(): bool
+    {
+        return $this->configHelper->isOutsideCheckoutDataCollectionEnabled(
+            $this->_storeManager->getStore()->getId()
+        );
+    }
 }

--- a/Block/Default/DataCollection.php
+++ b/Block/Default/DataCollection.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2021 Adyen BV (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\Payment\Block\Default;
+
+use Magento\Framework\View\Element\Template;
+
+class DataCollection extends Template
+{
+
+}

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -61,6 +61,7 @@ class Config
     const XML_PROCESSED_WEBHOOK_REMOVAL_TIME = 'processed_webhook_removal_time';
     const XML_PLATFORM_INTEGRATOR = 'platform_integrator';
     const XML_HAS_PLATFORM_INTEGRATOR = 'has_platform_integrator';
+    const XML_OUTSIDE_CHECKOUT_DATA_COLLECTION = 'outside_checkout_data_collection';
 
     protected ScopeConfigInterface $scopeConfig;
     private EncryptorInterface $encryptor;
@@ -610,6 +611,20 @@ class Config
             Config::XML_PLATFORM_INTEGRATOR,
             Config::XML_ADYEN_ABSTRACT_PREFIX,
             null
+        );
+    }
+
+    /**
+     * @param int|null $storeId
+     * @return bool
+     */
+    public function isOutsideCheckoutDataCollectionEnabled(?int $storeId = null): bool
+    {
+        return $this->getConfigData(
+            self::XML_OUTSIDE_CHECKOUT_DATA_COLLECTION,
+            Config::XML_ADYEN_ABSTRACT_PREFIX,
+            $storeId,
+            true
         );
     }
 

--- a/Test/Unit/Block/Default/DataCollectionTest.php
+++ b/Test/Unit/Block/Default/DataCollectionTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Adyen\Payment\Test\Unit\Block\Default;
+
+use Adyen\Payment\Block\Default\DataCollection;
+use Adyen\Payment\Helper\Config;
+use Adyen\Payment\Test\Unit\AbstractAdyenTestCase;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\View\Element\Template\Context;
+use Magento\Store\Api\Data\StoreInterface;
+use Magento\Store\Model\StoreManagerInterface;
+use PHPUnit\Framework\MockObject\Exception;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class DataCollectionTest extends AbstractAdyenTestCase
+{
+    protected ?DataCollection $dataCollection;
+    protected Config|MockObject $configMock;
+    protected Context|MockObject $contextMock;
+    protected StoreManagerInterface $storeManagerMock;
+    protected StoreInterface|MockObject $storeMock;
+    protected array $dataMock = [];
+    protected int $storeId = 1;
+
+    /**
+     * @return void
+     * @throws Exception
+     */
+    public function setUp(): void
+    {
+        $this->configMock = $this->createMock(Config::class);
+        $this->contextMock = $this->createMock(Context::class);
+
+        $this->storeMock = $this->createMock(StoreInterface::class);
+        $this->storeMock->method('getId')->willReturn($this->storeId);
+        $this->storeManagerMock = $this->createMock(StoreManagerInterface::class);
+        $this->storeManagerMock->method('getStore')->willReturn($this->storeMock);
+
+        $this->contextMock->method('getStoreManager')->willReturn($this->storeManagerMock);
+
+        $this->dataCollection = new DataCollection(
+            $this->configMock,
+            $this->contextMock,
+            $this->dataMock
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function tearDown(): void
+    {
+        $this->dataCollection = null;
+    }
+
+    /**
+     * @return array[]
+     */
+    private static function dataProviderGetEnvironment(): array
+    {
+        return [
+            [
+                'isDemoMode' => true,
+                'expectedEnvironment' => 'test'
+            ],
+            [
+                'isDemoMode' => false,
+                'expectedEnvironment' => 'live'
+            ]
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderGetEnvironment
+     *
+     * @param $isDemoMode
+     * @param $expectedEnvironment
+     * @return void
+     * @throws NoSuchEntityException
+     */
+    public function testGetEnvironment($isDemoMode, $expectedEnvironment)
+    {
+        $this->configMock->method('isDemoMode')->with($this->storeId)->willReturn($isDemoMode);
+        $this->assertEquals($expectedEnvironment, $this->dataCollection->getEnvironment());
+    }
+
+    /**
+     * @return void
+     * @throws NoSuchEntityException
+     */
+    public function testIsEnabled()
+    {
+        $isEnabled = true;
+
+        $this->configMock->method('isOutsideCheckoutDataCollectionEnabled')
+            ->with($this->storeId)
+            ->willReturn($isEnabled);
+
+        $this->assertEquals($isEnabled, $this->dataCollection->isEnabled());
+    }
+}

--- a/etc/adminhtml/system/adyen_risk_management.xml
+++ b/etc/adminhtml/system/adyen_risk_management.xml
@@ -28,13 +28,18 @@
                 ]]>
             </comment>
         </field>
-        <field id="fraud_manual_review_status" translate="label" type="select" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
+        <field id="outside_checkout_data_collection" translate="label" type="select" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
+            <label>Collect data outside of the checkout</label>
+            <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+            <config_path>payment/adyen_abstract/outside_checkout_data_collection</config_path>
+        </field>
+        <field id="fraud_manual_review_status" translate="label" type="select" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
             <label>Manual review status</label>
             <tooltip>This status will be triggered when Adyen notifies your Magento module that the payment has come under Manual Review. If you do not have this set up or do not want a separate status, please keep it on the default (e.g.'— Please Select —').</tooltip>
             <source_model>Magento\Sales\Model\Config\Source\Order\Status\NewStatus</source_model>
             <config_path>payment/adyen_abstract/fraud_manual_review_status</config_path>
         </field>
-        <field id="fraud_manual_review_accept_status" translate="label" type="select" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
+        <field id="fraud_manual_review_accept_status" translate="label" type="select" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1">
             <label>Manual review accepted status</label>
             <tooltip>Only relevant if you do not have an action defined when you accept a manual review. This status will be triggered when a 'MANUAL_REVIEW_ACCEPT' webhook is received from Adyen. If you have already asked Adyen to set an action for this (e.g. capture) or don't want a separate status for this, please keep it on the default (e.g.'— Please Select —')</tooltip>
             <source_model>Magento\Sales\Model\Config\Source\Order\Status\Processing</source_model>

--- a/etc/adminhtml/system/adyen_risk_management.xml
+++ b/etc/adminhtml/system/adyen_risk_management.xml
@@ -23,7 +23,7 @@
             <config_path>payment/adyen_abstract/send_additional_risk_data</config_path>
             <comment>
                 <![CDATA[
-                If enabled additional risk data will be sent with every payment request. To learn more about risk management refer to
+                If enabled additional risk data will be sent with every payment request. To learn more about risk management, refer to
                 <a target="_blank" href="https://docs.adyen.com/risk-management">Adyen documentation</a>.
                 ]]>
             </comment>
@@ -32,6 +32,12 @@
             <label>Collect data outside of the checkout</label>
             <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
             <config_path>payment/adyen_abstract/outside_checkout_data_collection</config_path>
+            <comment>
+                <![CDATA[
+                Additional data will be collected to detect fraud outside of the checkout page if enabled. To learn more about data collection to detect fraud, refer to
+                <a target="_blank" href="https://docs.adyen.com/risk-management/fraud-data-collection">Adyen documentation</a>.
+                ]]>
+            </comment>
         </field>
         <field id="fraud_manual_review_status" translate="label" type="select" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
             <label>Manual review status</label>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -36,6 +36,7 @@
                 <allow_multistore_tokens>1</allow_multistore_tokens>
                 <remove_processed_webhooks>0</remove_processed_webhooks>
                 <processed_webhook_removal_time>90</processed_webhook_removal_time>
+                <outside_checkout_data_collection>0</outside_checkout_data_collection>
             </adyen_abstract>
             <adyen_cc>
                 <active>0</active>

--- a/view/frontend/layout/default.xml
+++ b/view/frontend/layout/default.xml
@@ -1,8 +1,9 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
-        <block class="Adyen\Payment\Block\DataCollection"
-               name="adyen_payment_data_collection"
-               cacheable="false"
-               template="Adyen_Payment::default/data_collection.phtml"/>
+        <referenceContainer name="head.additional">
+            <block class="Adyen\Payment\Block\Default\DataCollection"
+                   name="adyen.default.dataCollection"
+                   template="Adyen_Payment::default/data_collection.phtml"/>
+        </referenceContainer>
     </body>
 </page>

--- a/view/frontend/layout/default.xml
+++ b/view/frontend/layout/default.xml
@@ -1,0 +1,8 @@
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <block class="Adyen\Payment\Block\DataCollection"
+               name="adyen_payment_data_collection"
+               cacheable="false"
+               template="Adyen_Payment::default/data_collection.phtml"/>
+    </body>
+</page>

--- a/view/frontend/templates/default/data_collection.phtml
+++ b/view/frontend/templates/default/data_collection.phtml
@@ -1,0 +1,5 @@
+
+
+<script>
+    alert("Layout Test");
+</script>

--- a/view/frontend/templates/default/data_collection.phtml
+++ b/view/frontend/templates/default/data_collection.phtml
@@ -1,5 +1,23 @@
+<?php
+/**
+ *
+ * Adyen Payment Module
+ *
+ * Copyright (c) 2025 Adyen N.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
 
+use Adyen\Payment\Block\Default\DataCollection;
+use Magento\Framework\Escaper;
 
-<script>
-    alert("Layout Test");
-</script>
+/** @var $block DataCollection */
+/** @var $escaper Escaper */
+
+?>
+
+<?php if ($block->isEnabled()): ?>
+    <script src="https://checkoutshopper-<?= $escaper->escapeHtmlAttr($block->getEnvironment()) ?>.adyen.com/checkoutshopper/assets/js/datacollection/datacollection.js"></script>
+<?php endif; ?>


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
This PR implements additional data collection to detect fraud outside of the checkout page. To enable this feature, go to Adyen Payments / Payment optimization / Risk management configuration and enable `Collect data outside of the checkout` field.

For further details, please refer to [Adyen documentation](https://docs.adyen.com/risk-management/fraud-data-collection/#collect-additional-data).

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- Data collection script loaded to DOM outside of the checkout page