### PR TITLE
[ECP-9693] Add payment method title override configuration

### DIFF
--- a/Block/Adminhtml/System/Config/Field/PaymentMethodTitles.php
+++ b/Block/Adminhtml/System/Config/Field/PaymentMethodTitles.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2026 Adyen N.V. (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\Payment\Block\Adminhtml\System\Config\Field;
+
+use Magento\Config\Block\System\Config\Form\Field\FieldArray\AbstractFieldArray;
+use Magento\Framework\DataObject;
+use Magento\Framework\Exception\LocalizedException;
+
+class PaymentMethodTitles extends AbstractFieldArray
+{
+    private ?PaymentMethodType $_paymentMethodTypeRenderer = null;
+
+    /**
+     * @return PaymentMethodType
+     * @throws LocalizedException
+     */
+    protected function getPaymentMethodTypeRenderer(): PaymentMethodType
+    {
+        if (!$this->_paymentMethodTypeRenderer) {
+            $this->_paymentMethodTypeRenderer = $this->getLayout()->createBlock(
+                PaymentMethodType::class,
+                '',
+                ['data' => ['is_render_to_js_template' => true]]
+            );
+        }
+
+        return $this->_paymentMethodTypeRenderer;
+    }
+
+    /**
+     * @return void
+     * @throws LocalizedException
+     */
+    protected function _prepareToRender(): void
+    {
+        $this->addColumn(
+            'payment_method_type',
+            [
+                'label'    => __('Payment Method'),
+                'renderer' => $this->getPaymentMethodTypeRenderer(),
+            ]
+        );
+        $this->addColumn(
+            'title',
+            [
+                'label'    => __('Custom Title'),
+                'renderer' => false,
+            ]
+        );
+
+        $this->_addAfter = false;
+        $this->_addButtonLabel = __('Add Override');
+    }
+
+    /**
+     * @param DataObject $row
+     * @return void
+     * @throws LocalizedException
+     */
+    protected function _prepareArrayRow(DataObject $row): void
+    {
+        $options = [];
+        $paymentMethodType = $row->getPaymentMethodType();
+
+        if ($paymentMethodType) {
+            $options['option_' . $this->getPaymentMethodTypeRenderer()->calcOptionHash($paymentMethodType)]
+                = 'selected="selected"';
+        }
+
+        $row->setData('option_extra_attrs', $options);
+    }
+}

--- a/Block/Adminhtml/System/Config/Field/PaymentMethodTitles.php
+++ b/Block/Adminhtml/System/Config/Field/PaymentMethodTitles.php
@@ -17,7 +17,7 @@ use Magento\Framework\Exception\LocalizedException;
 
 class PaymentMethodTitles extends AbstractFieldArray
 {
-    private ?PaymentMethodType $_paymentMethodTypeRenderer = null;
+    private ?PaymentMethodType $paymentMethodTypeRenderer = null;
 
     /**
      * @return PaymentMethodType
@@ -25,15 +25,15 @@ class PaymentMethodTitles extends AbstractFieldArray
      */
     protected function getPaymentMethodTypeRenderer(): PaymentMethodType
     {
-        if (!$this->_paymentMethodTypeRenderer) {
-            $this->_paymentMethodTypeRenderer = $this->getLayout()->createBlock(
+        if (!$this->paymentMethodTypeRenderer) {
+            $this->paymentMethodTypeRenderer = $this->getLayout()->createBlock(
                 PaymentMethodType::class,
                 '',
                 ['data' => ['is_render_to_js_template' => true]]
             );
         }
 
-        return $this->_paymentMethodTypeRenderer;
+        return $this->paymentMethodTypeRenderer;
     }
 
     /**

--- a/Block/Adminhtml/System/Config/Field/PaymentMethodType.php
+++ b/Block/Adminhtml/System/Config/Field/PaymentMethodType.php
@@ -3,7 +3,7 @@
  *
  * Adyen Payment module (https://www.adyen.com/)
  *
- * Copyright (c) 2026 Adyen N.V. (https://www.adyen.com/)
+ * Copyright (c) 2025 Adyen N.V. (https://www.adyen.com/)
  * See LICENSE.txt for license details.
  *
  * Author: Adyen <magento@adyen.com>
@@ -37,7 +37,7 @@ class PaymentMethodType extends Select
     {
         if (!$this->getOptions()) {
             foreach ($this->source->toOptionArray() as $option) {
-                $this->addOption($option['value'], addslashes((string) $option['label']));
+                $this->addOption($option['value'], (string) $option['label']);
             }
         }
 

--- a/Block/Adminhtml/System/Config/Field/PaymentMethodType.php
+++ b/Block/Adminhtml/System/Config/Field/PaymentMethodType.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2026 Adyen N.V. (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\Payment\Block\Adminhtml\System\Config\Field;
+
+use Adyen\Payment\Model\Config\Source\PaymentMethodType as PaymentMethodTypeSource;
+use Magento\Framework\View\Element\Context;
+use Magento\Framework\View\Element\Html\Select;
+
+class PaymentMethodType extends Select
+{
+    /**
+     * @param Context $context
+     * @param PaymentMethodTypeSource $source
+     * @param array $data
+     */
+    public function __construct(
+        Context $context,
+        private readonly PaymentMethodTypeSource $source,
+        array $data = []
+    ) {
+        parent::__construct($context, $data);
+    }
+
+    /**
+     * @return string
+     */
+    public function _toHtml(): string
+    {
+        if (!$this->getOptions()) {
+            foreach ($this->source->toOptionArray() as $option) {
+                $this->addOption($option['value'], addslashes((string) $option['label']));
+            }
+        }
+
+        return parent::_toHtml();
+    }
+
+    /**
+     * @param string $value
+     * @return $this
+     */
+    public function setInputName(string $value): self
+    {
+        return $this->setName($value);
+    }
+
+    /**
+     * @param string $value
+     * @return $this
+     */
+    public function setInputId(string $value): self
+    {
+        return $this->setId($value);
+    }
+}

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -68,6 +68,7 @@ class Config
     const XML_IGNORE_EXPIRE_WEBHOOK = 'ignore_expire_webhook';
     const XML_ADYEN_ANALYTICS_PREFIX = "adyen_analytics";
     const XML_INSTALLATION_TIME = 'installation_time';
+    const XML_PAYMENT_METHOD_TITLE_OVERRIDES = 'payment_method_title_overrides';
 
     /**
      * @param ScopeConfigInterface $scopeConfig
@@ -727,6 +728,34 @@ class Config
             self::XML_INSTALLATION_TIME,
             self::XML_ADYEN_ANALYTICS_PREFIX
         );
+    }
+
+    /**
+     * Returns the payment method title overrides configured by the merchant as a map of
+     * `[txVariant => customTitle]`. Returns an empty array when no overrides are configured
+     * or when the stored value cannot be decoded.
+     *
+     * @param int|null $storeId
+     * @return array<string, string>
+     */
+    public function getPaymentMethodTitleOverrides(?int $storeId = null): array
+    {
+        $serialized = $this->getConfigData(
+            self::XML_PAYMENT_METHOD_TITLE_OVERRIDES,
+            self::XML_ADYEN_ABSTRACT_PREFIX,
+            $storeId
+        );
+
+        if (empty($serialized)) {
+            return [];
+        }
+
+        try {
+            $result = $this->serializer->unserialize($serialized);
+            return is_array($result) ? $result : [];
+        } catch (\InvalidArgumentException $e) {
+            return [];
+        }
     }
 
     public function getConfigData(string $field, string $xmlPrefix, ?int $storeId, bool $flag = false): mixed

--- a/Helper/PaymentMethods.php
+++ b/Helper/PaymentMethods.php
@@ -280,6 +280,11 @@ class PaymentMethods extends AbstractHelper
             return json_encode([]);
         }
 
+        $responseData['paymentMethods'] = $this->applyPaymentMethodTitleOverrides(
+            $responseData['paymentMethods'],
+            (int) $store->getId()
+        );
+
         $paymentMethods = $responseData['paymentMethods'];
 
         $allowMultistoreTokens = $this->configHelper->getAllowMultistoreTokens($store->getId());
@@ -329,6 +334,34 @@ class PaymentMethods extends AbstractHelper
         }
 
         return $responseData;
+    }
+
+    /**
+     * Replaces the `name` field of each payment method in the API response with the
+     * merchant-configured override when one exists for the given tx-variant type.
+     * Methods without a configured override are left unchanged.
+     *
+     * @param array $paymentMethods
+     * @param int $storeId
+     * @return array
+     */
+    protected function applyPaymentMethodTitleOverrides(array $paymentMethods, int $storeId): array
+    {
+        $overrides = $this->configHelper->getPaymentMethodTitleOverrides($storeId);
+
+        if (empty($overrides)) {
+            return $paymentMethods;
+        }
+
+        foreach ($paymentMethods as &$paymentMethod) {
+            $type = $paymentMethod['type'] ?? null;
+            if ($type !== null && isset($overrides[$type])) {
+                $paymentMethod['name'] = $overrides[$type];
+            }
+        }
+        unset($paymentMethod);
+
+        return $paymentMethods;
     }
 
     /**

--- a/Model/Config/Backend/PaymentMethodTitles.php
+++ b/Model/Config/Backend/PaymentMethodTitles.php
@@ -1,0 +1,133 @@
+<?php
+/**
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2026 Adyen N.V. (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\Payment\Model\Config\Backend;
+
+use Magento\Framework\App\Cache\TypeListInterface;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\App\Config\Value;
+use Magento\Framework\Data\Collection\AbstractDb;
+use Magento\Framework\Math\Random;
+use Magento\Framework\Model\Context;
+use Magento\Framework\Model\ResourceModel\AbstractResource;
+use Magento\Framework\Registry;
+use Magento\Framework\Serialize\SerializerInterface;
+
+class PaymentMethodTitles extends Value
+{
+    /**
+     * @param Context $context
+     * @param Registry $registry
+     * @param ScopeConfigInterface $config
+     * @param TypeListInterface $cacheTypeList
+     * @param Random $mathRandom
+     * @param SerializerInterface $serializer
+     * @param AbstractResource|null $resource
+     * @param AbstractDb|null $resourceCollection
+     * @param array $data
+     */
+    public function __construct(
+        Context $context,
+        Registry $registry,
+        ScopeConfigInterface $config,
+        TypeListInterface $cacheTypeList,
+        protected readonly Random $mathRandom,
+        private readonly SerializerInterface $serializer,
+        ?AbstractResource $resource = null,
+        ?AbstractDb $resourceCollection = null,
+        array $data = []
+    ) {
+        parent::__construct($context, $registry, $config, $cacheTypeList, $resource, $resourceCollection, $data);
+    }
+
+    /**
+     * Serialize the dynamic table rows before saving to the database.
+     * Duplicate payment method types are deduplicated (last row wins).
+     *
+     * @return $this
+     */
+    public function beforeSave(): static
+    {
+        $value = $this->getValue();
+
+        if (!is_array($value)) {
+            return $this;
+        }
+
+        $result = [];
+
+        foreach ($value as $rowData) {
+            if (!is_array($rowData)) {
+                continue;
+            }
+
+            $type = trim((string) ($rowData['payment_method_type'] ?? ''));
+            $title = trim((string) ($rowData['title'] ?? ''));
+
+            if ($type === '' || $title === '') {
+                continue;
+            }
+
+            $result[$type] = $title;
+        }
+
+        $this->setValue($this->serializer->serialize($result));
+
+        return $this;
+    }
+
+    /**
+     * Deserialize the stored value after loading from the database so it can
+     * be rendered by the AbstractFieldArray dynamic table.
+     *
+     * @return $this
+     */
+    protected function _afterLoad(): static
+    {
+        $value = $this->getValue();
+
+        if (empty($value)) {
+            return $this;
+        }
+
+        $decoded = $this->serializer->unserialize($value);
+
+        if (!is_array($decoded)) {
+            return $this;
+        }
+
+        $this->setValue($this->encodeArrayFieldValue($decoded));
+
+        return $this;
+    }
+
+    /**
+     * Convert the stored `{type: title}` map into the row-keyed format that
+     * AbstractFieldArray expects for pre-population.
+     *
+     * @param array $value
+     * @return array
+     */
+    protected function encodeArrayFieldValue(array $value): array
+    {
+        $result = [];
+
+        foreach ($value as $type => $title) {
+            $id = $this->mathRandom->getUniqueHash('_');
+            $result[$id] = [
+                'payment_method_type' => $type,
+                'title'               => $title,
+            ];
+        }
+
+        return $result;
+    }
+}

