### PR TITLE
[ECP-9771-v9] Add applicationInfo to multiple gift card only payments

### DIFF
--- a/Gateway/Http/Client/TransactionPayment.php
+++ b/Gateway/Http/Client/TransactionPayment.php
@@ -123,6 +123,8 @@ class TransactionPayment implements ClientInterface
         $responseCollection['hasOnlyGiftCards'] = false;
 
         try {
+            $requestData['applicationInfo'] = $this->adyenHelper->buildApplicationInfo($client);
+
             list($requestData, $giftcardResponseCollection) = $this->processGiftcards($requestData, $service);
 
             /** @var array $responseCollection */
@@ -135,7 +137,6 @@ class TransactionPayment implements ClientInterface
                 }
             }
 
-            $requestData['applicationInfo'] = $this->adyenHelper->buildApplicationInfo($client);
             $paymentRequest = new PaymentRequest($requestData);
 
             $idempotencyKey = $this->idempotencyHelper->generateIdempotencyKey(

--- a/Helper/GiftcardPayment.php
+++ b/Helper/GiftcardPayment.php
@@ -19,6 +19,7 @@ use Magento\Framework\Pricing\Helper\Data as PricingData;
 class GiftcardPayment
 {
     const VALID_GIFTCARD_REQUEST_FIELDS = [
+        'applicationInfo',
         'merchantAccount',
         'shopperReference',
         'shopperEmail',


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
`applicationInfo` field was missing in the `/payments` request if the payment is completed with multiple gift card without another payment method.

This PR adds the missing `applicationInfo` field to these payments.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- Payment with multiple gift cards should have correct `applicationInfo` under Adyen Customer Area

Fixes #3032 