### PR TITLE
[ECP-9818] Remove thrown exceptions in the case duplicate webhooks and return [accepted]

### DIFF
--- a/Model/Webhook/TokenWebhookAcceptor.php
+++ b/Model/Webhook/TokenWebhookAcceptor.php
@@ -23,7 +23,6 @@ use Adyen\Webhook\Exception\AuthenticationException;
 use Adyen\Webhook\Exception\InvalidDataException;
 use Adyen\Webhook\Receiver\NotificationReceiver;
 use Magento\Framework\App\Request\Http;
-use Magento\Framework\Exception\AlreadyExistsException;
 use Magento\Framework\Serialize\SerializerInterface;
 use Magento\Sales\Model\Order;
 
@@ -65,7 +64,6 @@ class TokenWebhookAcceptor implements WebhookAcceptorInterface
     ) { }
 
     /**
-     * @throws AlreadyExistsException
      * @throws InvalidDataException
      * @throws AuthenticationException
      */
@@ -149,7 +147,9 @@ class TokenWebhookAcceptor implements WebhookAcceptorInterface
     }
 
     /**
-     * @throws AlreadyExistsException
+     * @param array $payload
+     * @param string $isLive
+     * @return Notification
      */
     private function toNotification(array $payload, string $isLive): Notification
     {
@@ -178,14 +178,14 @@ class TokenWebhookAcceptor implements WebhookAcceptorInterface
         $notification->setCreatedAt($formattedDate);
         $notification->setUpdatedAt($formattedDate);
 
-        // 💡 Add duplicate check here
-        if ($notification->isDuplicate()) {
-            throw new AlreadyExistsException(__('Webhook already exists!'));
-        }
-
         return $notification;
     }
 
+    /**
+     * @param array $array
+     * @param array $path
+     * @return mixed
+     */
     private function getNestedValue(array $array, array $path): mixed
     {
         foreach ($path as $key) {

--- a/Test/Unit/Model/Webhook/StandardWebhookAcceptorTest.php
+++ b/Test/Unit/Model/Webhook/StandardWebhookAcceptorTest.php
@@ -256,35 +256,6 @@ class StandardWebhookAcceptorTest extends AbstractAdyenTestCase
     }
 
     /**
-     * Duplicate notification -> AlreadyExistsException.
-     */
-    public function testToNotificationThrowsAlreadyExistsExceptionOnDuplicate(): void
-    {
-        $this->expectException(AlreadyExistsException::class);
-
-        $payload = $this->getValidPayload();
-        $item = $payload['notificationItems'][0]['NotificationRequestItem'];
-
-        // Env OK & merchant OK
-        $this->orderHelperMock->method('getOrderByIncrementId')->willReturn(null);
-        $this->configHelperMock->method('isDemoMode')->with(null)->willReturn(true);
-        $this->notificationReceiverMock->method('validateNotificationMode')->with('false', true)->willReturn(true);
-        $this->webhookHelperMock->method('isMerchantAccountValid')->with('TestMerchant', $item, 'webhook', null)->willReturn(true);
-
-        // HMAC check disabled (no key) to keep test focused
-        $this->configHelperMock->method('getNotificationsHmacKey')->willReturn(null);
-        $this->hmacSignatureMock->expects($this->never())->method('isHmacSupportedEventCode');
-        $this->notificationReceiverMock->expects($this->never())->method('validateHmac');
-
-        // Duplicate
-        $notification = $this->createMock(Notification::class);
-        $notification->method('isDuplicate')->willReturn(true);
-        $this->notificationFactoryMock->method('create')->willReturn($notification);
-
-        $this->acceptor->getNotifications($payload);
-    }
-
-    /**
      * If HMAC key missing or event not supported, HMAC is not validated.
      * Here we simulate "event not supported".
      */

--- a/Test/Unit/Model/Webhook/TokenWebhookAcceptorTest.php
+++ b/Test/Unit/Model/Webhook/TokenWebhookAcceptorTest.php
@@ -266,22 +266,6 @@ class TokenWebhookAcceptorTest extends AbstractAdyenTestCase
         $this->acceptor->getNotifications($payload);
     }
 
-    public function testToNotificationThrowsExceptionOnDuplicate(): void
-    {
-        $this->expectException(AlreadyExistsException::class);
-
-        $payload = $this->getValidPayload();
-
-        $notification = $this->createMock(Notification::class);
-        $notification->method('isDuplicate')->willReturn(true);
-        $this->notificationFactoryMock->method('create')->willReturn($notification);
-
-        $this->configHelperMock->method('isDemoMode')->willReturn(true);
-        $this->webhookHelperMock->method('isMerchantAccountValid')->willReturn(true);
-
-        $this->acceptor->getNotifications($payload);
-    }
-
     public function testLogsAndContinuesWhenPaymentLoadThrows(): void
     {
         $payload = $this->getValidPayload();


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
The plugin throws an exception in the case of duplicate webhooks and returns `Webhook already exists!` error message to Adyen. However, this triggers the retry process for the given event and puts the webhook on the `Failed` state. This leads Adyen not sending webhooks as the webhook is not operational at that moment.

This PR removes this thrown exception and returns `[accepted]` response to Adyen. This webhook is silently ignored by the plugin without any attempt to store it in the database.


**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- Accepting standart webhook body
- Accepting token webhook body