### PR TITLE
[ECP-9707] Implement recurring.token.created webhook handler

### DIFF
--- a/Helper/Webhook/RecurringTokenCreatedWebhookHandler.php
+++ b/Helper/Webhook/RecurringTokenCreatedWebhookHandler.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ *
+ * Adyen Payment Module
+ *
+ * Copyright (c) 2025 Adyen N.V.
+ * This file is open source and available under the MIT license.
+ * See the LICENSE file for more info.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\Payment\Helper\Webhook;
+
+use Adyen\Payment\Helper\Vault;
+use Adyen\Payment\Logger\AdyenLogger;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Sales\Model\Order;
+use Adyen\Payment\Model\Notification;
+
+class RecurringTokenCreatedWebhookHandler implements WebhookHandlerInterface
+{
+    public function __construct(
+        private readonly AdyenLogger $adyenLogger,
+        private readonly Vault $vaultHelper
+    ) { }
+
+    /**
+     * Handle the recurring.token.created webhook.
+     *
+     * @param Order $order
+     * @param Notification $notification
+     * @param string $transitionState
+     * @return Order
+     * @throws LocalizedException
+     */
+    public function handleWebhook(Order $order, Notification $notification, string $transitionState): Order
+    {
+        $paymentMethodInstance = $order->getPayment()->getMethodInstance();
+        $paymentMethodCode = $paymentMethodInstance->getCode();
+        $storeId = $paymentMethodInstance->getStore();
+        $isRecurringEnabled = $this->vaultHelper->getPaymentMethodRecurringActive($paymentMethodCode, $storeId);
+
+        if ($isRecurringEnabled) {
+            $paymentToken = $this->vaultHelper->createVaultToken(
+                $order->getPayment(),
+                $notification->getPspreference()
+            );
+            $extensionAttributes = $this->vaultHelper->getExtensionAttributes($order->getPayment());
+            $extensionAttributes->setVaultPaymentToken($paymentToken);
+        }
+        else{
+            $this->adyenLogger->addAdyenNotification(
+                'The vault token has not been stored as the recurring configuration is disabled.',
+                [
+                    'pspReference' => $notification->getPspreference(),
+                    'merchantReference' => $notification->getMerchantReference()
+                ]
+            );
+        }
+
+        return $order;
+    }
+}

--- a/Helper/Webhook/RecurringTokenCreatedWebhookHandler.php
+++ b/Helper/Webhook/RecurringTokenCreatedWebhookHandler.php
@@ -48,8 +48,7 @@ class RecurringTokenCreatedWebhookHandler implements WebhookHandlerInterface
             );
             $extensionAttributes = $this->vaultHelper->getExtensionAttributes($order->getPayment());
             $extensionAttributes->setVaultPaymentToken($paymentToken);