--- a/Model/Config/Backend/PaymentMethodTitles.php
+++ b/Model/Config/Backend/PaymentMethodTitles.php
@@ -15,6 +15,7 @@ use Magento\Framework\App\Cache\TypeListInterface;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\App\Config\Value;
 use Magento\Framework\Data\Collection\AbstractDb;
+use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Math\Random;
 use Magento\Framework\Model\Context;
 use Magento\Framework\Model\ResourceModel\AbstractResource;
@@ -50,9 +51,10 @@ class PaymentMethodTitles extends Value
 
     /**
      * Serialize the dynamic table rows before saving to the database.
-     * Duplicate payment method types are deduplicated (last row wins).
+     * Throws an exception if duplicate payment method types are detected.
      *
      * @return $this
+     * @throws LocalizedException
      */
     public function beforeSave(): static
     {
@@ -74,6 +76,12 @@ class PaymentMethodTitles extends Value
 
             if ($type === '' || $title === '') {
                 continue;
+            }
+
+            if (isset($result[$type])) {
+                throw new LocalizedException(
+                    __('Duplicate payment method override: "%1". Each payment method can only have one title override.', $type)
+                );
             }
 
             $result[$type] = $title;

--- a/Model/Config/Source/PaymentMethodType.php
+++ b/Model/Config/Source/PaymentMethodType.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2026 Adyen N.V. (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\Payment\Model\Config\Source;
+
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\Data\OptionSourceInterface;
+use Magento\Payment\Helper\Data as MagentoPaymentDataHelper;
+use Magento\Store\Model\ScopeInterface;
+
+class PaymentMethodType implements OptionSourceInterface
+{
+    private const PAYMENT_METHOD_MAP = [
+        'cc'     => 'scheme',
+        'boleto' => 'boletobancario',
+    ];
+
+    private const EXCLUDED_CODES = [
+        'adyen_hpp',
+        'adyen_hpp_vault',
+        'adyen_oneclick',
+        'adyen_pos_cloud',
+        'adyen_pay_by_link',
+        'adyen_moto',
+        'adyen_abstract',
+    ];
+
+    /**
+     * @param MagentoPaymentDataHelper $paymentHelper
+     * @param ScopeConfigInterface $scopeConfig
+     */
+    public function __construct(
+        private readonly MagentoPaymentDataHelper $paymentHelper,
+        private readonly ScopeConfigInterface $scopeConfig
+    ) {}
+
+    /**
+     * @return array
+     */
+    public function toOptionArray(): array
+    {
+        $options = [];
+        $paymentMethods = $this->paymentHelper->getPaymentMethodList();
+
+        foreach (array_keys($paymentMethods) as $code) {
+            if (!str_starts_with((string) $code, 'adyen_')) {
+                continue;
+            }
+            if (in_array($code, self::EXCLUDED_CODES, true)) {
+                continue;
+            }
+            if (str_ends_with((string) $code, '_vault')) {
+                continue;
+            }
+
+            $txVariant = substr((string) $code, strlen('adyen_'));
+            $txVariant = self::PAYMENT_METHOD_MAP[$txVariant] ?? $txVariant;
+
+            $title = (string) $this->scopeConfig->getValue(
+                'payment/' . $code . '/title',
+                ScopeInterface::SCOPE_STORE
+            );
+
+            $label = $title !== '' ? $title . ' (' . $txVariant . ')' : $txVariant;
+
+            $options[] = ['value' => $txVariant, 'label' => $label];
+        }
+
+        usort($options, static fn($a, $b) => strcmp((string) $a['label'], (string) $b['label']));
+
+        return $options;
+    }
+}

--- a/Test/Unit/Block/Adminhtml/System/Config/Field/PaymentMethodTitlesTest.php
+++ b/Test/Unit/Block/Adminhtml/System/Config/Field/PaymentMethodTitlesTest.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2026 Adyen N.V. (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+declare(strict_types=1);
+
+namespace Adyen\Payment\Test\Unit\Block\Adminhtml\System\Config\Field;
+
+use Adyen\Payment\Block\Adminhtml\System\Config\Field\PaymentMethodTitles;
+use Adyen\Payment\Block\Adminhtml\System\Config\Field\PaymentMethodType;
+use Adyen\Payment\Test\Unit\AbstractAdyenTestCase;
+use Magento\Framework\DataObject;
+use Magento\Framework\View\LayoutInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+
+#[CoversClass(PaymentMethodTitles::class)]
+class PaymentMethodTitlesTest extends AbstractAdyenTestCase
+{
+    private PaymentMethodTitles $block;
+    private MockObject $layoutMock;
+    private MockObject $rendererMock;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->rendererMock = $this->getMockBuilder(PaymentMethodType::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['calcOptionHash'])
+            ->getMock();
+
+        $this->layoutMock = $this->createMock(LayoutInterface::class);
+        $this->layoutMock->method('createBlock')
+            ->with(PaymentMethodType::class, '', ['data' => ['is_render_to_js_template' => true]])
+            ->willReturn($this->rendererMock);
+
+        $this->block = $this->getMockBuilder(PaymentMethodTitles::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getLayout'])
+            ->getMock();
+
+        $this->block->method('getLayout')->willReturn($this->layoutMock);
+    }
+
+    public function testPrepareArrayRowSetsSelectedOption(): void
+    {
+        $this->rendererMock->method('calcOptionHash')
+            ->with('scheme')
+            ->willReturn('123456');
+
+        $row = new DataObject([
+            'payment_method_type' => 'scheme',
+            'title' => 'Kreditkarte',
+        ]);
+
+        $this->invokeMethod($this->block, '_prepareArrayRow', [$row]);
+
+        $expected = ['option_123456' => 'selected="selected"'];
+        $this->assertSame($expected, $row->getData('option_extra_attrs'));
+    }
+
+    public function testPrepareArrayRowWithEmptyTypeSetsNoOptions(): void
+    {
+        $row = new DataObject([
+            'payment_method_type' => '',
+            'title' => 'Some Title',
+        ]);
+
+        $this->invokeMethod($this->block, '_prepareArrayRow', [$row]);
+
+        $this->assertSame([], $row->getData('option_extra_attrs'));
+    }
+
+    public function testPrepareArrayRowWithNullTypeSetsNoOptions(): void
+    {
+        $row = new DataObject([
+            'title' => 'Some Title',
+        ]);
+
+        $this->invokeMethod($this->block, '_prepareArrayRow', [$row]);
+
+        $this->assertSame([], $row->getData('option_extra_attrs'));
+    }
+
+    public function testPrepareToRenderAddsColumnsAndSetsButtonLabel(): void
+    {
+        $this->invokeMethod($this->block, '_prepareToRender');
+
+        $reflection = new \ReflectionClass($this->block);
+
+        $columnsProperty = $reflection->getProperty('_columns');
+        $columnsProperty->setAccessible(true);
+        $columns = $columnsProperty->getValue($this->block);
+
+        $this->assertArrayHasKey('payment_method_type', $columns);
+        $this->assertArrayHasKey('title', $columns);
+
+        $addAfterProperty = $reflection->getProperty('_addAfter');
+        $addAfterProperty->setAccessible(true);
+        $this->assertFalse($addAfterProperty->getValue($this->block));
+
+        $addButtonLabelProperty = $reflection->getProperty('_addButtonLabel');
+        $addButtonLabelProperty->setAccessible(true);
+        $this->assertEquals('Add Override', (string) $addButtonLabelProperty->getValue($this->block));
+    }
+
+    public function testGetPaymentMethodTypeRendererReturnsSameInstance(): void
+    {
+        $this->layoutMock->expects($this->once())
+            ->method('createBlock')
+            ->willReturn($this->rendererMock);
+
+        $renderer1 = $this->invokeMethod($this->block, 'getPaymentMethodTypeRenderer');
+        $renderer2 = $this->invokeMethod($this->block, 'getPaymentMethodTypeRenderer');
+
+        $this->assertSame($renderer1, $renderer2);
+    }
+}

--- a/Test/Unit/Block/Adminhtml/System/Config/Field/PaymentMethodTypeTest.php
+++ b/Test/Unit/Block/Adminhtml/System/Config/Field/PaymentMethodTypeTest.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2026 Adyen N.V. (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+declare(strict_types=1);
+
+namespace Adyen\Payment\Test\Unit\Block\Adminhtml\System\Config\Field;
+
+use Adyen\Payment\Block\Adminhtml\System\Config\Field\PaymentMethodType;
+use Adyen\Payment\Model\Config\Source\PaymentMethodType as PaymentMethodTypeSource;
+use Adyen\Payment\Test\Unit\AbstractAdyenTestCase;
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Element\Context;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+
+#[CoversClass(PaymentMethodType::class)]
+class PaymentMethodTypeTest extends AbstractAdyenTestCase
+{
+    private MockObject $block;
+    private MockObject $sourceMock;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->sourceMock = $this->createMock(PaymentMethodTypeSource::class);
+
+        $escaperMock = $this->createMock(Escaper::class);
+        $escaperMock->method('escapeHtml')->willReturnArgument(0);
+
+        $contextMock = $this->createMock(Context::class);
+        $contextMock->method('getEscaper')->willReturn($escaperMock);
+
+        $this->block = $this->getMockBuilder(PaymentMethodType::class)
+            ->setConstructorArgs([$contextMock, $this->sourceMock])
+            ->onlyMethods([])
+            ->getMock();
+    }
+
+    public function testSetInputNameDelegatesToSetName(): void
+    {
+        $result = $this->block->setInputName('test_name');
+
+        $this->assertInstanceOf(PaymentMethodType::class, $result);
+        $this->assertSame('test_name', $this->block->getName());
+    }
+
+    public function testSetInputIdDelegatesToSetId(): void
+    {
+        $result = $this->block->setInputId('test_id');
+
+        $this->assertInstanceOf(PaymentMethodType::class, $result);
+        $this->assertSame('test_id', $this->block->getId());
+    }
+
+    public function testToHtmlPopulatesOptionsFromSource(): void
+    {
+        $this->sourceMock->expects($this->once())
+            ->method('toOptionArray')
+            ->willReturn([
+                ['value' => 'scheme', 'label' => 'Cards (scheme)'],
+                ['value' => 'ideal', 'label' => 'iDEAL (ideal)'],
+            ]);
+
+        $this->assertEmpty($this->block->getOptions());
+
+        $this->invokeMethod($this->block, '_toHtml');
+
+        $options = $this->block->getOptions();
+        $this->assertCount(2, $options);
+        $this->assertSame('scheme', $options[0]['value']);
+        $this->assertSame('Cards (scheme)', $options[0]['label']);
+        $this->assertSame('ideal', $options[1]['value']);
+        $this->assertSame('iDEAL (ideal)', $options[1]['label']);
+    }
+
+    public function testToHtmlDoesNotReloadOptionsWhenAlreadySet(): void
+    {
+        $this->sourceMock->expects($this->once())
+            ->method('toOptionArray')
+            ->willReturn([
+                ['value' => 'scheme', 'label' => 'Cards (scheme)'],
+            ]);
+
+        $this->invokeMethod($this->block, '_toHtml');
+        $this->invokeMethod($this->block, '_toHtml');
+
+        $this->assertCount(1, $this->block->getOptions());
+    }
+}

--- a/Test/Unit/Helper/ConfigTest.php
+++ b/Test/Unit/Helper/ConfigTest.php
@@ -388,4 +388,55 @@ class ConfigTest extends AbstractAdyenTestCase
 
         $this->configHelper->setInstallationTime($installationTime);
     }
+
+    public function testGetPaymentMethodTitleOverridesReturnsDeserializedArray(): void
+    {
+        $serialized = '{"scheme":"Kreditkarte","ideal":"iDEAL"}';
+        $expected = ['scheme' => 'Kreditkarte', 'ideal' => 'iDEAL'];
+
+        $this->scopeConfigMock->method('getValue')
+            ->willReturn($serialized);
+
+        $this->serializerMock->expects($this->once())
+            ->method('unserialize')
+            ->with($serialized)
+            ->willReturn($expected);
+
+        $this->assertSame($expected, $this->configHelper->getPaymentMethodTitleOverrides(1));
+    }
+
+    public function testGetPaymentMethodTitleOverridesReturnsEmptyArrayWhenEmpty(): void
+    {
+        $this->scopeConfigMock->method('getValue')
+            ->willReturn(null);
+
+        $this->serializerMock->expects($this->never())->method('unserialize');
+
+        $this->assertSame([], $this->configHelper->getPaymentMethodTitleOverrides(1));
+    }
+
+    public function testGetPaymentMethodTitleOverridesReturnsEmptyArrayOnInvalidJson(): void
+    {
+        $this->scopeConfigMock->method('getValue')
+            ->willReturn('invalid-json');
+
+        $this->serializerMock->expects($this->once())
+            ->method('unserialize')
+            ->willThrowException(new \InvalidArgumentException('Unable to unserialize'));
+
+        $this->assertSame([], $this->configHelper->getPaymentMethodTitleOverrides(1));
+    }
+
+    public function testGetPaymentMethodTitleOverridesReturnsEmptyArrayWhenNotArray(): void
+    {
+        $this->scopeConfigMock->method('getValue')
+            ->willReturn('"just a string"');
+
+        $this->serializerMock->expects($this->once())
+            ->method('unserialize')
+            ->with('"just a string"')
+            ->willReturn('just a string');
+
+        $this->assertSame([], $this->configHelper->getPaymentMethodTitleOverrides(1));
+    }
 }

--- a/Test/Unit/Helper/PaymentMethodsTest.php
+++ b/Test/Unit/Helper/PaymentMethodsTest.php
@@ -1069,4 +1069,58 @@ class PaymentMethodsTest extends AbstractAdyenTestCase
 
         $this->assertSame($cached, $result);
     }
