### PR TITLE
[ECP-9737-v9] Add DB index to adyen_payment_response table for merchant_reference column

### DIFF
--- a/etc/db_schema.xml
+++ b/etc/db_schema.xml
@@ -111,6 +111,9 @@
     <constraint xsi:type="primary" referenceId="PRIMARY">
       <column name="entity_id"/>
     </constraint>
+    <index referenceId="ADYEN_PAYMENT_RESPONSE_MERCHANT_REFERENCE" indexType="btree">
+      <column name="merchant_reference"/>
+    </index>
   </table>
   <table name="adyen_creditmemo" resource="default" engine="innodb" comment="Adyen Creditmemo">
     <column xsi:type="int" name="entity_id" padding="10" unsigned="true" nullable="false" identity="true" comment="Adyen Creditmemo Entity ID"/>

--- a/etc/db_schema_whitelist.json
+++ b/etc/db_schema_whitelist.json
@@ -109,6 +109,9 @@
         },
         "constraint": {
             "PRIMARY": true
+        },
+        "index": {
+            "ADYEN_PAYMENT_RESPONSE_MERCHANT_REFERENCE": true
         }
     }
 }


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Due to the missing index on `merchant_reference` column on `adyen_payment_response` table, queries take extremely long time while completing multishipping payments.

This PR adds a DB index to optimize the SQL queries. 

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- DB index