### PR TITLE
[ECP-9750] Implement configuration field for metrics data collection

### DIFF
--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -61,6 +61,7 @@ class Config
     const XML_PROCESSED_WEBHOOK_REMOVAL_TIME = 'processed_webhook_removal_time';
     const XML_PLATFORM_INTEGRATOR = 'platform_integrator';
     const XML_HAS_PLATFORM_INTEGRATOR = 'has_platform_integrator';
+    const XML_RELIABILITY_DATA_COLLECTION = 'reliability_data_collection';
 
     /**
      * @param ScopeConfigInterface $scopeConfig
@@ -639,6 +640,22 @@ class Config
             Config::XML_PLATFORM_INTEGRATOR,
             Config::XML_ADYEN_ABSTRACT_PREFIX,
             null
+        );
+    }
+
+    /**
+     * Returns true if the reliability data collection is enabled
+     *
+     * @param int|null $storeId
+     * @return bool
+     */
+    public function isReliabilityDataCollectionEnabled(?int $storeId = null): bool
+    {
+        return $this->getConfigData(
+            Config::XML_RELIABILITY_DATA_COLLECTION,
+            Config::XML_ADYEN_ABSTRACT_PREFIX,
+            $storeId,
+            true
         );
     }
 

--- a/Test/Unit/Helper/ConfigTest.php
+++ b/Test/Unit/Helper/ConfigTest.php
@@ -244,4 +244,23 @@ class ConfigTest extends AbstractAdyenTestCase
 
         $this->assertEquals($mockIntegratorName, $this->configHelper->getPlatformIntegratorName());
     }
+
+    public function testIsReliabilityDataCollectionEnabled()
+    {
+        $isfeatureEnabled = true;
+
+        $path = sprintf(
+            "%s/%s/%s",
+            Config::XML_PAYMENT_PREFIX,
+            Config::XML_ADYEN_ABSTRACT_PREFIX,
+            Config::XML_RELIABILITY_DATA_COLLECTION
+        );
+
+        $this->scopeConfigMock->expects($this->once())
+            ->method('isSetFlag')
+            ->with($path, ScopeInterface::SCOPE_STORE, null)
+            ->willReturn($isfeatureEnabled);
+
+        $this->assertTrue($this->configHelper->isReliabilityDataCollectionEnabled());
+    }
 }

--- a/etc/adminhtml/system/adyen_testing_performance.xml
+++ b/etc/adminhtml/system/adyen_testing_performance.xml
@@ -77,5 +77,13 @@
                 This field determines the number of days after which processed webhooks will be removed by a cronjob. Note: Setting less than a reasonable number of days might reduce the desired visibility of webhooks in the Webhooks Overview.
             </tooltip>
         </field>
+        <field id="reliability_data_collection" translate="label" type="select" sortOrder="70" showInDefault="1" showInWebsite="1" showInStore="1">
+            <label>Collect and submit application reliability data</label>
+            <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+            <config_path>payment/adyen_abstract/reliability_data_collection</config_path>
+            <tooltip>
+                Enables application reliability metrics data collection and submission to Adyen for performance analysis purpose.
+            </tooltip>
+        </field>
     </group>
 </include>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -36,6 +36,7 @@
                 <allow_multistore_tokens>1</allow_multistore_tokens>
                 <remove_processed_webhooks>0</remove_processed_webhooks>
                 <processed_webhook_removal_time>90</processed_webhook_removal_time>
+                <reliability_data_collection>0</reliability_data_collection>
             </adyen_abstract>
             <adyen_cc>
                 <active>0</active>


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
This PR implements the configuration field for merchant consent for reliability metrics data collection and submission.

This feature is disabled by default.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- Automated test workflows