+
+    public function testApplyPaymentMethodTitleOverridesReplacesMatchingNames(): void
+    {
+        $overrides = ['scheme' => 'Kreditkarte', 'klarna' => 'Pay Later'];
+
+        $this->configHelper->method('getPaymentMethodTitleOverrides')
+            ->with(1)
+            ->willReturn($overrides);
+
+        $paymentMethods = [
+            ['type' => 'scheme', 'name' => 'Cards'],
+            ['type' => 'klarna', 'name' => 'Klarna'],
+            ['type' => 'ideal',  'name' => 'iDEAL'],
+        ];
+
+        $result = $this->invokeMethod($this->helper, 'applyPaymentMethodTitleOverrides', [$paymentMethods, 1]);
+
+        $this->assertSame('Kreditkarte', $result[0]['name']);
+        $this->assertSame('Pay Later',   $result[1]['name']);
+        $this->assertSame('iDEAL',       $result[2]['name']);
+    }
+
+    public function testApplyPaymentMethodTitleOverridesReturnUnchangedWhenNoOverrides(): void
+    {
+        $this->configHelper->method('getPaymentMethodTitleOverrides')
+            ->with(1)
+            ->willReturn([]);
+
+        $paymentMethods = [
+            ['type' => 'scheme', 'name' => 'Cards'],
+            ['type' => 'ideal',  'name' => 'iDEAL'],
+        ];
+
+        $result = $this->invokeMethod($this->helper, 'applyPaymentMethodTitleOverrides', [$paymentMethods, 1]);
+
+        $this->assertSame('Cards', $result[0]['name']);
+        $this->assertSame('iDEAL', $result[1]['name']);
+    }
+
+    public function testApplyPaymentMethodTitleOverridesIgnoresMethodsWithoutType(): void
+    {
+        $this->configHelper->method('getPaymentMethodTitleOverrides')
+            ->willReturn(['scheme' => 'Kreditkarte']);
+
+        $paymentMethods = [
+            ['name' => 'No Type Method'],
+            ['type' => 'scheme', 'name' => 'Cards'],
+        ];
+
+        $result = $this->invokeMethod($this->helper, 'applyPaymentMethodTitleOverrides', [$paymentMethods, 1]);
+
+        $this->assertSame('No Type Method', $result[0]['name']);
+        $this->assertSame('Kreditkarte',    $result[1]['name']);
+    }
 }

