### PR TITLE
[ECP-9781][ECP-9779] Refactor frontend data and /payments request related to the fundingSource

### DIFF
--- a/Observer/AdyenCcDataAssignObserver.php
+++ b/Observer/AdyenCcDataAssignObserver.php
@@ -97,11 +97,11 @@ class AdyenCcDataAssignObserver extends AbstractDataAssignObserver
         $data = $this->readDataArgument($observer);
         $paymentInfo = $this->readPaymentModelArgument($observer);
 
-        // Remove remaining brand_code information from the previous payment
-        $paymentInfo->unsAdditionalInformation('brand_code');
-
-        // Remove cc_type information from the previous payment
-        $paymentInfo->unsAdditionalInformation('cc_type');
+        // Remove the following information from the previous payment
+        $paymentInfo->unsAdditionalInformation(AdyenPaymentMethodDataAssignObserver::BRAND_CODE);
+        $paymentInfo->unsAdditionalInformation(self::CC_TYPE);
+        $paymentInfo->unsAdditionalInformation(self::NUMBER_OF_INSTALLMENTS);
+        $paymentInfo->unsAdditionalInformation(self::COMBO_CARD_TYPE);
 
         // Get additional data array
         $additionalData = $data->getData(PaymentInterface::KEY_ADDITIONAL_DATA);

--- a/Observer/AdyenPaymentMethodDataAssignObserver.php
+++ b/Observer/AdyenPaymentMethodDataAssignObserver.php
@@ -67,8 +67,10 @@ class AdyenPaymentMethodDataAssignObserver extends AbstractDataAssignObserver
         $data = $this->readDataArgument($observer);
         $paymentInfo = $this->readPaymentModelArgument($observer);
 
-        // Remove cc_type information from the previous payment
-        $paymentInfo->unsAdditionalInformation('cc_type');
+        // Remove the following information from the previous payment
+        $paymentInfo->unsAdditionalInformation(AdyenCcDataAssignObserver::CC_TYPE);
+        $paymentInfo->unsAdditionalInformation(AdyenCcDataAssignObserver::COMBO_CARD_TYPE);
+        $paymentInfo->unsAdditionalInformation(AdyenCcDataAssignObserver::NUMBER_OF_INSTALLMENTS);
 
         // Get additional data array
         $additionalData = $data->getData(PaymentInterface::KEY_ADDITIONAL_DATA);

--- a/Test/Unit/Gateway/Request/CheckoutDataBuilderTest.php
+++ b/Test/Unit/Gateway/Request/CheckoutDataBuilderTest.php
@@ -9,10 +9,13 @@ use Adyen\Payment\Helper\Data;
 use Adyen\Payment\Helper\PaymentMethods;
 use Adyen\Payment\Helper\StateData;
 use Adyen\Payment\Model\Config\Source\ThreeDSFlow;
+use Adyen\Payment\Model\Ui\AdyenCcConfigProvider;
+use Adyen\Payment\Observer\AdyenCcDataAssignObserver;
 use Adyen\Payment\Test\Unit\AbstractAdyenTestCase;
 use Magento\Payment\Gateway\Data\PaymentDataObject;
 use Magento\Payment\Model\MethodInterface;
 use Magento\Quote\Api\CartRepositoryInterface;
+use Magento\Quote\Api\Data\AddressInterface;
 use Magento\Sales\Model\Order;
 use Magento\Sales\Model\Order\Payment;
 use Magento\Catalog\Helper\Image;
@@ -87,5 +90,81 @@ class CheckoutDataBuilderTest extends AbstractAdyenTestCase
         $request = $this->checkoutDataBuilder->build($buildSubject);
 
         $this->assertArrayHasKey('nativeThreeDS', $request['body']['authenticationData']['threeDSRequestData']);
