### PR TITLE
[ECP-9813] Fix broken multishipping success page for non-Adyen payments

### DIFF
--- a/Block/Checkout/Multishipping/Success.php
+++ b/Block/Checkout/Multishipping/Success.php
@@ -174,7 +174,7 @@ class Success extends \Magento\Multishipping\Block\Checkout\Success
         return __('Payment Failed');
     }
 
-    public function isAdyenPayment(): ?bool
+    public function isAdyenPayment(): bool
     {
         return $this->isAdyenPayment;
     }


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
The plugin intercepts the success page to add Adyen related attributes to the success page. However, a missing default value declaration causes crash on the multishipping success page where the payment is completed with non-Adyen payment method as the property is expected to be set by Adyen.

This PR fixes the issue by adding default value to the `$isAdyenPayment` property as `false`.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- Check / Money order payment on multishipping
- Adyen Ideal payment on multishipping