### PR TITLE
[ECP-9904] Stop setting cc_type in payment additional_information

### DIFF
--- a/Api/CleanupAdditionalInformationInterface.php
+++ b/Api/CleanupAdditionalInformationInterface.php
@@ -22,7 +22,6 @@ interface CleanupAdditionalInformationInterface
     const FIELD_DONATION_TOKEN = 'donationToken';
     const FIELD_FRONTEND_TYPE = 'frontendType';
     const FIELD_COMBO_CARD_TYPE = 'combo_card_type';
-    const FIELD_CC_TYPE = 'cc_type';
     const FIELD_RESULT_CODE = 'resultCode';
 
     const FIELDS_TO_BE_CLEANED_UP = [
@@ -31,7 +30,6 @@ interface CleanupAdditionalInformationInterface
         self::FIELD_DONATION_TOKEN,
         self::FIELD_FRONTEND_TYPE,
         self::FIELD_COMBO_CARD_TYPE,
-        self::FIELD_CC_TYPE,
         self::FIELD_RESULT_CODE,
         OrdersApi::DATA_KEY_CHECKOUT_API_ORDER
     ];

--- a/Gateway/Response/CheckoutPaymentsResponseHandler.php
+++ b/Gateway/Response/CheckoutPaymentsResponseHandler.php
@@ -67,19 +67,12 @@ class CheckoutPaymentsResponseHandler implements HandlerInterface
             $payment->setAdditionalInformation('pspReference', $response['pspReference']);
         }
 
-        $ccType = $payment->getAdditionalInformation('cc_type');
-
         $isWalletPaymentMethod = $this->paymentMethodsHelper->isWalletPaymentMethod($paymentMethodInstance);
         $isCardPaymentMethod = $payment->getMethod() === PaymentMethods::ADYEN_CC ||
             $payment->getMethod() === PaymentMethods::ADYEN_CC_VAULT;
 
-        if (!empty($response['additionalData']['paymentMethod']) &&
-            is_null($ccType) &&
-            ($isWalletPaymentMethod || $isCardPaymentMethod)
-        ) {
-            $ccType = $response['additionalData']['paymentMethod'];
-            $payment->setAdditionalInformation('cc_type', $ccType);
-            $payment->setCcType($ccType);
+        if (!empty($response['additionalData']['paymentMethod']) && ($isWalletPaymentMethod || $isCardPaymentMethod)) {
+            $payment->setCcType($response['additionalData']['paymentMethod']);
         }
 
         if (!empty($response['action'])) {

--- a/Gateway/Validator/InstallmentRequestValidator.php
+++ b/Gateway/Validator/InstallmentRequestValidator.php
@@ -69,7 +69,7 @@ class InstallmentRequestValidator extends AbstractValidator
             $installmentsAvailable = $this->configHelper->getAdyenCcConfigData('installments');
             $installmentSelected = $payment->getAdditionalInformation('number_of_installments');
 
-            $ccType = $this->adyenHelper->getMagentoCreditCartType($payment->getAdditionalInformation('cc_type'));
+            $ccType = $this->adyenHelper->getMagentoCreditCartType($payment->getCcType());
             if ($installmentsAvailable) {
                 $installments = $this->serializer->unserialize($installmentsAvailable);
             }

--- a/Helper/PaymentResponseHandler.php
+++ b/Helper/PaymentResponseHandler.php
@@ -180,15 +180,10 @@ class PaymentResponseHandler
             $payment->setAdditionalInformation('donationToken', $paymentsDetailsResponse['donationToken']);
         }
 
-        $ccType = $payment->getAdditionalInformation('cc_type');
-
         if (!empty($paymentsDetailsResponse['additionalData']['paymentMethod']) &&
-            is_null($ccType) &&
             ($isWalletPaymentMethod || $isCardPaymentMethod)
         ) {
-            $ccType = $paymentsDetailsResponse['additionalData']['paymentMethod'];
-            $payment->setAdditionalInformation('cc_type', $ccType);
-            $payment->setCcType($ccType);
+            $payment->setCcType($paymentsDetailsResponse['additionalData']['paymentMethod']);
         }
 
         // Handle recurring details

--- a/Observer/AdyenCcDataAssignObserver.php
+++ b/Observer/AdyenCcDataAssignObserver.php
@@ -100,7 +100,6 @@ class AdyenCcDataAssignObserver extends AbstractDataAssignObserver
         $paymentInfo = $this->readPaymentModelArgument($observer);
 
         // Remove the following information from the previous payment
-        $paymentInfo->unsAdditionalInformation(self::CC_TYPE);
         $paymentInfo->unsAdditionalInformation(self::NUMBER_OF_INSTALLMENTS);
         $paymentInfo->unsAdditionalInformation(self::COMBO_CARD_TYPE);
 
@@ -137,6 +136,11 @@ class AdyenCcDataAssignObserver extends AbstractDataAssignObserver
 
         unset($additionalData[self::STATE_DATA]);
 
+        // Set ccType if it exists on the request, otherwise reset to prevent being inherited from the previous attempt
+        $paymentInfo->setCcType($additionalData[self::CC_TYPE] ?? null);
+        // Card type is stored in payment's `cc_type`. Setting it up on `additional_information` is redundant.
+        unset($additionalData[self::CC_TYPE]);
+
         if (
             !empty($additionalData[self::RECURRING_PROCESSING_MODEL]) &&
             !$this->vaultHelper->validateRecurringProcessingModel($additionalData[self::RECURRING_PROCESSING_MODEL])
@@ -148,11 +152,6 @@ class AdyenCcDataAssignObserver extends AbstractDataAssignObserver
         // Set additional data in the payment
         foreach ($additionalData as $key => $data) {
             $paymentInfo->setAdditionalInformation($key, $data);
-        }
-
-        // set ccType
-        if (!empty($additionalData[self::CC_TYPE])) {
-            $paymentInfo->setCcType($additionalData[self::CC_TYPE]);
         }
     }
 }