+    }
+
+    public function testComboCardsDataRemoveInstallments()
+    {
+        $storeId = 1;
+
+        $addressMock = $this->createMock(AddressInterface::class);
+        $addressMock->method('getCountryId')->willReturn('BR');
+
+        $orderMock = $this->createMock(Order::class);
+        $orderMock->method('getQuoteId')->willReturn(1);
+        $orderMock->method('getStoreId')->willReturn($storeId);
+        $orderMock->method('getBillingAddress')->willReturn($addressMock);
+
+        $paymentMethodInstanceMock = $this->createMock(MethodInterface::class);
+
+        $paymentMock = $this->createMock(Payment::class);
+        $paymentMock->method('getOrder')->willReturn($orderMock);
+        $paymentMock->method('getMethodInstance')->willReturn($paymentMethodInstanceMock);
+        $paymentMock->method('getMethod')->willReturn(AdyenCcConfigProvider::CODE);
+
+        $paymentMock->method('getAdditionalInformation')
+            ->willReturnMap([
+                [AdyenCcDataAssignObserver::NUMBER_OF_INSTALLMENTS, '4'],
+                [AdyenCcDataAssignObserver::COMBO_CARD_TYPE, PaymentMethods::FUNDING_SOURCE_DEBIT]
+            ]);
+
+        $buildSubject = [
+            'payment' => $this->createConfiguredMock(PaymentDataObject::class, [
+                'getPayment' => $paymentMock
+            ])
+        ];
+
+        $request = $this->checkoutDataBuilder->build($buildSubject);
+
+        $this->assertArrayHasKey('paymentMethod', $request['body']);
+        $this->assertArrayHasKey('fundingSource', $request['body']['paymentMethod']);
+        $this->assertArrayNotHasKey('installments', $request['body']);
+    }
+
+    public function testComboCardsDataWithInstallments()
+    {
+        $storeId = 1;
+
+        $addressMock = $this->createMock(AddressInterface::class);
+        $addressMock->method('getCountryId')->willReturn('BR');
+
+        $orderMock = $this->createMock(Order::class);
+        $orderMock->method('getQuoteId')->willReturn(1);
+        $orderMock->method('getStoreId')->willReturn($storeId);
+        $orderMock->method('getBillingAddress')->willReturn($addressMock);
+
+        $paymentMethodInstanceMock = $this->createMock(MethodInterface::class);
+
+        $paymentMock = $this->createMock(Payment::class);
+        $paymentMock->method('getOrder')->willReturn($orderMock);
+        $paymentMock->method('getMethodInstance')->willReturn($paymentMethodInstanceMock);
+        $paymentMock->method('getMethod')->willReturn(AdyenCcConfigProvider::CODE);
+
+        $paymentMock->method('getAdditionalInformation')
+            ->willReturnMap([
+                [AdyenCcDataAssignObserver::NUMBER_OF_INSTALLMENTS, '4'],
+                [AdyenCcDataAssignObserver::COMBO_CARD_TYPE, PaymentMethods::FUNDING_SOURCE_CREDIT]
+            ]);
+
+        $buildSubject = [
+            'payment' => $this->createConfiguredMock(PaymentDataObject::class, [
+                'getPayment' => $paymentMock
+            ])
+        ];
+
+        $request = $this->checkoutDataBuilder->build($buildSubject);
+
+        $this->assertArrayHasKey('paymentMethod', $request['body']);
+        $this->assertArrayHasKey('fundingSource', $request['body']['paymentMethod']);
+        $this->assertArrayHasKey('installments', $request['body']);
     }
 }

