### PR TITLE
[ECP-9753] Fix compiling issues related to mix return types

### DIFF
--- a/Model/Api/GuestAdyenPosCloud.php
+++ b/Model/Api/GuestAdyenPosCloud.php
@@ -11,13 +11,13 @@
 
 namespace Adyen\Payment\Model\Api;
 
+use Adyen\AdyenException;
 use Adyen\Payment\Api\GuestAdyenPosCloudInterface;
 use Adyen\Payment\Logger\AdyenLogger;
 use Adyen\Payment\Model\Sales\OrderRepository;
 use Magento\Payment\Gateway\Command\CommandPoolInterface;
 use Magento\Payment\Gateway\Data\PaymentDataObjectFactoryInterface;
 use Magento\Quote\Model\QuoteIdMaskFactory;
-
 
 class GuestAdyenPosCloud extends AdyenPosCloud implements GuestAdyenPosCloudInterface
 {
@@ -46,12 +46,16 @@ class GuestAdyenPosCloud extends AdyenPosCloud implements GuestAdyenPosCloudInte
     /**
      * @param string $cartId
      * @return void
+     * @throws AdyenException
      */
     public function payByCart(string $cartId): void
     {
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
         $quoteId = $quoteIdMask->getQuoteId();
         $order = $this->orderRepository->getOrderByQuoteId($quoteId);
+        if (!$order) {
+            throw new AdyenException('POS Payment Failed');
+        }
         $this->execute($order);
     }
 }

--- a/Model/Sales/OrderRepository.php
+++ b/Model/Sales/OrderRepository.php
@@ -64,7 +64,7 @@ class OrderRepository extends SalesOrderRepository
         $this->filterGroupBuilder = $filterGroupBuilder;
     }
 
-    public function getOrderByQuoteId(int $quoteId): OrderInterface|false
+    public function getOrderByQuoteId(int $quoteId): OrderInterface
     {
         $quoteIdFilter = $this->filterBuilder->setField('quote_id')
             ->setConditionType('eq')

--- a/Model/Sales/OrderRepository.php
+++ b/Model/Sales/OrderRepository.php
@@ -64,7 +64,7 @@ class OrderRepository extends SalesOrderRepository
         $this->filterGroupBuilder = $filterGroupBuilder;
     }
 
-    public function getOrderByQuoteId(int $quoteId): OrderInterface
+    public function getOrderByQuoteId(int $quoteId)
     {
         $quoteIdFilter = $this->filterBuilder->setField('quote_id')
             ->setConditionType('eq')


### PR DESCRIPTION

<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Even though PHP 8 supports multiple method return types, Magento 2 does not support it and throws exception while compiling the generated files on 2.4.4 and 2.4.5.


