### PR TITLE
[ECP-9898] Add US debit methods to manual support capture list

### DIFF
--- a/Helper/Util/PaymentMethodUtil.php
+++ b/Helper/Util/PaymentMethodUtil.php
@@ -109,7 +109,12 @@ class PaymentMethodUtil
         'girocard',
         'girocard_applepay',
         'scalapay_3x',
-        'scalapay_4x'
+        'scalapay_4x',
+        'star',
+        'nyce',
+        'carnet',
+        'accel',
+        'pulse'
     ];
 
     /**


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
This PR updates the manual capture supported payment method list.

The following methods have been added.
- Pulse
- Star
- Accel
- NYCE
- Carnet