### PR TITLE
[ECP-8906] Vault Payment Methods are not filtered out according to PM response

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/adyen-cc-vault-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-cc-vault-method.js
@@ -99,7 +99,7 @@ define([
 
             this.adyenVaultPaymentMethod(isTokenAllowed);
 
-            if (isTokenAllowed) {
+            if (paymentMethodsResponse?.paymentMethodsResponse) {
                 fullScreenLoader.stopLoader();
             }
         },


### PR DESCRIPTION

**Description**
When a shopper saves a stored card and later try to pay with it from a country, for which a merchant disabled that payment method in Customer Area, they are still able to do so.
This PR aims to solve the issue by having the correct filters in the Frontend logic. Which means that the issue would still persist for the headless integration.