### PR TITLE
[v9] Fix setState() silent failure causing state/status desynchronization

### DIFF
--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -535,11 +535,42 @@ class Order extends AbstractHelper
         }
 
         $this->adyenLogger->addAdyenNotification(
-            'No new state assigned, status should be connected to one of the following states: ' . json_encode($possibleStates),
+            'No new state assigned via preferred states, attempting fallback lookup. '
+            . 'Status should be connected to one of the following states: ' . json_encode($possibleStates),
             [
                 'pspReference' => $order->getPayment()->getData('adyen_psp_reference'),
                 'merchantReference' => $order->getPayment()->getData('entity_id')
             ]);
+
+        // Fallback: resolve state directly from sales_order_status_state without
+        // constraining to $possibleStates. This prevents state/status desynchronization
+        // when the configured status maps to a state not in STATE_TRANSITION_MATRIX.
+        // The fallback is intentionally unconstrained: the status was already set by the
+        // caller, so aligning the state to match is always better than leaving a permanent
+        // mismatch (e.g. state=pending_payment + status=complete).
+        // See https://github.com/Adyen/adyen-magento2/issues/3288
+        $fallbackCollection = $this->orderStatusCollectionFactory->create()
+            ->addFieldToFilter('main_table.status', $status)
+            ->joinStates();
+        $fallbackCollection->getSelect()->order('state_table.is_default DESC');
+        $fallbackCollection->setPageSize(1);
+        $fallbackStatus = $fallbackCollection->getFirstItem();
+        $fallbackState = $fallbackStatus->getState();
+
+        if (!empty($fallbackState)) {
+            $order->setState($fallbackState);
+            $this->adyenLogger->addAdyenNotification(
+                'State set via fallback to ' . $fallbackState
+                . ' (status "' . $status . '" not mapped to preferred states: '
+                . json_encode($possibleStates) . ')',
+                [
+                    'pspReference' => $order->getPayment()->getData('adyen_psp_reference'),
+                    'merchantReference' => $order->getPayment()->getData('entity_id')
+                ]
+            );
+
+            return $order;
+        }
 
         return $order;
     }


### PR DESCRIPTION
## What this PR does

Adds a fallback in `Helper/Order.php::setState()` so that when the `$possibleStates` constraint (from `STATE_TRANSITION_MATRIX`) doesn't produce a match, the method falls back to a direct lookup in `sales_order_status_state` for the given status. This prevents the order state from being permanently stuck at its previous value while the status advances.

## Why this is needed

Currently, `setState()` (line 512) iterates `$possibleStates` and if no match is found, it logs a notification and **returns without changing the state**. Meanwhile, the status was already updated by the caller (`addStatusHistoryComment` at line 285 calls `setStatus()` internally). This leaves the order with a mismatched state/status that never gets corrected.

On our production Magento 2.4.8-p4 with Adyen 9.20.8, this resulted in **63,805 orders** accumulating with `state=pending_payment` + `status=complete/closed` since 2021. This also causes the `sales_clean_orders` cron to generate thousands of failed Adyen API calls per hour trying to void expired authorizations on these "pending" orders.

## How it works

The fix adds a fallback **after** the existing `$possibleStates` loop fails:

```php
// Fallback: resolve state directly from sales_order_status_state
$fallbackStatus = $this->orderStatusCollectionFactory->create()
    ->addFieldToFilter('main_table.status', $status)
    ->joinStates()
    ->getFirstItem();

if ($fallbackStatus->getState()) {
    $order->setState($fallbackStatus->getState());
    // ... log the fallback
    return $order;
}
```

This uses Magento's own `sales_order_status_state` table — the authoritative source for status→state mapping. The preferred `STATE_TRANSITION_MATRIX` states are still tried first; the fallback only activates when no preferred match is found.

## What this does NOT change

- The `STATE_TRANSITION_MATRIX` is not modified
- The preferred state resolution logic is untouched
- The order of operations in `finalizeOrder()` is not changed (the status-before-state pattern remains — fixing that would be a larger refactor)
- No new dependencies are introduced

## Testing

- Verified on a multi-store Magento 2.4.8-p4 instance with 12 websites
- Tested with manual capture mode + Adyen CC, PayPal, Klarna, MobilePay
- After applying this fix, orders correctly transition from `pending_payment` to the state mapped to their configured status in `sales_order_status_state`

## Related

- Fixes #3288
- Related to #1767 (Captured orders stuck in pending_payment state)
- Related to #2097 (Wrong Order status when payment_pre_authorized is set)
- Related to #3269 (MobilePay orders stuck in Pending)