### PR TITLE
[ECP-9785] Installments are incorrectly shown for tokenized cards when CVC is required

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/adyen-cc-vault-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-cc-vault-method.js
@@ -144,13 +144,12 @@ define([
         },
 
         renderCheckoutComponent: function () {
-            let self = this;
             if (!this.getClientKey()) {
                 return false;
             }
 
             let requireCvc = window.checkoutConfig.payment.adyenCc.requireCvc;
-            const allInstallments = self.getAllInstallments();
+            const allInstallments = this.getAllInstallments();
 
             const componentConfig = {
                 hideCVC: !requireCvc,
@@ -162,33 +161,29 @@ define([
             };
 
             // Always try to initialize installments based on the stored card type
-            const brand = self.getCardType();
-            const creditCardType = self.getCcCodeByAltCode(brand);
+            const brand = this.getCardType();
+            const creditCardType = this.getCcCodeByAltCode(brand);
             let numberOfInstallments = [];
+            const cardInstallments = allInstallments[creditCardType];
+            if (cardInstallments) {
+                const grandTotal = this.grandTotal();
+                const precision = quote.getPriceFormat().precision;
+                const currencyCode = quote.totals().quote_currency_code;
 
-            if (creditCardType) {
-                if (creditCardType in allInstallments) {
-                    const cardInstallments = allInstallments[creditCardType];
-                    const grandTotal = self.grandTotal();
-                    const precision = quote.getPriceFormat().precision;
-                    const currencyCode = quote.totals().quote_currency_code;
-
-                    numberOfInstallments = installmentsHelper.getInstallmentsWithPrices(
-                        cardInstallments, grandTotal,
-                        precision, currencyCode
-                    );
-                }
+                numberOfInstallments = installmentsHelper.getInstallmentsWithPrices(
+                    cardInstallments, grandTotal, precision, currencyCode
+                );
             }
 
-            self.installments(numberOfInstallments.length ? numberOfInstallments : 0);
+            this.installments(numberOfInstallments);
 
-            self.component = adyenCheckout.mountPaymentMethodComponent(
+            this.component = adyenCheckout.mountPaymentMethodComponent(
                 this.checkoutComponent,
                 'card',
                 componentConfig,
                 '#cvcContainer-' + this.getId()
             )
-            this.component = self.component
+            this.component = this.component
 
             return true
         },

--- a/view/frontend/web/template/payment/cc-vault-form.html
+++ b/view/frontend/web/template/payment/cc-vault-form.html
@@ -74,7 +74,7 @@
         <!-- ko if: (hasInstallments())-->
 
         <div class="field required"
-            data-bind="attr: {id: getCode() + '_installments_div'}, visible: installments() && Array.isArray(installments()) && installments().length > 0">
+            data-bind="attr: {id: getCode() + '_installments_div'}, visible: Array.isArray(installments()) && installments().length > 0">
             <label data-bind="attr: {for: getCode() + '_installments'}" class="label">
                 <span><!-- ko text: $t('Installments')--><!-- /ko --></span>
             </label>
@@ -83,14 +83,12 @@
                 <select class="select"
                         name="payment[number_of_installments]"
                         data-bind="attr: {id: getCode() + '_installments', 'data-container': getCode() + '-installments', 'data-validate': JSON.stringify({required:false})},
-
                                         enable: isActive($parents),
                                         options: installments,
                                         optionsValue: 'value',
                                         optionsText: 'key',
                                         optionsCaption: $t('Do not use Installments'),
-                                        value: installment"
-                        data-validate="{required:true}">
+                                        value: installment">
                 </select>
             </div>
         </div>


### PR DESCRIPTION

<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
The **onBrand ** event was not triggered when CVC was disabled and making it trigger manually resulted in inconsistency, so brand/type detection didn't run, causing stale or incorrect state, resulting in installments being shown incorrectly after navigating away and back, the component re-rendered correctly, hiding the installments — revealing a UI inconsistency.
With this PR we are explicitly evaluating and setting the installments observable using the stored card's brand
**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->

Fixes  <!-- #-prefixed github issue number -->
