### PR TITLE
[ECP-9940] Fix missing countryId for virtual product payments

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/adyen-cc-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-cc-method.js
@@ -149,18 +149,28 @@ define(
             },
             // Build AdyenCheckout library and creates the payment method component
             createCheckoutComponent: async function () {
-                if (!this.checkoutComponent) {
-                    const paymentMethodsResponse = adyenPaymentService.getPaymentMethods();
-                    const countryCode = quote.billingAddress().countryId;
+                const billingAddressObservable = quote.billingAddress;
+                let self = this;
 
-                    this.checkoutComponent = await adyenCheckout.buildCheckoutComponent(
-                        paymentMethodsResponse(),
-                        countryCode,
-                        this.handleOnAdditionalDetails.bind(this)
-                    )
+                if (billingAddressObservable() && billingAddressObservable().countryId) {
+                    if (!this.checkoutComponent) {
+                        const paymentMethodsResponse = adyenPaymentService.getPaymentMethods();
+
+                        this.checkoutComponent = await adyenCheckout.buildCheckoutComponent(
+                            paymentMethodsResponse(),
+                            billingAddressObservable().countryId,
+                            this.handleOnAdditionalDetails.bind(this)
+                        )
+                    }
+
+                    this.renderCCPaymentMethod();
+                } else {
+                    billingAddressObservable.subscribe(function (updatedBillingAddress) {
+                        if (updatedBillingAddress && updatedBillingAddress.countryId) {
+                            self.createCheckoutComponent();
+                        }
+                    });
                 }
-
-                this.renderCCPaymentMethod();
             },
             /**
              * Returns true if card details can be stored

--- a/view/frontend/web/js/view/payment/method-renderer/adyen-cc-vault-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-cc-vault-method.js
@@ -130,18 +130,28 @@ define([
 
         // Build AdyenCheckout library and creates the payment method component
         createCheckoutComponent: async function() {
-            if (!this.checkoutComponent) {
-                const paymentMethodsResponse = adyenPaymentService.getPaymentMethods();
-                const countryCode = quote.billingAddress().countryId;
+            const billingAddressObservable = quote.billingAddress;
+            let self = this;
 
-                this.checkoutComponent = await adyenCheckout.buildCheckoutComponent(
-                    paymentMethodsResponse(),
-                    countryCode,
-                    this.handleOnAdditionalDetails.bind(this)
-                );
+            if (billingAddressObservable() && billingAddressObservable().countryId) {
+                if (!this.checkoutComponent) {
+                    const paymentMethodsResponse = adyenPaymentService.getPaymentMethods();
+
+                    this.checkoutComponent = await adyenCheckout.buildCheckoutComponent(
+                        paymentMethodsResponse(),
+                        billingAddressObservable().countryId,
+                        this.handleOnAdditionalDetails.bind(this)
+                    );
+                }
+
+                this.renderCheckoutComponent();
+            } else {
+                billingAddressObservable.subscribe(function (updatedBillingAddress) {
+                    if (updatedBillingAddress && updatedBillingAddress.countryId) {
+                        self.createCheckoutComponent();
+                    }
+                });
             }
-
-            this.renderCheckoutComponent();
         },
 
         handleOnAdditionalDetails: function (result) {

--- a/view/frontend/web/js/view/payment/method-renderer/adyen-giftcard-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-giftcard-method.js
@@ -55,6 +55,7 @@ define(
             selectedGiftcardPaymentMethod: ko.observable(null),
             giftcardTitle: ko.observable(null),
             icon: ko.observable(window.checkoutConfig.payment.adyen.giftcard.icon),
+            billingAddressAvailable: ko.observable(false),
 
             initialize: async function () {
                 this._super();
@@ -74,6 +75,8 @@ define(
                     this.fetchGiftcardPaymentMethods(paymentMethodsObserver());
                     this.fetchRedeemedGiftcards();
                 }
+
+                this.billingAddressAvailable(quote.billingAddress() !== null);
             },
 
             addNewGiftcard: function () {

--- a/view/frontend/web/js/view/payment/method-renderer/adyen-pm-method.js
+++ b/view/frontend/web/js/view/payment/method-renderer/adyen-pm-method.js
@@ -80,6 +80,7 @@ define(
 
                 this._lastGrandTotal = undefined;
 
+                // This event is triggered when the total changes or billing address is added (virtual products)
                 quote.totals.subscribe(function (totals) {
                     if (!totals) {
                         return;
@@ -177,20 +178,24 @@ define(
 
             // Build AdyenCheckout library and creates the payment method component
             createCheckoutComponent: async function(forceCreate = false) {
-                if (!this.checkoutComponent || forceCreate) {
-                    const paymentMethodsResponse = adyenPaymentService.getPaymentMethods();
-                    const countryCode = quote.billingAddress().countryId;
+                const billingAddressObservable = quote.billingAddress;
+                let self = this;
 
-                    this.checkoutComponent = await adyenCheckout.buildCheckoutComponent(
-                        paymentMethodsResponse(),
-                        countryCode,
-                        this.handleOnAdditionalDetails.bind(this),
-                        this.handleOnCancel.bind(this),
-                        this.handleOnSubmit.bind(this),
-                        this.handleOnError.bind(this)
-                    );
+                if (billingAddressObservable() && billingAddressObservable().countryId) {
+                    if (!this.checkoutComponent || forceCreate) {
+                        const paymentMethodsResponse = adyenPaymentService.getPaymentMethods();
 
-                    this.renderCheckoutComponent();
+                        this.checkoutComponent = await adyenCheckout.buildCheckoutComponent(
+                            paymentMethodsResponse(),
+                            billingAddressObservable().countryId,
+                            this.handleOnAdditionalDetails.bind(this),
+                            this.handleOnCancel.bind(this),
+                            this.handleOnSubmit.bind(this),
+                            this.handleOnError.bind(this)
+                        );
+
+                        this.renderCheckoutComponent();
+                    }
                 }
             },
 

--- a/view/frontend/web/template/payment/giftcard-form.html
+++ b/view/frontend/web/template/payment/giftcard-form.html
@@ -43,6 +43,7 @@
             <!--/ko-->
         </div>
 
+        <!-- ko if: billingAddressAvailable -->
         <div data-bind="attr: {'id': getCode() + '_new_giftcard_wrapper'}">
             <div class="field" data-bind="attr: {'id': getCode() + '_giftcard_button_wrapper'}, visible: canAddNewGiftCard">
                 <button data-bind="click: addNewGiftcard, attr: {'class': 'adyen-checkout__button'}">
@@ -59,6 +60,7 @@
                 </select>
             </div>
         </div>
+        <!-- /ko -->
 
         <h2 data-bind="attr: {'class': 'adyen-giftcard-header'}, visible: giftcardTitle, text: giftcardTitle"></h2>
         <div class="field" data-bind="attr: {'id': 'giftcard-component-wrapper'}"></div>


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
It has been observed that the plugin was unable to mount the checkout component due to missing `countryId` while initiating a payment method. The root cause behind was the billing address assignment is delayed and payment methods used to be rendered earlier.

With this fix, the plugin observes the `countryId` before mounting the checkout component.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
Following cases manually testes for both virtual and standard products with guest and logged-in shoppers.
- Card w/wo 3DS2
- Card recurring
- Wallets (PayPal + Google Pay)
- Gift card payments
- Redirect (Ideal + Klarna)

Fixes #3270 