### PR TITLE
[ECP-9768] Fix failing order confirmation email submission in the case of missing brand_code

### DIFF
--- a/view/frontend/templates/info/adyen_giftcard.phtml
+++ b/view/frontend/templates/info/adyen_giftcard.phtml
@@ -30,7 +30,17 @@ use Adyen\Payment\Block\Info\Giftcard;
         <?php endforeach; ?>
     <?php else: ?>
         <dt class="title">
-            <?= $block->escapeHtml(sprintf("%s: %s", $_info->getMethodInstance()->getTitle(), ucwords($_info->getAdditionalInformation('brand_code')))); ?>
+            <?php
+            $brandCode = $_info->getAdditionalInformation('brand_code');
+
+            if (!empty($brandCode)) {
+                $html =  sprintf("%s: %s", $_info->getMethodInstance()->getTitle(), ucwords($brandCode));
+            } else {
+                $html = $_info->getMethodInstance()->getTitle();
+            }
+
+            echo $block->escapeHtml($html);
+            ?>
         </dt>
     <?php endif; ?>
 </dl>


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
The `brand_code` field is only obtained after processing the authorisation webhooks for giftcards only payments. However, this field is required in `frontend/info/adyen_giftcard.phtml` file if the partial payments are not processed, yet. 

This PR updates the `adyen_giftcard` info block template to check the existence of the `brand_code` field before consuming it while sending the order confirmation email.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- Order confirmation email sent before/after webhook processing.