### PR TITLE
[ECP-9778] 🗑️ Remove openinvoicedata.merchantData for Klara payment

### DIFF
--- a/Gateway/Request/CheckoutDataBuilder.php
+++ b/Gateway/Request/CheckoutDataBuilder.php
@@ -90,9 +90,7 @@ class CheckoutDataBuilder implements BuilderInterface
                 $requestBody['captureDelayHours'] = 0;
             }
 
-            if (str_contains($payment->getMethod(), PaymentMethods::KLARNA) ||
-                $payment->getMethod() === AdyenPayByLinkConfigProvider::CODE
-            ) {
+            if ($payment->getMethod() === AdyenPayByLinkConfigProvider::CODE) {
                 $otherDeliveryInformation = $this->getOtherDeliveryInformation($order);
                 if (isset($otherDeliveryInformation)) {
                     $requestBody['additionalData']['openinvoicedata.merchantData'] =


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**

The PR remove `openinvoicedata.merchantData` data in `additionalData` arg for Klarna payment.

As discussed here https://github.com/Adyen/adyen-magento2/issues/3038, `openinvoicedata.merchantData` is invalid.

Fixes  #3038
