### PR TITLE
[ECP-9802] Expect CANCEL_OR_REFUND webhook on the refund flow

### DIFF
--- a/Model/AdyenCreditmemoRepository.php
+++ b/Model/AdyenCreditmemoRepository.php
@@ -103,7 +103,7 @@ class AdyenCreditmemoRepository implements AdyenCreditmemoRepositoryInterface
      */
     public function getByRefundWebhook(NotificationInterface $notification): ?CreditmemoInterface
     {
-        if (in_array($notification->getPspreference(), [EventCodes::REFUND, EventCodes::CANCEL_OR_REFUND])) {
+        if (!in_array($notification->getEventCode(), [EventCodes::REFUND, EventCodes::CANCEL_OR_REFUND])) {
             throw new AdyenException(sprintf(
                 'REFUND or CANCEL_OR_REFUND webhook is expected to get the adyen_creditmemo, %s notification given.',
                 $notification->getEventCode()

--- a/Test/Unit/Model/AdyenCreditmemoRepositoryTest.php
+++ b/Test/Unit/Model/AdyenCreditmemoRepositoryTest.php
@@ -199,6 +199,12 @@ class AdyenCreditmemoRepositoryTest extends AbstractAdyenTestCase
                 'isResultValid' => true
             ],
             [
+                'eventCode' => 'CANCEL_OR_REFUND',
+                'isExpectedType' => true,
+                'creditmemoId' => "1",
+                'isResultValid' => true
+            ],
+            [
                 'eventCode' => 'CAPTURE',
                 'isExpectedType' => false,
                 'creditmemoId' => "1",


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
After rejecting a case requiring manual review, Adyen sends `CANCEL_OR_REFUND` webhook if the payment is captured already.

This PR allows processing `CANCEL_OR_REFUND` webhook in the refund flow.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- Refund after rejecting a case manually on immediate capture flow
