### PR TITLE
[ECP-9755] onSubmit callback cannot be made for redirect payment method

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/adyen-paypal-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-paypal-method.js
@@ -39,7 +39,6 @@ define(
                 let paypalConfiguration = Object.assign(baseComponentConfiguration, paymentMethodsExtraInfo[paymentMethod.type].configuration);
                 paypalConfiguration.showPayButton = true;
                 paypalConfiguration.cspNonce = adyenConfiguration.getCspNonce();
-                paypalConfiguration.onSubmit = this.handleOnSubmit.bind(this);
 
                 let agreementsConfig = adyenConfiguration.getAgreementsConfig();
 

--- a/view/frontend/web/js/view/payment/method-renderer/adyen-pm-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-pm-method.js
@@ -203,6 +203,8 @@ define(
                         onChange: function (state) {
                             paymentComponentStates().setIsPlaceOrderAllowed(self.getMethodCode(), state.isValid);
                         },
+                        onSubmit: this.handleOnSubmit.bind(this)
+
                     });
 
                 return configuration;


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
onSubmit callback cannot be made for redirect payment methods(GooglePay, Paypal) on V10 of the plugin. For all components which extends from the adyen-pm-method.js and do not have its own onSubmit, the children component lost the binding for the submit function.

Adding the onSubmit on the Payment Component configuration level.