--- a/Observer/AdyenMotoDataAssignObserver.php
+++ b/Observer/AdyenMotoDataAssignObserver.php
@@ -117,14 +117,14 @@ class AdyenMotoDataAssignObserver extends AbstractDataAssignObserver
 
         unset($additionalData[self::STATE_DATA]);
 
+        // Set ccType if it exists on the request, otherwise reset to prevent being inherited from the previous attempt
+        $paymentInfo->setCcType($additionalData[self::CC_TYPE] ?? null);
+        // Card type is stored in payment's `cc_type`. Setting it up on `additional_information` is redundant.
+        unset($additionalData[self::CC_TYPE]);
+
         // Set additional data in the payment
         foreach ($additionalData as $key => $data) {
             $paymentInfo->setAdditionalInformation($key, $data);
-        }
-
-        // set ccType
-        if (!empty($additionalData[self::CC_TYPE])) {
-            $paymentInfo->setCcType($additionalData[self::CC_TYPE]);
         }
 
         // set storeCc

--- a/Observer/AdyenPayByLinkDataAssignObserver.php
+++ b/Observer/AdyenPayByLinkDataAssignObserver.php
@@ -40,8 +40,8 @@ class AdyenPayByLinkDataAssignObserver extends AbstractDataAssignObserver
         $paymentInfo = $this->readPaymentModelArgument($observer);
 
         // Remove cc_type information from the previous payment
