### PR TITLE
[ECP-9781][ECP-9779][V10] Refactor frontend data and /payments request related to the fundingSource

### DIFF
--- a/Gateway/Request/CheckoutDataBuilder.php
+++ b/Gateway/Request/CheckoutDataBuilder.php
@@ -15,6 +15,7 @@ use Adyen\Payment\Helper\Config;
 use Adyen\Payment\Helper\PaymentMethods;
 use Adyen\Payment\Helper\StateData;
 use Adyen\Payment\Model\Config\Source\ThreeDSFlow;
+use Adyen\Payment\Model\Ui\AdyenCcConfigProvider;
 use Adyen\Payment\Model\Ui\AdyenPayByLinkConfigProvider;
 use Adyen\Payment\Observer\AdyenCcDataAssignObserver;
 use Adyen\Payment\Observer\AdyenPaymentMethodDataAssignObserver;
@@ -122,24 +123,24 @@ class CheckoutDataBuilder implements BuilderInterface
         $numberOfInstallments = $payment->getAdditionalInformation(
             AdyenCcDataAssignObserver::NUMBER_OF_INSTALLMENTS
         ) ?: 0;
-        $comboCardType = $payment->getAdditionalInformation(AdyenCcDataAssignObserver::COMBO_CARD_TYPE);
         if ($numberOfInstallments > 0) {
             $requestBody['installments']['value'] = $numberOfInstallments;
         }
 
-        /*
-         * if the combo card type is debit then add the funding source
-         * and unset the installments & brand fields
-         */
-        if (!empty($comboCardType)) {
+        $comboCardType = $payment->getAdditionalInformation(AdyenCcDataAssignObserver::COMBO_CARD_TYPE);
+        if (!empty($comboCardType) && strcmp($payment->getMethod(), AdyenCcConfigProvider::CODE) === 0) {
             switch ($comboCardType) {
-                case 'debit':
-                    $requestBody['paymentMethod']['fundingSource'] = 'debit';
-                    unset($requestBody['paymentMethod']['brand']);
-                    unset($requestBody['installments']);
+                case PaymentMethods::FUNDING_SOURCE_DEBIT:
+                    // Remove installments if the fundingSource is debit and the country code is Brazil
+                    if (strcmp($order->getBillingAddress()->getCountryId(), 'BR') === 0) {
+                        unset($requestBody['paymentMethod']['brand']);
+                        unset($requestBody['installments']);
+                    }
+
+                    $requestBody['paymentMethod']['fundingSource'] = $comboCardType;
                     break;
-                case 'credit':
-                    $requestBody['paymentMethod']['fundingSource'] = 'credit';
+                case PaymentMethods::FUNDING_SOURCE_CREDIT:
+                    $requestBody['paymentMethod']['fundingSource'] = $comboCardType;
                     break;
             }
         }

--- a/Observer/AdyenCcDataAssignObserver.php
+++ b/Observer/AdyenCcDataAssignObserver.php
@@ -97,8 +97,10 @@ class AdyenCcDataAssignObserver extends AbstractDataAssignObserver
         $data = $this->readDataArgument($observer);
         $paymentInfo = $this->readPaymentModelArgument($observer);
 
-        // Remove cc_type information from the previous payment
-        $paymentInfo->unsAdditionalInformation('cc_type');
+        // Remove the following information from the previous payment
+        $paymentInfo->unsAdditionalInformation(self::CC_TYPE);
+        $paymentInfo->unsAdditionalInformation(self::NUMBER_OF_INSTALLMENTS);
+        $paymentInfo->unsAdditionalInformation(self::COMBO_CARD_TYPE);
 
         // Get additional data array
         $additionalData = $data->getData(PaymentInterface::KEY_ADDITIONAL_DATA);

--- a/Observer/AdyenPaymentMethodDataAssignObserver.php
+++ b/Observer/AdyenPaymentMethodDataAssignObserver.php
@@ -75,8 +75,10 @@ class AdyenPaymentMethodDataAssignObserver extends AbstractDataAssignObserver
         $data = $this->readDataArgument($observer);
         $paymentInfo = $this->readPaymentModelArgument($observer);
 
-        // Remove cc_type information from the previous payment
-        $paymentInfo->unsAdditionalInformation('cc_type');
+        // Remove the following information from the previous payment
+        $paymentInfo->unsAdditionalInformation(AdyenCcDataAssignObserver::CC_TYPE);
+        $paymentInfo->unsAdditionalInformation(AdyenCcDataAssignObserver::COMBO_CARD_TYPE);
+        $paymentInfo->unsAdditionalInformation(AdyenCcDataAssignObserver::NUMBER_OF_INSTALLMENTS);
 
         // Get additional data array
         $additionalData = $data->getData(PaymentInterface::KEY_ADDITIONAL_DATA);

--- a/view/frontend/web/js/view/payment/method-renderer/adyen-cc-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-cc-method.js
@@ -49,7 +49,7 @@ define(
             // need to duplicate as without the button will never activate on first time page view
             isPlaceOrderActionAllowed: ko.observable(
                 quote.billingAddress() != null),
-            comboCardOption: ko.observable('credit'),
+            comboCardOption: ko.observable(),
             checkoutComponent: null,
             cardComponent: null,
 
@@ -276,12 +276,18 @@ define(
                     additional_data: {
                         'stateData': {},
                         'guestEmail': quote.guestEmail,
-                        'combo_card_type': this.comboCardOption(),
-                        //This is required by magento to store the token
-                        'is_active_payment_token_enabler' : this.storeCc,
                         'frontendType': 'default'
                     }
                 };
+
+                if (!!this.comboCardOption()) {
+                    data.additional_data.combo_card_type = this.comboCardOption();
+                }
+
+                // This is required by magento to store the token
+                if (this.storeCc) {
+                    data.additional_data.is_active_payment_token_enabler = true;
+                }
 
                 // Get state data only if the checkout component is ready,
                 if (this.checkoutComponent) {
@@ -478,8 +484,7 @@ define(
                 let countryId = quote.billingAddress().countryId;
                 let currencyCode = quote.totals().quote_currency_code;
                 let allowedCurrenciesByCountry = {
-                    'BR': 'BRL',
-                    'MX': 'MXN',
+                    'BR': 'BRL'
                 };
                 return allowedCurrenciesByCountry[countryId] &&
                     currencyCode === allowedCurrenciesByCountry[countryId];


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
This PR refactors the multiple parts of the plugin related to the fundingSource. So that,
1. `fundingSource` related `combo_card_type` dropdown will not be shown in the Mexico region
2. `fundingSource` and `number_of_installments` fields will only be added to the card payments requests
3. Data from previous payments in payment data assign observers are removed before setting the new data

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- Combo card payments w/wo installements in Brazil
- Card payments with installments in Mexico
- Failing card payment completed with Klarna on the second attempt