### PR TITLE
[ECP-9807-v9] Implement error mapper and remove the thrown exceptions from the response validator

### DIFF
--- a/Test/Unit/Gateway/Validator/CheckoutResponseValidatorTest.php
+++ b/Test/Unit/Gateway/Validator/CheckoutResponseValidatorTest.php
@@ -10,6 +10,7 @@ use Magento\Framework\Exception\ValidatorException;
 use Magento\Payment\Gateway\Data\OrderAdapterInterface;
 use Magento\Payment\Gateway\Data\PaymentDataObject;
 use Magento\Payment\Gateway\Validator\Result;
+use Magento\Payment\Gateway\Validator\ResultInterface;
 use Magento\Payment\Gateway\Validator\ResultInterfaceFactory;
 use Magento\Sales\Model\Order\Payment;
 
@@ -46,8 +47,14 @@ class CheckoutResponseValidatorTest extends AbstractAdyenTestCase
             'response' => []
         ];
 
-        $this->expectException(ValidatorException::class);
-        $this->expectExceptionMessage("No responses were provided");
+        $resultMock = $this->createMock(ResultInterface::class);
+        $this->resultFactoryMock->expects($this->once())->method('create')
+            ->with([
+                'isValid' => false,
+                'failsDescription' => [],
+                'errorCodes' => ['authError_empty_response']
+            ])
+            ->willReturn($resultMock);
 
         $this->checkoutResponseValidator->validate($validationSubject);
     }
@@ -93,8 +100,14 @@ class CheckoutResponseValidatorTest extends AbstractAdyenTestCase
             ]
         ];
 
-        $this->expectException(ValidatorException::class);
-        $this->expectExceptionMessage("The payment is REFUSED.");
+        $resultMock = $this->createMock(ResultInterface::class);
+        $this->resultFactoryMock->expects($this->once())->method('create')
+            ->with([
+                'isValid' => false,
+                'failsDescription' => [],
+                'errorCodes' => ['authError_refused']
+            ])
+            ->willReturn($resultMock);
 
         $this->checkoutResponseValidator->validate($validationSubject);
     }
@@ -114,8 +127,14 @@ class CheckoutResponseValidatorTest extends AbstractAdyenTestCase
             ]
         ];
 
-        $this->expectException(ValidatorException::class);
-        $this->expectExceptionMessage("Error with payment method please select different payment method.");
+        $resultMock = $this->createMock(ResultInterface::class);
+        $this->resultFactoryMock->expects($this->once())->method('create')
+            ->with([
+                'isValid' => false,
+                'failsDescription' => [],
+                'errorCodes' => ['authError_generic']
+            ])
+            ->willReturn($resultMock);
 
         $this->checkoutResponseValidator->validate($validationSubject);
     }
@@ -132,13 +151,19 @@ class CheckoutResponseValidatorTest extends AbstractAdyenTestCase
                     'resultCode' => '',
                     'pspReference' => 'ABC12345',
                     'errorCode' => '124',
-                    'error' => 'No result code present in response.'
+                    'error' => 'Invalid phone number'
                 ]
             ]
         ];
 
-        $this->expectException(ValidatorException::class);
-        $this->expectExceptionMessage("No result code present in response.");
+        $resultMock = $this->createMock(ResultInterface::class);
+        $this->resultFactoryMock->expects($this->once())->method('create')
+            ->with([
+                'isValid' => false,
+                'failsDescription' => [],
+                'errorCodes' => ['124']
+            ])
+            ->willReturn($resultMock);
 
         $this->checkoutResponseValidator->validate($validationSubject);
     }
@@ -214,8 +239,14 @@ class CheckoutResponseValidatorTest extends AbstractAdyenTestCase
              ]
          ];
 
-         $this->expectException(ValidatorException::class);
-         $this->expectExceptionMessage("The payment is REFUSED.");
+         $resultMock = $this->createMock(ResultInterface::class);
+         $this->resultFactoryMock->expects($this->once())->method('create')
+             ->with([
+                 'isValid' => false,
+                 'failsDescription' => [],
+                 'errorCodes' => ['authError_refused']
+             ])
+            ->willReturn($resultMock);
 
          $this->checkoutResponseValidator->validate($validationSubject);
      }