--- a/Test/Unit/Model/Config/Backend/PaymentMethodTitlesTest.php
+++ b/Test/Unit/Model/Config/Backend/PaymentMethodTitlesTest.php
@@ -1,0 +1,194 @@
+<?php
+/**
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2026 Adyen N.V. (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+declare(strict_types=1);
+
+namespace Adyen\Payment\Test\Unit\Model\Config\Backend;
+
+use Adyen\Payment\Model\Config\Backend\PaymentMethodTitles;
+use Adyen\Payment\Test\Unit\AbstractAdyenTestCase;
+use Magento\Framework\App\Cache\TypeListInterface;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\Data\Collection\AbstractDb;
+use Magento\Framework\Event\ManagerInterface;
+use Magento\Framework\Math\Random;
+use Magento\Framework\Model\Context;
+use Magento\Framework\Model\ResourceModel\AbstractResource;
+use Magento\Framework\Registry;
+use Magento\Framework\Serialize\SerializerInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+
+#[CoversClass(PaymentMethodTitles::class)]
+class PaymentMethodTitlesTest extends AbstractAdyenTestCase
+{
+    private PaymentMethodTitles $model;
+    private MockObject $serializerMock;
+    private MockObject $mathRandomMock;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->serializerMock = $this->createMock(SerializerInterface::class);
+        $this->mathRandomMock = $this->createMock(Random::class);
+
+        $this->model = $this->getMockBuilder(PaymentMethodTitles::class)
+            ->setConstructorArgs([
+                $this->createConfiguredMock(Context::class, [
+                    'getEventDispatcher' => $this->createMock(ManagerInterface::class),
+                ]),
+                $this->createMock(Registry::class),
+                $this->createMock(ScopeConfigInterface::class),
+                $this->createMock(TypeListInterface::class),
+                $this->mathRandomMock,
+                $this->serializerMock,
+                $this->createMock(AbstractResource::class),
+                $this->createMock(AbstractDb::class),
+                [],
+            ])
+            ->onlyMethods([])
+            ->getMock();
+    }
+
+    public function testBeforeSaveSerializesValidRows(): void
+    {
+        $inputRows = [
+            'row1' => ['payment_method_type' => 'scheme', 'title' => 'Kreditkarte'],
+            'row2' => ['payment_method_type' => 'klarna', 'title' => 'Klarna'],
+        ];
+
+        $expectedMap = ['scheme' => 'Kreditkarte', 'klarna' => 'Klarna'];
+        $serialized  = '{"scheme":"Kreditkarte","klarna":"Klarna"}';
+
+        $this->serializerMock->expects($this->once())
+            ->method('serialize')
+            ->with($expectedMap)
+            ->willReturn($serialized);
+
+        $this->model->setData('value', $inputRows);
+        $result = $this->model->beforeSave();
+
+        $this->assertInstanceOf(PaymentMethodTitles::class, $result);
+        $this->assertSame($serialized, $this->model->getData('value'));
+    }
+
+    public function testBeforeSaveSkipsRowsWithEmptyType(): void
+    {
+        $inputRows = [
+            'row1' => ['payment_method_type' => '', 'title' => 'Some Title'],
+            'row2' => ['payment_method_type' => 'klarna', 'title' => 'Klarna'],
+        ];
+
+        $this->serializerMock->expects($this->once())
+            ->method('serialize')
+            ->with(['klarna' => 'Klarna'])
+            ->willReturn('{"klarna":"Klarna"}');
+
+        $this->model->setData('value', $inputRows);
+        $this->model->beforeSave();
+
+        $this->assertSame('{"klarna":"Klarna"}', $this->model->getData('value'));
+    }
+
+    public function testBeforeSaveSkipsRowsWithEmptyTitle(): void
+    {
+        $inputRows = [
+            'row1' => ['payment_method_type' => 'scheme', 'title' => ''],
+            'row2' => ['payment_method_type' => 'ideal', 'title' => 'iDEAL'],
+        ];
+
+        $this->serializerMock->expects($this->once())
+            ->method('serialize')
+            ->with(['ideal' => 'iDEAL'])
+            ->willReturn('{"ideal":"iDEAL"}');
+
+        $this->model->setData('value', $inputRows);
+        $this->model->beforeSave();
+
+        $this->assertSame('{"ideal":"iDEAL"}', $this->model->getData('value'));
+    }
+
+    public function testBeforeSaveDeduplicatesOnLastRow(): void
+    {
+        $inputRows = [
+            'row1' => ['payment_method_type' => 'scheme', 'title' => 'Cards'],
+            'row2' => ['payment_method_type' => 'scheme', 'title' => 'Kreditkarte'],
+        ];
+
+        $this->serializerMock->expects($this->once())
+            ->method('serialize')
+            ->with(['scheme' => 'Kreditkarte'])
+            ->willReturn('{"scheme":"Kreditkarte"}');
+
+        $this->model->setData('value', $inputRows);
+        $this->model->beforeSave();
+
+        $this->assertSame('{"scheme":"Kreditkarte"}', $this->model->getData('value'));
+    }
+
+    public function testBeforeSaveWithNonArrayValueReturnsEarly(): void
+    {
+        $this->serializerMock->expects($this->never())->method('serialize');
+
+        $this->model->setData('value', 'not-an-array');
+        $result = $this->model->beforeSave();
+
+        $this->assertInstanceOf(PaymentMethodTitles::class, $result);
+        $this->assertSame('not-an-array', $this->model->getData('value'));
+    }
+
+    public function testAfterLoadDeserializesAndSetsRows(): void
+    {
+        $serialized = '{"scheme":"Kreditkarte","ideal":"iDEAL"}';
+        $decoded    = ['scheme' => 'Kreditkarte', 'ideal' => 'iDEAL'];
+
+        $this->serializerMock->expects($this->once())
+            ->method('unserialize')
+            ->with($serialized)
+            ->willReturn($decoded);
+
+        $this->mathRandomMock->method('getUniqueHash')
+            ->willReturnOnConsecutiveCalls('_abc', '_def');
+
+        $expectedRows = [
+            '_abc' => ['payment_method_type' => 'scheme', 'title' => 'Kreditkarte'],
+            '_def' => ['payment_method_type' => 'ideal',  'title' => 'iDEAL'],
+        ];
+
+        $this->model->setData('value', $serialized);
+        $this->invokeMethod($this->model, '_afterLoad');
+
+        $this->assertSame($expectedRows, $this->model->getData('value'));
+    }
+
+    public function testAfterLoadWithEmptyValueReturnsEarly(): void
+    {
+        $this->serializerMock->expects($this->never())->method('unserialize');
+
+        $this->model->setData('value', '');
+        $this->invokeMethod($this->model, '_afterLoad');
+
+        $this->assertSame('', $this->model->getData('value'));
+    }
+
+    public function testAfterLoadWithNonArrayDeserializedValueReturnsEarly(): void
+    {
+        $this->serializerMock->expects($this->once())
+            ->method('unserialize')
+            ->willReturn('not-an-array');
+
+        $this->model->setData('value', 'invalid');
+        $this->invokeMethod($this->model, '_afterLoad');
+
+        $this->assertSame('invalid', $this->model->getData('value'));
+    }
+}

--- a/Test/Unit/Model/Config/Backend/PaymentMethodTitlesTest.php
+++ b/Test/Unit/Model/Config/Backend/PaymentMethodTitlesTest.php
@@ -19,6 +19,7 @@ use Magento\Framework\App\Cache\TypeListInterface;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\Data\Collection\AbstractDb;
 use Magento\Framework\Event\ManagerInterface;
+use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Math\Random;
 use Magento\Framework\Model\Context;
 use Magento\Framework\Model\ResourceModel\AbstractResource;
@@ -117,22 +118,38 @@ class PaymentMethodTitlesTest extends AbstractAdyenTestCase
         $this->assertSame('{"ideal":"iDEAL"}', $this->model->getData('value'));
     }
 
-    public function testBeforeSaveDeduplicatesOnLastRow(): void
+    public function testBeforeSaveThrowsExceptionOnDuplicatePaymentMethod(): void
     {
         $inputRows = [
             'row1' => ['payment_method_type' => 'scheme', 'title' => 'Cards'],
             'row2' => ['payment_method_type' => 'scheme', 'title' => 'Kreditkarte'],
         ];
 
+        $this->serializerMock->expects($this->never())->method('serialize');
+
+        $this->model->setData('value', $inputRows);
+
+        $this->expectException(LocalizedException::class);
+        $this->expectExceptionMessage('Duplicate payment method override: "scheme"');
+        $this->model->beforeSave();
+    }
+
+    public function testBeforeSaveSkipsNonArrayRowEntries(): void
+    {
+        $inputRows = [
+            'row1' => 'not-an-array',
+            'row2' => ['payment_method_type' => 'ideal', 'title' => 'iDEAL'],
+        ];
+
         $this->serializerMock->expects($this->once())
             ->method('serialize')
-            ->with(['scheme' => 'Kreditkarte'])
-            ->willReturn('{"scheme":"Kreditkarte"}');
+            ->with(['ideal' => 'iDEAL'])
+            ->willReturn('{"ideal":"iDEAL"}');
 
         $this->model->setData('value', $inputRows);
         $this->model->beforeSave();
 
-        $this->assertSame('{"scheme":"Kreditkarte"}', $this->model->getData('value'));
+        $this->assertSame('{"ideal":"iDEAL"}', $this->model->getData('value'));
     }
 
     public function testBeforeSaveWithNonArrayValueReturnsEarly(): void

--- a/Test/Unit/Model/Config/Source/PaymentMethodTypeTest.php
+++ b/Test/Unit/Model/Config/Source/PaymentMethodTypeTest.php
@@ -1,0 +1,179 @@
+<?php
+/**
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2026 Adyen N.V. (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+declare(strict_types=1);
+
+namespace Adyen\Payment\Test\Unit\Model\Config\Source;
+
+use Adyen\Payment\Model\Config\Source\PaymentMethodType;
+use Adyen\Payment\Test\Unit\AbstractAdyenTestCase;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Payment\Helper\Data as MagentoPaymentDataHelper;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+
+#[CoversClass(PaymentMethodType::class)]
+class PaymentMethodTypeTest extends AbstractAdyenTestCase
+{
+    private MockObject $paymentHelperMock;
+    private MockObject $scopeConfigMock;
+    private PaymentMethodType $source;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->paymentHelperMock = $this->createMock(MagentoPaymentDataHelper::class);
+        $this->scopeConfigMock = $this->createMock(ScopeConfigInterface::class);
+
+        $this->source = new PaymentMethodType(
+            $this->paymentHelperMock,
+            $this->scopeConfigMock
+        );
+    }
+
+    public function testToOptionArrayFiltersNonAdyenMethods(): void
+    {
+        $this->paymentHelperMock->method('getPaymentMethodList')
+            ->willReturn([
+                'checkmo' => 'Check / Money Order',
+                'banktransfer' => 'Bank Transfer',
+                'adyen_ideal' => 'iDEAL',
+            ]);
+
+        $this->scopeConfigMock->method('getValue')
+            ->willReturn('iDEAL');
+
+        $result = $this->source->toOptionArray();
+
+        $this->assertCount(1, $result);
+        $this->assertSame('ideal', $result[0]['value']);
+    }
+
+    public function testToOptionArrayExcludesExcludedCodes(): void
+    {
+        $this->paymentHelperMock->method('getPaymentMethodList')
+            ->willReturn([
+                'adyen_hpp' => 'HPP',
+                'adyen_oneclick' => 'One Click',
+                'adyen_pos_cloud' => 'POS Cloud',
+                'adyen_pay_by_link' => 'Pay by Link',
+                'adyen_moto' => 'MOTO',
+                'adyen_abstract' => 'Abstract',
+                'adyen_hpp_vault' => 'HPP Vault',
+                'adyen_ideal' => 'iDEAL',
+            ]);
+
+        $this->scopeConfigMock->method('getValue')
+            ->willReturn('iDEAL');
+
+        $result = $this->source->toOptionArray();
+
+        $this->assertCount(1, $result);
+        $this->assertSame('ideal', $result[0]['value']);
+    }
+
+    public function testToOptionArrayExcludesVaultMethods(): void
+    {
+        $this->paymentHelperMock->method('getPaymentMethodList')
+            ->willReturn([
+                'adyen_klarna' => 'Klarna',
+                'adyen_klarna_vault' => 'Stored Klarna',
+                'adyen_cc_vault' => 'Stored Cards',
+            ]);
+
+        $this->scopeConfigMock->method('getValue')
+            ->willReturn('Klarna');
+
+        $result = $this->source->toOptionArray();
+
+        $this->assertCount(1, $result);
+        $this->assertSame('klarna', $result[0]['value']);
+    }
+
+    public function testToOptionArrayMapsCcToScheme(): void
+    {
+        $this->paymentHelperMock->method('getPaymentMethodList')
+            ->willReturn(['adyen_cc' => 'Cards']);
+
+        $this->scopeConfigMock->method('getValue')
+            ->willReturn('Cards');
+
+        $result = $this->source->toOptionArray();
+
+        $this->assertCount(1, $result);
+        $this->assertSame('scheme', $result[0]['value']);
+        $this->assertSame('Cards (scheme)', (string) $result[0]['label']);
+    }
+
+    public function testToOptionArrayMapsBoletoToBoletobancario(): void
+    {
+        $this->paymentHelperMock->method('getPaymentMethodList')
+            ->willReturn(['adyen_boleto' => 'Boleto']);
+
+        $this->scopeConfigMock->method('getValue')
+            ->willReturn('Boleto');
+
+        $result = $this->source->toOptionArray();
+
+        $this->assertCount(1, $result);
+        $this->assertSame('boletobancario', $result[0]['value']);
+        $this->assertSame('Boleto (boletobancario)', (string) $result[0]['label']);
+    }
+
+    public function testToOptionArrayUsesCodeAsFallbackWhenTitleEmpty(): void
+    {
+        $this->paymentHelperMock->method('getPaymentMethodList')
+            ->willReturn(['adyen_ideal' => 'iDEAL']);
+
+        $this->scopeConfigMock->method('getValue')
+            ->willReturn('');
+
+        $result = $this->source->toOptionArray();
+
+        $this->assertCount(1, $result);
+        $this->assertSame('ideal', (string) $result[0]['label']);
+    }
+
+    public function testToOptionArraySortsAlphabetically(): void
+    {
+        $this->paymentHelperMock->method('getPaymentMethodList')
+            ->willReturn([
+                'adyen_sepadirectdebit' => 'SEPA',
+                'adyen_ideal' => 'iDEAL',
+                'adyen_cc' => 'Cards',
+            ]);
+
+        $this->scopeConfigMock->method('getValue')
+            ->willReturnMap([
+                ['payment/adyen_sepadirectdebit/title', 'store', null, 'SEPA Direct Debit'],
+                ['payment/adyen_ideal/title', 'store', null, 'iDEAL'],
+                ['payment/adyen_cc/title', 'store', null, 'Cards'],
+            ]);
+
+        $result = $this->source->toOptionArray();
+
+        // strcmp sorts uppercase before lowercase: Cards < SEPA < iDEAL
+        $this->assertSame('scheme', $result[0]['value']);
+        $this->assertSame('sepadirectdebit', $result[1]['value']);
+        $this->assertSame('ideal', $result[2]['value']);
+    }
+
+    public function testToOptionArrayReturnsEmptyWhenNoAdyenMethods(): void
+    {
+        $this->paymentHelperMock->method('getPaymentMethodList')
+            ->willReturn(['checkmo' => 'Check / Money Order']);
+
+        $result = $this->source->toOptionArray();
+
+        $this->assertSame([], $result);
+    }
+}

--- a/etc/adminhtml/system/adyen_online_checkout.xml
+++ b/etc/adminhtml/system/adyen_online_checkout.xml
@@ -21,6 +21,13 @@
             <source_model>Adyen\Payment\Model\Config\Source\RenderMode</source_model>
             <config_path>payment/adyen_abstract/title_renderer</config_path>
         </field>
+        <field id="payment_method_title_overrides" translate="label" sortOrder="15" showInDefault="1" showInWebsite="1" showInStore="1">
+            <label>Payment Method Title Overrides</label>
+            <tooltip>Override the payment method title returned by the /paymentMethods API. The custom title will be used in checkout instead of the translated title from the API response. Leave the title blank or remove the row to fall back to the API response value.</tooltip>
+            <frontend_model>Adyen\Payment\Block\Adminhtml\System\Config\Field\PaymentMethodTitles</frontend_model>
+            <backend_model>Adyen\Payment\Model\Config\Backend\PaymentMethodTitles</backend_model>
+            <config_path>payment/adyen_abstract/payment_method_title_overrides</config_path>
+        </field>
         <field id="return_path" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
             <label>Checkout return path</label>
             <config_path>payment/adyen_abstract/return_path</config_path>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1550,6 +1550,11 @@
             <argument name="serializer" xsi:type="object">Magento\Framework\Serialize\Serializer\Serialize</argument>
         </arguments>
     </type>
+    <type name="Adyen\Payment\Model\Config\Backend\PaymentMethodTitles">
+        <arguments>
+            <argument name="serializer" xsi:type="object">Magento\Framework\Serialize\Serializer\Json</argument>
+        </arguments>
+    </type>
     <type name="Adyen\Payment\Gateway\Validator\InstallmentRequestValidator">
         <arguments>
             <argument name="serializer" xsi:type="object">Magento\Framework\Serialize\Serializer\Serialize</argument>


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
This PR adds a dynamic configuration table under Accepting Payments > Online Checkout that allows merchants to override payment method titles returned by the /paymentMethods API response.

Fixes https://github.com/Adyen/adyen-magento2/issues/2858
