### PR TITLE
[ECP-9943] Fix installment data loss during GraphQL placeOrder

### DIFF
--- a/Observer/AdyenCcDataAssignObserver.php
+++ b/Observer/AdyenCcDataAssignObserver.php
@@ -99,11 +99,6 @@ class AdyenCcDataAssignObserver extends AbstractDataAssignObserver
         $data = $this->readDataArgument($observer);
         $paymentInfo = $this->readPaymentModelArgument($observer);
 
-        // Remove the following information from the previous payment
-        $paymentInfo->unsAdditionalInformation(self::CC_TYPE);
-        $paymentInfo->unsAdditionalInformation(self::NUMBER_OF_INSTALLMENTS);
-        $paymentInfo->unsAdditionalInformation(self::COMBO_CARD_TYPE);
-
         // Get additional data array
         $additionalData = $data->getData(PaymentInterface::KEY_ADDITIONAL_DATA);
         if (!is_array($additionalData)) {
@@ -115,6 +110,16 @@ class AdyenCcDataAssignObserver extends AbstractDataAssignObserver
             $additionalData,
             self::$approvedAdditionalDataKeys
         );
+
+        // Remove each CC-specific field from the previous payment only if the incoming
+        // data contains a replacement for that specific field. This prevents the placeOrder
+        // mutation from clearing data that was set by setPaymentMethodOnCart.
+        $ccSpecificKeys = [self::CC_TYPE, self::NUMBER_OF_INSTALLMENTS, self::COMBO_CARD_TYPE];
+        foreach ($ccSpecificKeys as $ccKey) {
+            if (array_key_exists($ccKey, $additionalData)) {
+                $paymentInfo->unsAdditionalInformation($ccKey);
+            }
+        }
 
         // JSON decode state data from the frontend or fetch it from the DB entity with the quote ID
         if (!empty($additionalData[self::STATE_DATA])) {


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
This PR fixes an issue in GraphQL headless checkout where the placeOrder mutation re-triggers AdyenCcDataAssignObserver without the original additional payment data, causing fields like number_of_installments to be cleared.

Fixes  https://github.com/Adyen/adyen-magento2/issues/2346