--- a/etc/authorize_error_mapping.xml
+++ b/etc/authorize_error_mapping.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<mapping xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Payment:etc/error_mapping.xsd">
+    <message_list>
+        <message code="124" translate="true">Invalid phone number</message>
+        <message code="authError_refused" translate="true">The payment is REFUSED.</message>
+        <message code="authError_empty_response" translate="true">No responses were provided</message>
+        <message code="authError_generic" translate="true">Error with payment method, please select a different payment method.</message>
+    </message_list>
+</mapping>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -849,6 +849,7 @@
             <argument name="client" xsi:type="object">Adyen\Payment\Gateway\Http\Client\TransactionPayment</argument>
             <argument name="validator" xsi:type="object">CheckoutResponseValidator</argument>
             <argument name="handler" xsi:type="object">AdyenPaymentResponseHandlerComposite</argument>
+            <argument name="errorMessageMapper" xsi:type="object">AdyenAuthorizeErrorMessageMapper</argument>
         </arguments>
     </virtualType>
     <virtualType name="AdyenPaymentDonationsCommandPool" type="Magento\Payment\Gateway\Command\CommandPool">
@@ -889,6 +890,7 @@
             <argument name="client" xsi:type="object">Adyen\Payment\Gateway\Http\Client\TransactionPayment</argument>
             <argument name="validator" xsi:type="object">CheckoutResponseValidator</argument>
             <argument name="handler" xsi:type="object">AdyenPaymentVaultResponseHandlerComposite</argument>
+            <argument name="errorMessageMapper" xsi:type="object">AdyenAuthorizeErrorMessageMapper</argument>
         </arguments>
     </virtualType>
     <virtualType name="AdyenPaymentBoletoCommandPool" type="Magento\Payment\Gateway\Command\CommandPool">
@@ -941,6 +943,7 @@
             <argument name="client" xsi:type="object">Adyen\Payment\Gateway\Http\Client\TransactionPayment</argument>
             <argument name="validator" xsi:type="object">CheckoutResponseValidator</argument>
             <argument name="handler" xsi:type="object">AdyenPaymentResponseHandlerComposite</argument>
+            <argument name="errorMessageMapper" xsi:type="object">AdyenAuthorizeErrorMessageMapper</argument>
         </arguments>
     </virtualType>
     <virtualType name="AdyenPaymentMotoAuthorizeCommand" type="Magento\Payment\Gateway\Command\GatewayCommand">
@@ -950,6 +953,7 @@
             <argument name="client" xsi:type="object">Adyen\Payment\Gateway\Http\Client\TransactionPayment</argument>
             <argument name="validator" xsi:type="object">CheckoutResponseValidator</argument>
             <argument name="handler" xsi:type="object">AdyenPaymentResponseHandlerComposite</argument>
+            <argument name="errorMessageMapper" xsi:type="object">AdyenAuthorizeErrorMessageMapper</argument>
         </arguments>
     </virtualType>
     <virtualType name="AdyenPaymentOneclickAuthorizeCommand" type="Magento\Payment\Gateway\Command\GatewayCommand">
@@ -959,6 +963,7 @@
             <argument name="client" xsi:type="object">Adyen\Payment\Gateway\Http\Client\TransactionPayment</argument>
             <argument name="validator" xsi:type="object">CheckoutResponseValidator</argument>
             <argument name="handler" xsi:type="object">AdyenPaymentResponseHandlerComposite</argument>
+            <argument name="errorMessageMapper" xsi:type="object">AdyenAuthorizeErrorMessageMapper</argument>
         </arguments>
     </virtualType>
     <virtualType name="AdyenPaymentAuthorizeCommand" type="Magento\Payment\Gateway\Command\GatewayCommand">
@@ -968,6 +973,7 @@
             <argument name="client" xsi:type="object">Adyen\Payment\Gateway\Http\Client\TransactionPayment</argument>
             <argument name="validator" xsi:type="object">CheckoutResponseValidator</argument>
             <argument name="handler" xsi:type="object">AdyenPaymentResponseHandlerComposite</argument>
