### PR TITLE
fix: fix code generation error of the OrderRepository class

### DIFF
--- a/Model/Sales/OrderRepository.php
+++ b/Model/Sales/OrderRepository.php
@@ -64,7 +64,7 @@ class OrderRepository extends SalesOrderRepository
         $this->filterGroupBuilder = $filterGroupBuilder;
     }
 
-    public function getOrderByQuoteId(int $quoteId): OrderInterface|false
+    public function getOrderByQuoteId(int $quoteId): ?OrderInterface
     {
         $quoteIdFilter = $this->filterBuilder->setField('quote_id')
             ->setConditionType('eq')
@@ -85,6 +85,9 @@ class OrderRepository extends SalesOrderRepository
         $orders = $this->getList($searchCriteria)->getItems();
 
         /** @var OrderInterface $order */
-        return reset($orders);
+        foreach ($orders as $order) {
+            return $order;
+        }
+        return null;
     }
 }


### PR DESCRIPTION
In developer mode, code generation of the `OrderRepository` class failed because of the union return type of the `getOrderByQuoteId` method. This PR resolves this by changing the resturn type from `OrderInterface|false` to `?OrderInterface`. Although this changes the error value from `false` to `null`, this does not affect usages of this method in this module.

Fixes  #3006.