-        $paymentInfo->unsAdditionalInformation('cc_type');
-        
+        $paymentInfo->setCcType(null);
+
         // Get additional data array
         $additionalData = $data->getData(PaymentInterface::KEY_ADDITIONAL_DATA);
         if (!is_array($additionalData)) {

--- a/Observer/AdyenPaymentMethodDataAssignObserver.php
+++ b/Observer/AdyenPaymentMethodDataAssignObserver.php
@@ -78,7 +78,7 @@ class AdyenPaymentMethodDataAssignObserver extends AbstractDataAssignObserver
         $paymentInfo = $this->readPaymentModelArgument($observer);
 
         // Remove the following information from the previous payment
-        $paymentInfo->unsAdditionalInformation(AdyenCcDataAssignObserver::CC_TYPE);
+        $paymentInfo->setCcType(null);
         $paymentInfo->unsAdditionalInformation(AdyenCcDataAssignObserver::COMBO_CARD_TYPE);
         $paymentInfo->unsAdditionalInformation(AdyenCcDataAssignObserver::NUMBER_OF_INSTALLMENTS);
 

--- a/Observer/AdyenPosCloudDataAssignObserver.php
+++ b/Observer/AdyenPosCloudDataAssignObserver.php
@@ -39,7 +39,7 @@ class AdyenPosCloudDataAssignObserver extends AbstractDataAssignObserver
         $paymentInfo = $this->readPaymentModelArgument($observer);
 
         // Remove cc_type information from the previous payment
-        $paymentInfo->unsAdditionalInformation('cc_type');
+        $paymentInfo->setCcType(null);
 
         foreach ($this->additionalInformationList as $additionalInformationKey) {
             if (array_key_exists($additionalInformationKey, $additionalData)) {

--- a/Test/Unit/Gateway/Validator/InstallmentRequestValidatorTest.php
+++ b/Test/Unit/Gateway/Validator/InstallmentRequestValidatorTest.php
@@ -79,15 +79,15 @@ class InstallmentRequestValidatorTest extends AbstractAdyenTestCase
 
         $paymentMock = $this->createGeneratedMock(
             Payment::class,
-            ['getAdditionalInformation'],
+            ['getAdditionalInformation', 'getCcType'],
             ['getQuoteId']
         );
         $paymentMock->expects($this->once())->method('getQuoteId')->willReturn($quoteId);
         $paymentMock->expects($this->any())->method('getAdditionalInformation')
             ->willReturnMap([
-                ['number_of_installments', 5],
-                ['cc_type', 'visa']
+                ['number_of_installments', 5]
             ]);
+        $paymentMock->expects($this->any())->method('getCcType')->willReturn('visa');
 
         $quoteMock = $this->createMock(Quote::class);
 

--- a/Test/Unit/Observer/AdyenCcDataAssignObserverTest.php
+++ b/Test/Unit/Observer/AdyenCcDataAssignObserverTest.php
@@ -1,0 +1,346 @@
+<?php
+declare(strict_types=1);
+
+namespace Adyen\Payment\Test\Unit\Observer;
+
+use Adyen\Payment\Helper\StateData;
+use Adyen\Payment\Helper\Util\CheckoutStateDataValidator;
+use Adyen\Payment\Helper\Vault;
+use Adyen\Payment\Model\ResourceModel\StateData\Collection;
+use Adyen\Payment\Observer\AdyenCcDataAssignObserver;
+use Adyen\Payment\Test\Unit\AbstractAdyenTestCase;
+use Magento\Framework\DataObject;
+use Magento\Framework\Event;
+use Magento\Framework\Event\Observer;
+use Magento\Payment\Observer\AbstractDataAssignObserver;
+use Magento\Quote\Api\Data\PaymentInterface;
+use Magento\Quote\Model\Quote\Payment;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class AdyenCcDataAssignObserverTest extends AbstractAdyenTestCase
+{
+    private MockObject|CheckoutStateDataValidator $checkoutStateDataValidator;
+    private MockObject|Collection $stateDataCollection;
+    private MockObject|StateData $stateData;
+    private MockObject|Vault $vaultHelper;
+    private MockObject|Payment $paymentInfo;
+    private AdyenCcDataAssignObserver $observer;
+
+    protected function setUp(): void
+    {
+        $this->checkoutStateDataValidator = $this->createMock(CheckoutStateDataValidator::class);
+        $this->stateDataCollection = $this->createMock(Collection::class);
+        $this->stateData = $this->createMock(StateData::class);
+        $this->vaultHelper = $this->createMock(Vault::class);
+        $this->paymentInfo = $this->createGeneratedMock(
+            Payment::class,
+            ['unsAdditionalInformation', 'setAdditionalInformation', 'getData'],
+            ['setCcType']
+        );
+        $this->observer = new AdyenCcDataAssignObserver(
+            $this->checkoutStateDataValidator,
+            $this->stateDataCollection,
+            $this->stateData,
+            $this->vaultHelper
+        );
+    }
+
+    public function testExecuteWithNoAdditionalData()
+    {
+        $dataObject = new DataObject();
+        $observer = $this->getPreparedObserverWithMap([
+            [AbstractDataAssignObserver::DATA_CODE, $dataObject],
+            [AbstractDataAssignObserver::MODEL_CODE, $this->paymentInfo],
+        ]);
+
+        $this->paymentInfo->expects($this->exactly(2))->method('unsAdditionalInformation');
+        $this->stateData->expects($this->never())->method('setStateData');
+        $this->paymentInfo->expects($this->never())->method('setAdditionalInformation');
+
+        $this->observer->execute($observer);
+    }
+
+    public function testExecuteWithStateDataFromFrontend()
+    {
+        $stateDataJson = json_encode(['paymentMethod' => ['type' => 'scheme']]);
+        $additionalData = [
+            'stateData' => $stateDataJson,
+            'combo_card_type' => 'credit',
+            'number_of_installments' => '3',
+            'cc_type' => 'visa',
+        ];
+
+        $dataObject = new DataObject([
+            PaymentInterface::KEY_ADDITIONAL_DATA => $additionalData,
+        ]);
+
+        $observer = $this->getPreparedObserverWithMap([
+            [AbstractDataAssignObserver::DATA_CODE, $dataObject],
+            [AbstractDataAssignObserver::MODEL_CODE, $this->paymentInfo],
+        ]);
+
+        $this->paymentInfo->expects($this->exactly(2))->method('unsAdditionalInformation');
+
+        $this->paymentInfo->method('getData')
+            ->with('quote_id')
+            ->willReturn(123);
+
+        $validatedStateData = ['paymentMethod' => ['type' => 'scheme']];
+        $this->checkoutStateDataValidator->expects($this->once())
+            ->method('getValidatedAdditionalData')
+            ->willReturn($validatedStateData);
+
+        $this->stateData->expects($this->once())
+            ->method('setStateData')
+            ->with($validatedStateData, 123);
+
+        $this->paymentInfo->expects($this->once())
+            ->method('setCcType')
+            ->with('visa');
+
+        // combo_card_type + number_of_installments (stateData and cc_type are unset before this loop)
+        $this->paymentInfo->expects($this->exactly(2))->method('setAdditionalInformation');
+
+        $this->observer->execute($observer);
+    }
+
+    public function testExecuteWithStateDataFromDatabase()
+    {
+        $additionalData = [
+            'number_of_installments' => '3',
+        ];
+
+        $dataObject = new DataObject([
+            PaymentInterface::KEY_ADDITIONAL_DATA => $additionalData,
+        ]);
+
+        $observer = $this->getPreparedObserverWithMap([
+            [AbstractDataAssignObserver::DATA_CODE, $dataObject],
+            [AbstractDataAssignObserver::MODEL_CODE, $this->paymentInfo],
+        ]);
+
+        $this->paymentInfo->method('getData')
+            ->with('quote_id')
+            ->willReturn(456);
+
+        $dbStateData = ['paymentMethod' => ['type' => 'scheme']];
+        $this->stateDataCollection->expects($this->once())
+            ->method('getStateDataArrayWithQuoteId')
+            ->with(456)
+            ->willReturn($dbStateData);
+
+        $validatedStateData = ['paymentMethod' => ['type' => 'scheme']];
+        $this->checkoutStateDataValidator->expects($this->once())
+            ->method('getValidatedAdditionalData')
+            ->willReturn($validatedStateData);
+
+        $this->stateData->expects($this->once())
+            ->method('setStateData')
+            ->with($validatedStateData, 456);
+
+        $this->paymentInfo->expects($this->once())
+            ->method('setCcType')
+            ->with(null);
+
+        $this->observer->execute($observer);
+    }
+
+    public function testExecuteWithGiftcardStateDataSkipsValidation()
+    {
+        $stateDataJson = json_encode(['paymentMethod' => ['type' => 'giftcard']]);
+        $additionalData = [
+            'stateData' => $stateDataJson,
+        ];
+
+        $dataObject = new DataObject([
+            PaymentInterface::KEY_ADDITIONAL_DATA => $additionalData,
+        ]);
+
+        $observer = $this->getPreparedObserverWithMap([
+            [AbstractDataAssignObserver::DATA_CODE, $dataObject],
+            [AbstractDataAssignObserver::MODEL_CODE, $this->paymentInfo],
+        ]);
+
+        $this->paymentInfo->method('getData')
+            ->with('quote_id')
+            ->willReturn(1);
+
+        $this->checkoutStateDataValidator->expects($this->never())
+            ->method('getValidatedAdditionalData');
+
+        $this->stateData->expects($this->never())
+            ->method('setStateData');
+
+        $this->observer->execute($observer);
+    }
+
+    public function testExecuteWithStorePaymentMethod()
+    {
+        $stateDataJson = json_encode(['paymentMethod' => ['type' => 'scheme']]);
+        $additionalData = [
+            'stateData' => $stateDataJson,
+        ];
+
+        $dataObject = new DataObject([
+            PaymentInterface::KEY_ADDITIONAL_DATA => $additionalData,
+        ]);
+
+        $observer = $this->getPreparedObserverWithMap([
+            [AbstractDataAssignObserver::DATA_CODE, $dataObject],
+            [AbstractDataAssignObserver::MODEL_CODE, $this->paymentInfo],
+        ]);
+
+        $this->paymentInfo->method('getData')
+            ->with('quote_id')
+            ->willReturn(1);
+
+        $validatedStateData = [
+            'paymentMethod' => ['type' => 'scheme'],
+            'storePaymentMethod' => true,
+        ];
+        $this->checkoutStateDataValidator->expects($this->once())
+            ->method('getValidatedAdditionalData')
+            ->willReturn($validatedStateData);
+
+        $this->stateData->expects($this->once())->method('setStateData');
+
+        $this->paymentInfo->expects($this->once())
+            ->method('setAdditionalInformation')
+            ->with('store_cc', true);
+
+        $this->observer->execute($observer);
+    }
+
+    public function testExecuteWithValidRecurringProcessingModel()
+    {
+        $additionalData = [
+            'stateData' => json_encode(['paymentMethod' => ['type' => 'scheme']]),
+            'recurringProcessingModel' => 'Subscription',
+        ];
+
+        $dataObject = new DataObject([
+            PaymentInterface::KEY_ADDITIONAL_DATA => $additionalData,
+        ]);
+
+        $observer = $this->getPreparedObserverWithMap([
+            [AbstractDataAssignObserver::DATA_CODE, $dataObject],
+            [AbstractDataAssignObserver::MODEL_CODE, $this->paymentInfo],
+        ]);
+
+        $this->paymentInfo->method('getData')
+            ->with('quote_id')
+            ->willReturn(1);
+
+        $this->checkoutStateDataValidator->method('getValidatedAdditionalData')
+            ->willReturn(['paymentMethod' => ['type' => 'scheme']]);
+
+        $this->vaultHelper->expects($this->once())
+            ->method('validateRecurringProcessingModel')
+            ->with('Subscription')
+            ->willReturn(true);
+
+        // unsAdditionalInformation should NOT be called for recurringProcessingModel
+        $this->paymentInfo->expects($this->exactly(2))
+            ->method('unsAdditionalInformation');
+
+        // recurringProcessingModel should be set as additional information
+        $this->paymentInfo->expects($this->once())
+            ->method('setAdditionalInformation')
+            ->with('recurringProcessingModel', 'Subscription');
+
+        $this->observer->execute($observer);
+    }
+
+    public function testExecuteWithInvalidRecurringProcessingModel()
+    {
+        $additionalData = [
+            'stateData' => json_encode(['paymentMethod' => ['type' => 'scheme']]),
+            'recurringProcessingModel' => 'invalid',
+        ];
+
+        $dataObject = new DataObject([
+            PaymentInterface::KEY_ADDITIONAL_DATA => $additionalData,
+        ]);
+
+        $observer = $this->getPreparedObserverWithMap([
+            [AbstractDataAssignObserver::DATA_CODE, $dataObject],
+            [AbstractDataAssignObserver::MODEL_CODE, $this->paymentInfo],
+        ]);
+
+        $this->paymentInfo->method('getData')
+            ->with('quote_id')
+            ->willReturn(1);
+
+        $this->checkoutStateDataValidator->method('getValidatedAdditionalData')
+            ->willReturn(['paymentMethod' => ['type' => 'scheme']]);
+
+        $this->vaultHelper->expects($this->once())
+            ->method('validateRecurringProcessingModel')
+            ->with('invalid')
+            ->willReturn(false);
+
+        // 2 initial calls + 1 for recurringProcessingModel
+        $this->paymentInfo->expects($this->exactly(3))
+            ->method('unsAdditionalInformation');
+
+        // recurringProcessingModel should NOT be set as additional information
+        $this->paymentInfo->expects($this->never())
+            ->method('setAdditionalInformation');
+
+        $this->observer->execute($observer);
+    }
+
+    public function testExecuteCcTypeSetToNullWhenNotProvided()
+    {
+        $additionalData = [
+            'guestEmail' => 'test@example.com',
+        ];
+
+        $dataObject = new DataObject([
+            PaymentInterface::KEY_ADDITIONAL_DATA => $additionalData,
+        ]);
+
+        $observer = $this->getPreparedObserverWithMap([
+            [AbstractDataAssignObserver::DATA_CODE, $dataObject],
+            [AbstractDataAssignObserver::MODEL_CODE, $this->paymentInfo],
+        ]);
+
+        $this->paymentInfo->method('getData')
+            ->with('quote_id')
+            ->willReturn(1);
+
+        $this->stateDataCollection->method('getStateDataArrayWithQuoteId')
+            ->willReturn([]);
+
+        $this->paymentInfo->expects($this->once())
+            ->method('setCcType')
+            ->with(null);
+
+        $this->observer->execute($observer);
+    }
+
+    /**
+     * @param array $returnMap
+     * @return MockObject|Observer
+     */
+    private function getPreparedObserverWithMap(array $returnMap): Observer|MockObject
+    {
+        $observer = $this->getMockBuilder(Observer::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $event = $this->getMockBuilder(Event::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $observer->expects(static::atLeastOnce())
+            ->method('getEvent')
+            ->willReturn($event);
+        $event->expects(static::atLeastOnce())
+            ->method('getDataByKey')
+            ->willReturnMap(
+                $returnMap
+            );
+
+        return $observer;
+    }
+}

--- a/Test/Unit/Observer/AdyenMotoDataAssignObserverTest.php
+++ b/Test/Unit/Observer/AdyenMotoDataAssignObserverTest.php
@@ -1,0 +1,300 @@
+<?php
+declare(strict_types=1);
+
+namespace Adyen\Payment\Test\Unit\Observer;
+
+use Adyen\Payment\Helper\StateData;
+use Adyen\Payment\Helper\Util\CheckoutStateDataValidator;
+use Adyen\Payment\Model\ResourceModel\StateData\Collection;
+use Adyen\Payment\Observer\AdyenMotoDataAssignObserver;
+use Adyen\Payment\Test\Unit\AbstractAdyenTestCase;
+use Magento\Framework\DataObject;
+use Magento\Framework\Event;
+use Magento\Framework\Event\Observer;
+use Magento\Payment\Observer\AbstractDataAssignObserver;
+use Magento\Quote\Api\Data\PaymentInterface;
+use Magento\Quote\Model\Quote\Payment;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class AdyenMotoDataAssignObserverTest extends AbstractAdyenTestCase
+{
+    private MockObject|CheckoutStateDataValidator $checkoutStateDataValidator;
+    private MockObject|Collection $stateDataCollection;
+    private MockObject|StateData $stateData;
+    private MockObject|Payment $paymentInfo;
+    private AdyenMotoDataAssignObserver $observer;
+
+    protected function setUp(): void
+    {
+        $this->checkoutStateDataValidator = $this->createMock(CheckoutStateDataValidator::class);
+        $this->stateDataCollection = $this->createMock(Collection::class);
+        $this->stateData = $this->createMock(StateData::class);
+        $this->paymentInfo = $this->createGeneratedMock(
+            Payment::class,
+            ['unsAdditionalInformation', 'setAdditionalInformation', 'getData'],
+            ['setCcType']
+        );
+        $this->observer = new AdyenMotoDataAssignObserver(
+            $this->checkoutStateDataValidator,
+            $this->stateDataCollection,
+            $this->stateData
+        );
+    }
+
+    public function testExecuteWithNoAdditionalData()
+    {
+        $dataObject = new DataObject();
+        $observer = $this->getPreparedObserverWithMap([
+            [AbstractDataAssignObserver::DATA_CODE, $dataObject],
+            [AbstractDataAssignObserver::MODEL_CODE, $this->paymentInfo],
+        ]);
+
+        $this->paymentInfo->expects($this->once())->method('unsAdditionalInformation')
+            ->with('cc_type');
+        $this->stateData->expects($this->never())->method('setStateData');
+        $this->paymentInfo->expects($this->never())->method('setAdditionalInformation');
+
+        $this->observer->execute($observer);
+    }
+
+    public function testExecuteWithStateDataFromFrontend()
+    {
+        $stateDataJson = json_encode(['paymentMethod' => ['type' => 'scheme']]);
+        $additionalData = [
+            'stateData' => $stateDataJson,
+            'combo_card_type' => 'credit',
+            'number_of_installments' => '3',
+            'cc_type' => 'visa',
+        ];
+
+        $dataObject = new DataObject([
+            PaymentInterface::KEY_ADDITIONAL_DATA => $additionalData,
+        ]);
+
+        $observer = $this->getPreparedObserverWithMap([
+            [AbstractDataAssignObserver::DATA_CODE, $dataObject],
+            [AbstractDataAssignObserver::MODEL_CODE, $this->paymentInfo],
+        ]);
+
+        $this->paymentInfo->method('getData')
+            ->with('quote_id')
+            ->willReturn(123);
+
+        $validatedStateData = ['paymentMethod' => ['type' => 'scheme']];
+        $this->checkoutStateDataValidator->expects($this->once())
+            ->method('getValidatedAdditionalData')
+            ->willReturn($validatedStateData);
+
+        $this->stateData->expects($this->once())
+            ->method('setStateData')
+            ->with($validatedStateData, 123);
+
+        $this->paymentInfo->expects($this->once())
+            ->method('setCcType')
+            ->with('visa');
+
+        // combo_card_type + number_of_installments (stateData and cc_type are unset before the loop)
+        $this->paymentInfo->expects($this->exactly(2))->method('setAdditionalInformation');
+
+        $this->observer->execute($observer);
+    }
+
+    public function testExecuteWithEmptyStateData()
+    {
+        $additionalData = [
+            'number_of_installments' => '3',
+        ];
+
+        $dataObject = new DataObject([
+            PaymentInterface::KEY_ADDITIONAL_DATA => $additionalData,
+        ]);
+
+        $observer = $this->getPreparedObserverWithMap([
+            [AbstractDataAssignObserver::DATA_CODE, $dataObject],
+            [AbstractDataAssignObserver::MODEL_CODE, $this->paymentInfo],
+        ]);
+
+        $this->checkoutStateDataValidator->expects($this->never())
+            ->method('getValidatedAdditionalData');
+
+        $this->stateData->expects($this->never())
+            ->method('setStateData');
+
+        $this->paymentInfo->expects($this->once())
+            ->method('setCcType')
+            ->with(null);
+
+        // number_of_installments
+        $this->paymentInfo->expects($this->once())
+            ->method('setAdditionalInformation')
+            ->with('number_of_installments', '3');
+
+        $this->observer->execute($observer);
+    }
+
+    public function testExecuteCcTypeSetToNullWhenNotProvided()
+    {
+        $additionalData = [
+            'stateData' => json_encode(['paymentMethod' => ['type' => 'scheme']]),
+        ];
+
+        $dataObject = new DataObject([
+            PaymentInterface::KEY_ADDITIONAL_DATA => $additionalData,
+        ]);
+
+        $observer = $this->getPreparedObserverWithMap([
+            [AbstractDataAssignObserver::DATA_CODE, $dataObject],
+            [AbstractDataAssignObserver::MODEL_CODE, $this->paymentInfo],
+        ]);
+
+        $this->paymentInfo->method('getData')
+            ->with('quote_id')
+            ->willReturn(1);
+
+        $this->checkoutStateDataValidator->method('getValidatedAdditionalData')
+            ->willReturn(['paymentMethod' => ['type' => 'scheme']]);
+
+        $this->paymentInfo->expects($this->once())
+            ->method('setCcType')
+            ->with(null);
+
+        $this->observer->execute($observer);
+    }
+
+    public function testExecuteWithStorePaymentMethod()
+    {
+        $stateDataJson = json_encode(['paymentMethod' => ['type' => 'scheme']]);
+        $additionalData = [
+            'stateData' => $stateDataJson,
+        ];
+
+        $dataObject = new DataObject([
+            PaymentInterface::KEY_ADDITIONAL_DATA => $additionalData,
+        ]);
+
+        $observer = $this->getPreparedObserverWithMap([
+            [AbstractDataAssignObserver::DATA_CODE, $dataObject],
+            [AbstractDataAssignObserver::MODEL_CODE, $this->paymentInfo],
+        ]);
+
+        $this->paymentInfo->method('getData')
+            ->with('quote_id')
+            ->willReturn(1);
+
+        $validatedStateData = [
+            'paymentMethod' => ['type' => 'scheme'],
+            'storePaymentMethod' => true,
+        ];
+        $this->checkoutStateDataValidator->expects($this->once())
+            ->method('getValidatedAdditionalData')
+            ->willReturn($validatedStateData);
+
+        $this->stateData->expects($this->once())->method('setStateData');
+
+        $this->paymentInfo->expects($this->once())
+            ->method('setAdditionalInformation')
+            ->with('store_cc', true);
+
+        $this->observer->execute($observer);
+    }
+
+    public function testExecuteWithMotoMerchantAccount()
+    {
+        $stateDataJson = json_encode(['paymentMethod' => ['type' => 'scheme']]);
+        $additionalData = [
+            'stateData' => $stateDataJson,
+        ];
+
+        $dataObject = new DataObject([
+            PaymentInterface::KEY_ADDITIONAL_DATA => $additionalData,
+        ]);
+
+        $observer = $this->getPreparedObserverWithMap([
+            [AbstractDataAssignObserver::DATA_CODE, $dataObject],
+            [AbstractDataAssignObserver::MODEL_CODE, $this->paymentInfo],
+        ]);
+
+        $this->paymentInfo->method('getData')
+            ->with('quote_id')
+            ->willReturn(1);
+
+        $validatedStateData = [
+            'paymentMethod' => ['type' => 'scheme'],
+            'motoMerchantAccount' => 'TestMerchantMOTO',
+        ];
+        $this->checkoutStateDataValidator->expects($this->once())
+            ->method('getValidatedAdditionalData')
+            ->willReturn($validatedStateData);
+
+        $this->stateData->expects($this->once())->method('setStateData');
+
+        $this->paymentInfo->expects($this->once())
+            ->method('setAdditionalInformation')
+            ->with('motoMerchantAccount', 'TestMerchantMOTO');
+
+        $this->observer->execute($observer);
+    }
+
+    public function testExecuteWithStorePaymentMethodAndMotoMerchantAccount()
+    {
+        $stateDataJson = json_encode(['paymentMethod' => ['type' => 'scheme']]);
+        $additionalData = [
+            'stateData' => $stateDataJson,
+        ];
+
+        $dataObject = new DataObject([
+            PaymentInterface::KEY_ADDITIONAL_DATA => $additionalData,
+        ]);
+
+        $observer = $this->getPreparedObserverWithMap([
+            [AbstractDataAssignObserver::DATA_CODE, $dataObject],
+            [AbstractDataAssignObserver::MODEL_CODE, $this->paymentInfo],
+        ]);
+
+        $this->paymentInfo->method('getData')
+            ->with('quote_id')
+            ->willReturn(1);
+
+        $validatedStateData = [
+            'paymentMethod' => ['type' => 'scheme'],
+            'storePaymentMethod' => true,
+            'motoMerchantAccount' => 'TestMerchantMOTO',
+        ];
+        $this->checkoutStateDataValidator->expects($this->once())
+            ->method('getValidatedAdditionalData')
+            ->willReturn($validatedStateData);
+
+        $this->stateData->expects($this->once())->method('setStateData');
+
+        // store_cc + motoMerchantAccount
+        $this->paymentInfo->expects($this->exactly(2))
+            ->method('setAdditionalInformation');
+
+        $this->observer->execute($observer);
+    }
+
+    /**
+     * @param array $returnMap
+     * @return MockObject|Observer
+     */
+    private function getPreparedObserverWithMap(array $returnMap): Observer|MockObject
+    {
+        $observer = $this->getMockBuilder(Observer::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $event = $this->getMockBuilder(Event::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $observer->expects(static::atLeastOnce())
+            ->method('getEvent')
+            ->willReturn($event);
+        $event->expects(static::atLeastOnce())
+            ->method('getDataByKey')
+            ->willReturnMap(
+                $returnMap
+            );
+
+        return $observer;
+    }
+}

--- a/Test/Unit/Observer/AdyenPayByLinkDataAssignObserverTest.php
+++ b/Test/Unit/Observer/AdyenPayByLinkDataAssignObserverTest.php
@@ -1,0 +1,151 @@
+<?php
+declare(strict_types=1);
+
+namespace Adyen\Payment\Test\Unit\Observer;
+
+use Adyen\Payment\Observer\AdyenPayByLinkDataAssignObserver;
+use Adyen\Payment\Test\Unit\AbstractAdyenTestCase;
+use Magento\Framework\DataObject;
+use Magento\Framework\Event;
+use Magento\Framework\Event\Observer;
+use Magento\Payment\Observer\AbstractDataAssignObserver;
+use Magento\Quote\Api\Data\PaymentInterface;
+use Magento\Quote\Model\Quote\Payment;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class AdyenPayByLinkDataAssignObserverTest extends AbstractAdyenTestCase
+{
+    private MockObject|Payment $paymentInfo;
+    private AdyenPayByLinkDataAssignObserver $observer;
+
+    protected function setUp(): void
+    {
+        $this->paymentInfo = $this->createGeneratedMock(
+            Payment::class,
+            ['setAdditionalInformation'],
+            ['setCcType']
+        );
+        $this->observer = new AdyenPayByLinkDataAssignObserver();
+    }
+
+    public function testExecuteWithNoAdditionalData()
+    {
+        $dataObject = new DataObject();
+        $observer = $this->getPreparedObserverWithMap([
+            [AbstractDataAssignObserver::DATA_CODE, $dataObject],
+            [AbstractDataAssignObserver::MODEL_CODE, $this->paymentInfo],
+        ]);
+
+        $this->paymentInfo->expects($this->once())
+            ->method('setCcType')
+            ->with(null);
+
+        $this->paymentInfo->expects($this->never())
+            ->method('setAdditionalInformation');
+
+        $this->observer->execute($observer);
+    }
+
+    public function testExecuteWithExpiryDate()
+    {
+        $additionalData = [
+            'adyen_pbl_expires_at' => '2026-04-01',
+        ];
+
+        $dataObject = new DataObject([
+            PaymentInterface::KEY_ADDITIONAL_DATA => $additionalData,
+        ]);
+
+        $observer = $this->getPreparedObserverWithMap([
+            [AbstractDataAssignObserver::DATA_CODE, $dataObject],
+            [AbstractDataAssignObserver::MODEL_CODE, $this->paymentInfo],
+        ]);
+
+        $this->paymentInfo->expects($this->once())
+            ->method('setCcType')
+            ->with(null);
+
+        $this->paymentInfo->expects($this->once())
+            ->method('setAdditionalInformation')
+            ->with('adyen_pbl_expires_at', '2026-04-01');
+
+        $this->observer->execute($observer);
+    }
+
+    public function testExecuteIgnoresUnapprovedKeys()
+    {
+        $additionalData = [
+            'adyen_pbl_expires_at' => '2026-04-01',
+            'unknown_key' => 'should_be_ignored',
+        ];
+
+        $dataObject = new DataObject([
+            PaymentInterface::KEY_ADDITIONAL_DATA => $additionalData,
+        ]);
+
+        $observer = $this->getPreparedObserverWithMap([
+            [AbstractDataAssignObserver::DATA_CODE, $dataObject],
+            [AbstractDataAssignObserver::MODEL_CODE, $this->paymentInfo],
+        ]);
+
+        $this->paymentInfo->expects($this->once())
+            ->method('setCcType')
+            ->with(null);
+
+        $this->paymentInfo->expects($this->once())
+            ->method('setAdditionalInformation')
+            ->with('adyen_pbl_expires_at', '2026-04-01');
+
+        $this->observer->execute($observer);
+    }
+
+    public function testExecuteWithOnlyUnapprovedKeys()
+    {
+        $additionalData = [
+            'unknown_key' => 'should_be_ignored',
+        ];
+
+        $dataObject = new DataObject([
+            PaymentInterface::KEY_ADDITIONAL_DATA => $additionalData,
+        ]);
+
+        $observer = $this->getPreparedObserverWithMap([
+            [AbstractDataAssignObserver::DATA_CODE, $dataObject],
+            [AbstractDataAssignObserver::MODEL_CODE, $this->paymentInfo],
+        ]);
+
+        $this->paymentInfo->expects($this->once())
+            ->method('setCcType')
+            ->with(null);
+
+        $this->paymentInfo->expects($this->never())
+            ->method('setAdditionalInformation');
+
+        $this->observer->execute($observer);
+    }
+
+    /**
+     * @param array $returnMap
+     * @return MockObject|Observer
+     */
+    private function getPreparedObserverWithMap(array $returnMap): Observer|MockObject
+    {
+        $observer = $this->getMockBuilder(Observer::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $event = $this->getMockBuilder(Event::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $observer->expects(static::atLeastOnce())
+            ->method('getEvent')
+            ->willReturn($event);
+        $event->expects(static::atLeastOnce())
+            ->method('getDataByKey')
+            ->willReturnMap(
+                $returnMap
+            );
+
+        return $observer;
+    }
+}

--- a/Test/Unit/Observer/AdyenPaymentMethodDataAssignObserverTest.php
+++ b/Test/Unit/Observer/AdyenPaymentMethodDataAssignObserverTest.php
@@ -73,7 +73,7 @@ class AdyenPaymentMethodDataAssignObserverTest extends AbstractAdyenTestCase
             [AbstractDataAssignObserver::MODEL_CODE, $this->paymentInfo],
         ]);
 
-        $this->paymentInfo->expects($this->exactly(3))->method('unsAdditionalInformation');
+        $this->paymentInfo->expects($this->exactly(2))->method('unsAdditionalInformation');
 
         $this->paymentInfo->method('getData')
             ->with('quote_id')

--- a/Test/Unit/Observer/AdyenPosCloudDataAssignObserverTest.php
+++ b/Test/Unit/Observer/AdyenPosCloudDataAssignObserverTest.php
@@ -1,0 +1,175 @@
+<?php
+declare(strict_types=1);
+
+namespace Adyen\Payment\Test\Unit\Observer;
+
+use Adyen\Payment\Observer\AdyenPosCloudDataAssignObserver;
+use Adyen\Payment\Test\Unit\AbstractAdyenTestCase;
+use Magento\Framework\DataObject;
+use Magento\Framework\Event;
+use Magento\Framework\Event\Observer;
+use Magento\Payment\Observer\AbstractDataAssignObserver;
+use Magento\Quote\Api\Data\PaymentInterface;
+use Magento\Quote\Model\Quote\Payment;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class AdyenPosCloudDataAssignObserverTest extends AbstractAdyenTestCase
+{
+    private MockObject|Payment $paymentInfo;
+    private AdyenPosCloudDataAssignObserver $observer;
+
+    protected function setUp(): void
+    {
+        $this->paymentInfo = $this->createGeneratedMock(
+            Payment::class,
+            ['setAdditionalInformation'],
+            ['setCcType']
+        );
+        $this->observer = new AdyenPosCloudDataAssignObserver();
+    }
+
+    public function testExecuteWithNoAdditionalData()
+    {
+        $dataObject = new DataObject();
+        $observer = $this->getPreparedObserverWithMap([
+            [AbstractDataAssignObserver::DATA_CODE, $dataObject],
+            [AbstractDataAssignObserver::MODEL_CODE, $this->paymentInfo],
+        ]);
+
+        $this->paymentInfo->expects($this->never())->method('setCcType');
+        $this->paymentInfo->expects($this->never())->method('setAdditionalInformation');
+
+        $this->observer->execute($observer);
+    }
+
+    public function testExecuteWithAllAdditionalData()
+    {
+        $additionalData = [
+            'terminal_id' => 'P400Plus-123456789',
+            'number_of_installments' => '3',
+            'funding_source' => 'credit',
+        ];
+
+        $dataObject = new DataObject([
+            PaymentInterface::KEY_ADDITIONAL_DATA => $additionalData,
+        ]);
+
+        $observer = $this->getPreparedObserverWithMap([
+            [AbstractDataAssignObserver::DATA_CODE, $dataObject],
+            [AbstractDataAssignObserver::MODEL_CODE, $this->paymentInfo],
+        ]);
+
+        $this->paymentInfo->expects($this->once())
+            ->method('setCcType')
+            ->with(null);
+
+        $this->paymentInfo->expects($this->exactly(3))
+            ->method('setAdditionalInformation');
+
+        $this->observer->execute($observer);
+    }
+
+    public function testExecuteWithPartialAdditionalData()
+    {
+        $additionalData = [
+            'terminal_id' => 'P400Plus-123456789',
+        ];
+
+        $dataObject = new DataObject([
+            PaymentInterface::KEY_ADDITIONAL_DATA => $additionalData,
+        ]);
+
+        $observer = $this->getPreparedObserverWithMap([
+            [AbstractDataAssignObserver::DATA_CODE, $dataObject],
+            [AbstractDataAssignObserver::MODEL_CODE, $this->paymentInfo],
+        ]);
+
+        $this->paymentInfo->expects($this->once())
+            ->method('setCcType')
+            ->with(null);
+
+        $this->paymentInfo->expects($this->once())
+            ->method('setAdditionalInformation')
+            ->with('terminal_id', 'P400Plus-123456789');
+
+        $this->observer->execute($observer);
+    }
+
+    public function testExecuteIgnoresUnapprovedKeys()
+    {
+        $additionalData = [
+            'terminal_id' => 'P400Plus-123456789',
+            'unknown_key' => 'should_be_ignored',
+        ];
+
+        $dataObject = new DataObject([
+            PaymentInterface::KEY_ADDITIONAL_DATA => $additionalData,
+        ]);
+
+        $observer = $this->getPreparedObserverWithMap([
+            [AbstractDataAssignObserver::DATA_CODE, $dataObject],
+            [AbstractDataAssignObserver::MODEL_CODE, $this->paymentInfo],
+        ]);
+
+        $this->paymentInfo->expects($this->once())
+            ->method('setCcType')
+            ->with(null);
+
+        // Only terminal_id should be set, unknown_key should be ignored
+        $this->paymentInfo->expects($this->once())
+            ->method('setAdditionalInformation')
+            ->with('terminal_id', 'P400Plus-123456789');
+
+        $this->observer->execute($observer);
+    }
+
+    public function testExecuteWithEmptyApprovedKeys()
+    {
+        $additionalData = [
+            'unknown_key' => 'should_be_ignored',
+        ];
+
+        $dataObject = new DataObject([
+            PaymentInterface::KEY_ADDITIONAL_DATA => $additionalData,
+        ]);
+
+        $observer = $this->getPreparedObserverWithMap([
+            [AbstractDataAssignObserver::DATA_CODE, $dataObject],
+            [AbstractDataAssignObserver::MODEL_CODE, $this->paymentInfo],
+        ]);
+
+        $this->paymentInfo->expects($this->once())
+            ->method('setCcType')
+            ->with(null);
+
+        $this->paymentInfo->expects($this->never())
+            ->method('setAdditionalInformation');
+
+        $this->observer->execute($observer);
+    }
+
+    /**
+     * @param array $returnMap
+     * @return MockObject|Observer
+     */
+    private function getPreparedObserverWithMap(array $returnMap): Observer|MockObject
+    {
+        $observer = $this->getMockBuilder(Observer::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $event = $this->getMockBuilder(Event::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $observer->expects(static::atLeastOnce())
+            ->method('getEvent')
+            ->willReturn($event);
+        $event->expects(static::atLeastOnce())
+            ->method('getDataByKey')
+            ->willReturnMap(
+                $returnMap
+            );
+
+        return $observer;
+    }
+}


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
With this refactoring, the plugin now sets card type only on `cc_type` field of `sales_order_payment` table but not on the `additional_information`.