-        }
-        else{
+        } else {
             $this->adyenLogger->addAdyenNotification(
                 'The vault token has not been stored as the recurring configuration is disabled.',
                 [

--- a/Helper/Webhook/RecurringTokenDisabledWebhookHandler.php
+++ b/Helper/Webhook/RecurringTokenDisabledWebhookHandler.php
@@ -33,6 +33,8 @@ class RecurringTokenDisabledWebhookHandler implements WebhookHandlerInterface
     ) { }
 
     /**
+     * Handle the recurring.token.disabled webhook.
+     *
      * @throws LocalizedException
      */
     public function handleWebhook(Order $order, Notification $notification, string $transitionState): Order

--- a/Helper/Webhook/WebhookHandlerFactory.php
+++ b/Helper/Webhook/WebhookHandlerFactory.php
@@ -40,6 +40,7 @@ class WebhookHandlerFactory
     private CaptureFailedWebhookHandler $captureFailedWebhookHandler;
     private RecurringTokenAlreadyExistingWebhookHandler $recurringTokenAlreadyExistingWebhookHandler;
     private RecurringTokenDisabledWebhookHandler $recurringTokenDisabledWebhookHandler;
+    private RecurringTokenCreatedWebhookHandler $recurringTokenCreatedWebhookHandler;
 
     public function __construct(
         AdyenLogger $adyenLogger,
@@ -63,7 +64,8 @@ class WebhookHandlerFactory
         NotificationOfChargebackWebhookHandler $notificationOfChargebackWebhookHandler,
         CaptureFailedWebhookHandler $captureFailedWebhookHandler,
         RecurringTokenAlreadyExistingWebhookHandler $recurringTokenAlreadyExistingWebhookHandler,
-        RecurringTokenDisabledWebhookHandler $recurringTokenDisabledWebhookHandler
+        RecurringTokenDisabledWebhookHandler $recurringTokenDisabledWebhookHandler,
+        RecurringTokenCreatedWebhookHandler $recurringTokenCreatedWebhookHandler
     ) {
         $this->adyenLogger = $adyenLogger;
         $this->authorisationWebhookHandler = $authorisationWebhookHandler;
@@ -87,6 +89,7 @@ class WebhookHandlerFactory
         $this->captureFailedWebhookHandler = $captureFailedWebhookHandler;
         $this->recurringTokenAlreadyExistingWebhookHandler = $recurringTokenAlreadyExistingWebhookHandler;
         $this->recurringTokenDisabledWebhookHandler = $recurringTokenDisabledWebhookHandler;
+        $this->recurringTokenCreatedWebhookHandler = $recurringTokenCreatedWebhookHandler;
     }
 
     /**
@@ -138,6 +141,8 @@ class WebhookHandlerFactory
                 return $this->recurringTokenAlreadyExistingWebhookHandler;
             case Notification::RECURRING_TOKEN_DISABLED:
                 return $this->recurringTokenDisabledWebhookHandler;
+            case Notification::RECURRING_TOKEN_CREATED:
+                return $this->recurringTokenCreatedWebhookHandler;
         }
 
         $exceptionMessage = sprintf(

--- a/Model/Notification.php
+++ b/Model/Notification.php
@@ -50,6 +50,7 @@ class Notification extends AbstractModel implements NotificationInterface
     const CHARGEBACK_REVERSED = "CHARGEBACK_REVERSED";
     const REQUEST_FOR_INFORMATION = "REQUEST_FOR_INFORMATION";
     const NOTIFICATION_OF_CHARGEBACK = "NOTIFICATION_OF_CHARGEBACK";
+    const RECURRING_TOKEN_CREATED = 'recurring.token.created';
     const RECURRING_TOKEN_DISABLED = 'recurring.token.disabled';
     const RECURRING_TOKEN_ALREADY_EXISTING  = "recurring.token.alreadyExisting";
     const STATE_ADYEN_AUTHORIZED = "adyen_authorized";

--- a/Test/Unit/Helper/Webhook/WebhookHandlerFactoryTest.php
+++ b/Test/Unit/Helper/Webhook/WebhookHandlerFactoryTest.php
@@ -18,6 +18,7 @@ use Adyen\Payment\Helper\Webhook\OrderOpenedWebhookHandler;
 use Adyen\Payment\Helper\Webhook\PendingWebhookHandler;
 use Adyen\Payment\Helper\Webhook\RecurringContractWebhookHandler;
 use Adyen\Payment\Helper\Webhook\RecurringTokenAlreadyExistingWebhookHandler;
+use Adyen\Payment\Helper\Webhook\RecurringTokenCreatedWebhookHandler;
 use Adyen\Payment\Helper\Webhook\RecurringTokenDisabledWebhookHandler;
 use Adyen\Payment\Helper\Webhook\RefundFailedWebhookHandler;
 use Adyen\Payment\Helper\Webhook\RefundWebhookHandler;
@@ -53,7 +54,8 @@ class WebhookHandlerFactoryTest extends AbstractAdyenTestCase
             [Notification::SECOND_CHARGEBACK, SecondChargebackWebhookHandler::class],
             [Notification::CAPTURE_FAILED, CaptureFailedWebhookHandler::class],
             [Notification::RECURRING_TOKEN_DISABLED, RecurringTokenDisabledWebhookHandler::class],
-            [Notification::RECURRING_TOKEN_ALREADY_EXISTING, RecurringTokenAlreadyExistingWebhookHandler::class]
+            [Notification::RECURRING_TOKEN_ALREADY_EXISTING, RecurringTokenAlreadyExistingWebhookHandler::class],
+            [Notification::RECURRING_TOKEN_CREATED, RecurringTokenCreatedWebhookHandler::class]
         ];
     }
 
@@ -85,6 +87,7 @@ class WebhookHandlerFactoryTest extends AbstractAdyenTestCase
         $recurringTokenDisabledWebhookHandler = $this->createMock(RecurringTokenDisabledWebhookHandler::class);
         $recurringTokenAlreadyExistingWebhookHandler =
             $this->createMock(RecurringTokenAlreadyExistingWebhookHandler::class);
+        $recurringTokenCreatedWebhookHandler = $this->createMock(RecurringTokenCreatedWebhookHandler::class);
 
         $factory = new WebhookHandlerFactory(
             $adyenLogger,
@@ -108,7 +111,8 @@ class WebhookHandlerFactoryTest extends AbstractAdyenTestCase
             $notificationOfChargebackWebhookHandler,
             $captureFailedWebhookHandler,
             $recurringTokenAlreadyExistingWebhookHandler,
-            $recurringTokenDisabledWebhookHandler
+            $recurringTokenDisabledWebhookHandler,
+            $recurringTokenCreatedWebhookHandler
         );
 
         $handler = $factory->create($notificationType);


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
This PR implements recurring.token.created webhook handler as a part of new token lifecycle events implementation.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- Processing `recurring.token.created` webhook