### PR TITLE
[ECP-9756] Add onError callback to component configuration

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/adyen-pm-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-pm-method.js
@@ -203,8 +203,8 @@ define(
                         onChange: function (state) {
                             paymentComponentStates().setIsPlaceOrderAllowed(self.getMethodCode(), state.isValid);
                         },
-                        onSubmit: this.handleOnSubmit.bind(this)
-
+                        onSubmit: this.handleOnSubmit.bind(this),
+                        onError: this.handleOnError.bind(this)
                     });
 
                 return configuration;


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
This PR inserts `onError` callback to payment method component configuration as a temporary solution to the broken binding of the configuration objects of AdyenCheckout library and payment method component.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- PayPal happy flow and shopper cancellation