### PR TITLE
[ECP-9768-v10] Add missing payment method title for giftcard payments

### DIFF
--- a/view/frontend/templates/info/adyen_giftcard.phtml
+++ b/view/frontend/templates/info/adyen_giftcard.phtml
@@ -29,5 +29,7 @@ use Adyen\Payment\Block\Info\Giftcard;
                 sprintf("%s: %s", $block->getMethod()->getTitle(), ucwords($payment->getPaymentMethod()))
             );
         ?>
+    <?php else: ?>
+        <?= $block->escapeHtml($block->getInfo()->getMethodInstance()->getTitle()); ?>
     <?php endif; ?>
 </dl>


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Payment method title does not show up until processing Authorisation webhook on giftcard only payments.

This PR adds the method instance title to the payment info block on the order confirmation email and order detail page of shopper account.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- Giftcard only payments order confirmation and order details page