### PR TITLE
[ECP-9705] Deprecate RECURRING_CONTRACT webhook handler

### DIFF
--- a/Helper/Webhook/RecurringContractWebhookHandler.php
+++ b/Helper/Webhook/RecurringContractWebhookHandler.php
@@ -20,6 +20,11 @@ use Magento\Sales\Model\Order as MagentoOrder;
 use Magento\Vault\Api\PaymentTokenRepositoryInterface;
 use Magento\Vault\Model\PaymentTokenManagement;
 
+/**
+ * @deprecated This webhook event has been deprecated.
+ * You can start using tokenization webhooks. Please visit the following link for further information.
+ * https://docs.adyen.com/api-explorer/Tokenization-webhooks/1/overview
+ */
 class RecurringContractWebhookHandler implements WebhookHandlerInterface
 {
     private AdyenLogger $adyenLogger;


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
This PR deprecated RECURRING_CONTRACT webhook handler and promotes usage of new token lifecycle webhooks. For more information, please refer to Adyen documentation.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- N/A