+            <argument name="errorMessageMapper" xsi:type="object">AdyenAuthorizeErrorMessageMapper</argument>
         </arguments>
     </virtualType>
     <virtualType name="AdyenPaymentGiftcardAuthorizeCommand" type="Magento\Payment\Gateway\Command\GatewayCommand">
@@ -977,6 +983,7 @@
             <argument name="client" xsi:type="object">Adyen\Payment\Gateway\Http\Client\TransactionPayment</argument>
             <argument name="validator" xsi:type="object">CheckoutResponseValidator</argument>
             <argument name="handler" xsi:type="object">AdyenPaymentResponseHandlerComposite</argument>
+            <argument name="errorMessageMapper" xsi:type="object">AdyenAuthorizeErrorMessageMapper</argument>
         </arguments>
     </virtualType>
     <virtualType name="AdyenPaymentBoletoAuthorizeCommand" type="Magento\Payment\Gateway\Command\GatewayCommand">
@@ -986,6 +993,7 @@
             <argument name="client" xsi:type="object">Adyen\Payment\Gateway\Http\Client\TransactionPayment</argument>
             <argument name="validator" xsi:type="object">CheckoutResponseValidator</argument>
             <argument name="handler" xsi:type="object">AdyenPaymentBoletoResponseHandlerComposite</argument>
+            <argument name="errorMessageMapper" xsi:type="object">AdyenAuthorizeErrorMessageMapper</argument>
         </arguments>
     </virtualType>
     <virtualType name="AdyenPaymentPosCloudAuthorizeCommand" type="Magento\Payment\Gateway\Command\GatewayCommand">
@@ -997,6 +1005,24 @@
             <argument name="handler" xsi:type="object">AdyenPaymentPosCloudResponseHandlerComposite</argument>
         </arguments>
     </virtualType>
+    <!-- Error code mapping for authorize command -->
+    <virtualType name="Adyen\Payment\Gateway\ErrorMapper\VirtualConfigReader" type="Magento\Payment\Gateway\ErrorMapper\VirtualConfigReader">
+        <arguments>
+            <argument name="fileName" xsi:type="string">authorize_error_mapping.xml</argument>
+        </arguments>
+    </virtualType>
+    <virtualType name="Adyen\Payment\Gateway\ErrorMapper\VirtualMappingData" type="Magento\Payment\Gateway\ErrorMapper\MappingData">
+        <arguments>
+            <argument name="reader" xsi:type="object">Adyen\Payment\Gateway\ErrorMapper\VirtualConfigReader</argument>
+            <argument name="cacheId" xsi:type="string">adyen_error_mapper</argument>
+        </arguments>
+    </virtualType>
+    <virtualType name="AdyenAuthorizeErrorMessageMapper" type="Magento\Payment\Gateway\ErrorMapper\ErrorMessageMapper">
+        <arguments>
+            <argument name="messageMapping" xsi:type="object">Adyen\Payment\Gateway\ErrorMapper\VirtualMappingData</argument>
+        </arguments>
+    </virtualType>
+    <!-- End of error code mapping for authorize command -->
     <!-- Capture command  -->
     <virtualType name="AdyenPaymentCaptureCommand" type="Magento\Payment\Gateway\Command\GatewayCommand">
         <arguments>


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
This PR removes the thrown exceptions from the `CheckoutResponseValidator` and the new implementation returns `ResultInterface` for any validation result.

Besides that, an error code mapper has been implemented. From now on, this new `authorize_error_mapper.xml` file will be used to indicate the result validation issues.

To see the error message on the GraphQL implementation, the [errors](https://github.com/magento/magento2/blob/59ff8f405c6a9672d70af8fe8d3419cde0bb4320/app/code/Magento/QuoteGraphQl/etc/schema.graphqls#L265) parameter can be used.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- Handling happy flow with card payments and Ideal
- Handling Refused card payments
- GraphQL refused card payments