### PR TITLE
[ECP-9852] Fix broken adyen.notification queue processor

### DIFF
--- a/Api/Data/NotificationInterface.php
+++ b/Api/Data/NotificationInterface.php
@@ -234,9 +234,4 @@ interface NotificationInterface
      * @return NotificationInterface
      */
     public function setUpdatedAt(string $timestamp): NotificationInterface;
-
-    /**
-     * @return string|null
-     */
-    public function getFormattedAmountCurrency(): ?string;
 }


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Message queue processor is broken due to incorrect data structure. This PR removes the helper function from the interface and leaves it only in the concrete class.

The impact of this bug is that the webhooks published to the message queue (RabbitMQ or SQL) won't be consumed by he queue consumer.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- Webhook queue consumer