### PR TITLE
[v10] Fix setState() silent failure causing state/status desynchronization

### DIFF
--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -493,11 +493,42 @@ class Order extends AbstractHelper
         }
 
         $this->adyenLogger->addAdyenNotification(
-            'No new state assigned, status should be connected to one of the following states: ' . json_encode($possibleStates),
+            'No new state assigned via preferred states, attempting fallback lookup. '
+            . 'Status should be connected to one of the following states: ' . json_encode($possibleStates),
             [
                 'pspReference' => $order->getPayment()->getData('adyen_psp_reference'),
                 'merchantReference' => $order->getPayment()->getData('entity_id')
             ]);
+
+        // Fallback: resolve state directly from sales_order_status_state without
+        // constraining to $possibleStates. This prevents state/status desynchronization
+        // when the configured status maps to a state not in STATE_TRANSITION_MATRIX.
+        // The fallback is intentionally unconstrained: the status was already set by the
+        // caller, so aligning the state to match is always better than leaving a permanent
+        // mismatch (e.g. state=pending_payment + status=complete).
+        // See https://github.com/Adyen/adyen-magento2/issues/3288
+        $fallbackCollection = $this->orderStatusCollectionFactory->create()
+            ->addFieldToFilter('main_table.status', $status)
+            ->joinStates();
+        $fallbackCollection->getSelect()->order('state_table.is_default DESC');
+        $fallbackCollection->setPageSize(1);
+        $fallbackStatus = $fallbackCollection->getFirstItem();
+        $fallbackState = $fallbackStatus->getState();
+
+        if (!empty($fallbackState)) {
+            $order->setState($fallbackState);
+            $this->adyenLogger->addAdyenNotification(
+                'State set via fallback to ' . $fallbackState
+                . ' (status "' . $status . '" not mapped to preferred states: '
+                . json_encode($possibleStates) . ')',
+                array_merge(
+                    $this->adyenLogger->getOrderContext($order),
+                    ['pspReference' => $order->getPayment()->getData('adyen_psp_reference')]
+                )
+            );
+
+            return $order;
+        }
 
         return $order;
     }


### PR DESCRIPTION
This is the v10 equivalent of #3289 (submitted against main-9).

## What this PR does

Adds a fallback in `Helper/Order.php::setState()` so that when the `$possibleStates` constraint (from `STATE_TRANSITION_MATRIX`) doesn't produce a match, the method falls back to a direct lookup in `sales_order_status_state` for the given status. This prevents the order state from being permanently stuck at its previous value while the status advances.

## Why this is needed

Currently, `setState()` iterates `$possibleStates` and if no match is found, it logs a notification and **returns without changing the state**. Meanwhile, the status was already updated by the caller (`addStatusHistoryComment` calls `setStatus()` internally). This leaves the order with a mismatched state/status that never gets corrected.

On our production instance, this resulted in **63,805 orders** with `state=pending_payment` + `status=complete/closed` since 2021. The code is identical in v9.20.13 and v10.10.0.

## How it works

After the existing `$possibleStates` loop fails, the fix does a direct lookup in `sales_order_status_state`:

```php
$fallbackStatus = $this->orderStatusCollectionFactory->create()
    ->addFieldToFilter('main_table.status', $status)
    ->joinStates()
    ->getFirstItem();

if ($fallbackStatus->getState()) {
    $order->setState($fallbackStatus->getState());
    return $order;
}
```

The preferred `STATE_TRANSITION_MATRIX` states are still tried first. The fallback only activates when no preferred match is found.

## Related

- Fixes #3288
- v9 PR: #3289
- Related: #1767, #2097, #3269