### PR TITLE
[ECP-9925-v9] Display error message when 3DS2 challenge is cancelled

### DIFF
--- a/Model/Api/AdyenPaymentsDetails.php
+++ b/Model/Api/AdyenPaymentsDetails.php
@@ -20,6 +20,7 @@ use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\Exception\ValidatorException;
 use Magento\Sales\Api\OrderRepositoryInterface;
+use Magento\Framework\Message\ManagerInterface;
 
 class AdyenPaymentsDetails implements AdyenPaymentsDetailsInterface
 {
@@ -27,17 +28,20 @@ class AdyenPaymentsDetails implements AdyenPaymentsDetailsInterface
     private PaymentsDetails $paymentsDetails;
     private PaymentResponseHandler $paymentResponseHandler;
     private Session $checkoutSession;
+    private ManagerInterface $messageManager;
 
     public function __construct(
         OrderRepositoryInterface $orderRepository,
         PaymentsDetails $paymentsDetails,
         PaymentResponseHandler $paymentResponseHandler,
-        Session $checkoutSession
+        Session $checkoutSession,
+        ManagerInterface $messageManager
     ) {
         $this->orderRepository = $orderRepository;
         $this->paymentsDetails = $paymentsDetails;
         $this->paymentResponseHandler = $paymentResponseHandler;
         $this->checkoutSession = $checkoutSession;
+        $this->messageManager = $messageManager;
     }
 
     /**
@@ -68,6 +72,7 @@ class AdyenPaymentsDetails implements AdyenPaymentsDetailsInterface
         // Handle response
         if (!$this->paymentResponseHandler->handlePaymentsDetailsResponse($response, $order)) {
             $this->checkoutSession->restoreQuote();
+            $this->messageManager->addErrorMessage(__('The payment is REFUSED.'));
             throw new ValidatorException(__('The payment is REFUSED.'));
         }
 

--- a/Test/Unit/Model/Api/AdyenPaymentsDetailsTest.php
+++ b/Test/Unit/Model/Api/AdyenPaymentsDetailsTest.php
@@ -19,6 +19,7 @@ use Magento\Framework\Exception\ValidatorException;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\Sales\Api\Data\OrderInterface;
 use Magento\Sales\Api\OrderRepositoryInterface;
+use Magento\Framework\Message\ManagerInterface;
 
 class AdyenPaymentsDetailsTest extends AbstractAdyenTestCase
 {
@@ -26,6 +27,7 @@ class AdyenPaymentsDetailsTest extends AbstractAdyenTestCase
     private $orderRepositoryMock;
     private $paymentsDetailsHelperMock;
     private $paymentResponseHandlerHelperMock;
+    private $messageManagerMock;
 
     protected function setUp(): void
     {
@@ -35,12 +37,14 @@ class AdyenPaymentsDetailsTest extends AbstractAdyenTestCase
             PaymentResponseHandler::class,
             ['handlePaymentsDetailsResponse']
         );
+        $this->messageManagerMock = $this->createMock(ManagerInterface::class);
 
         $objectManager = new ObjectManager($this);
         $this->adyenPaymentsDetails = $objectManager->getObject(AdyenPaymentsDetails::class, [
             'orderRepository' => $this->orderRepositoryMock,
             'paymentsDetails' => $this->paymentsDetailsHelperMock,
-            'paymentResponseHandler' => $this->paymentResponseHandlerHelperMock
+            'paymentResponseHandler' => $this->paymentResponseHandlerHelperMock,
+            'messageManager' => $this->messageManagerMock
         ]);
     }
 
@@ -98,6 +102,10 @@ class AdyenPaymentsDetailsTest extends AbstractAdyenTestCase
         $this->paymentResponseHandlerHelperMock
             ->method('handlePaymentsDetailsResponse')
             ->willReturn(false);
+            
+        $this->messageManagerMock
+            ->expects($this->once())
+            ->method('addErrorMessage');
 
         $this->adyenPaymentsDetails->initiate($payload, $orderId);
     }


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
Previously, if a shopper cancelled the 3DS2 challenge during a Google Pay Express checkout, the window closed silently without providing failure feedback on the screen.
This PR fixes the issue by utilizing Magento's core message manager to persist the error state. Now, when a Google Pay Express payment is refused or cancelled, an error message is displayed.