--- a/Test/Unit/Observer/AdyenCcDataAssignObserverTest.php
+++ b/Test/Unit/Observer/AdyenCcDataAssignObserverTest.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2025 Adyen N.V. (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\Payment\Test\Unit\Observer;
+
+use Adyen\Payment\Helper\StateData;
+use Adyen\Payment\Helper\Util\CheckoutStateDataValidator;
+use Adyen\Payment\Helper\Vault;
+use Adyen\Payment\Model\ResourceModel\StateData\Collection;
+use Adyen\Payment\Observer\AdyenCcDataAssignObserver;
+use Adyen\Payment\Test\Unit\AbstractAdyenTestCase;
+use Magento\Framework\Event;
+use Magento\Framework\Event\Observer;
+use Magento\Payment\Model\InfoInterface;
+use Magento\Quote\Model\Quote\Payment;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class AdyenCcDataAssignObserverTest extends AbstractAdyenTestCase
+{
+    protected ?AdyenCcDataAssignObserver $observer;
+    protected CheckoutStateDataValidator|MockObject $checkoutStateDataValidatorMock;
+    protected Collection|MockObject $stateDataCollectionMock;
+    protected StateData|MockObject $stateDataMock;
+    protected Vault|MockObject $vaultHelperMock;
+
+    protected function setUp(): void
+    {
+        $this->checkoutStateDataValidatorMock = $this->createMock(CheckoutStateDataValidator::class);
+        $this->stateDataCollectionMock = $this->createMock(Collection::class);
+        $this->stateDataMock = $this->createMock(StateData::class);
+        $this->vaultHelperMock = $this->createMock(Vault::class);
+
+        $this->observer = new AdyenCcDataAssignObserver(
+            $this->checkoutStateDataValidatorMock,
+            $this->stateDataCollectionMock,
+            $this->stateDataMock,
+            $this->vaultHelperMock
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        $this->observer = null;
+    }
+
+    public function testExecuteRemovePreviousData()
+    {
+        $paymentMock = $this->createMock(Payment::class);
+
+        $eventMock = $this->createMock(Event::class);
+        $eventMock->method('getDataByKey')->willReturn($paymentMock);
+
+        $observerMock = $this->createMock(Observer::class);
+        $observerMock->method('getEvent')->willReturn($eventMock);
+
+        $paymentMock->expects($this->atLeast(4))->method('unsAdditionalInformation');
+
+        $this->observer->execute($observerMock);
+    }
+}

--- a/Test/Unit/Observer/AdyenPaymentMethodDataAssignObserverTest.php
+++ b/Test/Unit/Observer/AdyenPaymentMethodDataAssignObserverTest.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2025 Adyen N.V. (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\Payment\Test\Unit\Observer;
+
+use Adyen\Payment\Helper\StateData;
+use Adyen\Payment\Helper\Util\CheckoutStateDataValidator;
+use Adyen\Payment\Helper\Vault;
+use Adyen\Payment\Model\ResourceModel\StateData\Collection;
+use Adyen\Payment\Observer\AdyenPaymentMethodDataAssignObserver;
+use Adyen\Payment\Test\Unit\AbstractAdyenTestCase;
+use Magento\Framework\Event;
+use Magento\Framework\Event\Observer;
+use Magento\Quote\Model\Quote\Payment;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class AdyenPaymentMethodDataAssignObserverTest extends AbstractAdyenTestCase
+{
+    protected ?AdyenPaymentMethodDataAssignObserver $observer;
+    protected CheckoutStateDataValidator|MockObject $checkoutStateDataValidatorMock;
+    protected Collection|MockObject $stateDataCollectionMock;
+    protected StateData|MockObject $stateDataMock;
+    protected Vault|MockObject $vaultHelperMock;
+
+    protected function setUp(): void
+    {
+        $this->checkoutStateDataValidatorMock = $this->createMock(CheckoutStateDataValidator::class);
+        $this->stateDataCollectionMock = $this->createMock(Collection::class);
+        $this->stateDataMock = $this->createMock(StateData::class);
+        $this->vaultHelperMock = $this->createMock(Vault::class);
+
+        $this->observer = new AdyenPaymentMethodDataAssignObserver(
+            $this->checkoutStateDataValidatorMock,
+            $this->stateDataCollectionMock,
+            $this->stateDataMock,
+            $this->vaultHelperMock
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        $this->observer = null;
+    }
+
+    public function testExecuteRemovePreviousData()
+    {
+        $paymentMock = $this->createMock(Payment::class);
+
+        $eventMock = $this->createMock(Event::class);
+        $eventMock->method('getDataByKey')->willReturn($paymentMock);
+
+        $observerMock = $this->createMock(Observer::class);
+        $observerMock->method('getEvent')->willReturn($eventMock);
+
+        $paymentMock->expects($this->atLeast(3))->method('unsAdditionalInformation');
+
+        $this->observer->execute($observerMock);
+    }
+}

--- a/view/frontend/web/js/view/payment/method-renderer/adyen-cc-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-cc-method.js
@@ -49,7 +49,7 @@ define(
             // need to duplicate as without the button will never activate on first time page view
             isPlaceOrderActionAllowed: ko.observable(
                 quote.billingAddress() != null),
-            comboCardOption: ko.observable('credit'),
+            comboCardOption: ko.observable(),
             checkoutComponent: null,
             cardComponent: null,
 
@@ -306,14 +306,26 @@ define(
                     additional_data: {
                         'stateData': {},
                         'guestEmail': quote.guestEmail,
-                        'cc_type': this.creditCardType(),
-                        'combo_card_type': this.comboCardOption(),
-                        //This is required by magento to store the token
-                        'is_active_payment_token_enabler' : this.storeCc,
-                        'number_of_installments': this.installment(),
                         'frontendType': 'default'
                     }
                 };
+
+                if (!!this.comboCardOption()) {
+                    data.additional_data.combo_card_type = this.comboCardOption();
+                }
+
+                if (!!this.creditCardType()) {
+                    data.additional_data.cc_type = this.creditCardType();
+                }
+
+                if (!!this.installment()) {
+                    data.additional_data.number_of_installments = this.installment();
+                }
+
+                // This is required by magento to store the token
+                if (this.storeCc) {
+                    data.additional_data.is_active_payment_token_enabler = true;
+                }
 
                 // Get state data only if the checkout component is ready,
                 if (this.checkoutComponent) {
@@ -494,7 +506,7 @@ define(
                     : false;
             },
             hasInstallments: function() {
-                return this.comboCardOption() === 'credit' &&
+                return this.comboCardOption() !== 'debit' &&
                     window.checkoutConfig.payment.adyenCc.hasInstallments;
             },
             getAllInstallments: function() {
@@ -507,8 +519,7 @@ define(
                 let countryId = quote.billingAddress().countryId;
                 let currencyCode = quote.totals().quote_currency_code;
                 let allowedCurrenciesByCountry = {
-                    'BR': 'BRL',
-                    'MX': 'MXN',
+                    'BR': 'BRL'
                 };
                 return allowedCurrenciesByCountry[countryId] &&
                     currencyCode === allowedCurrenciesByCountry[countryId];

--- a/view/frontend/web/js/view/payment/method-renderer/adyen-cc-vault-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-cc-vault-method.js
@@ -232,16 +232,21 @@ define([
             let stateData = self.component.data;
             stateData = JSON.stringify(stateData);
             window.sessionStorage.setItem('adyen.stateData', stateData);
-            return {
+            let data = {
                 method: this.code,
                 additional_data: {
                     stateData: stateData,
                     public_hash: this.publicHash,
-                    'number_of_installments': self.installment(),
                     frontendType: 'default',
                     'cc_type': self.getCcCodeByAltCode(self.getCardType())
                 },
             };
+
+            if (!!this.installment()) {
+                data.additional_data.number_of_installments = this.installment();
+            }
+
+            return data;
         },
 
         handleAdyenResult: function (responseJSON, orderId) {


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
This PR refactors the multiple parts of the plugin related to the fundingSource. So that,
1. `fundingSource` related `combo_card_type` dropdown will not be shown in the Mexico region
2. `fundingSource` and `number_of_installments` fields will only be added to the card payments requests
3. Data from previous payments in payment data assign observers are removed before setting the new data

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- Combo card payments w/wo installements in Brazil
- Card payments with installments in Mexico
- Failing card payment completed with Klarna on the second attempt

Fixes #3045