### PR TITLE
[ECP-9944] Add cron to clean up stale adyen_payment_response rows

### DIFF
--- a/Api/Data/PaymentResponseInterface.php
+++ b/Api/Data/PaymentResponseInterface.php
@@ -17,10 +17,13 @@ interface PaymentResponseInterface
     /**
      * Constants for keys of data array. Identical to the name of the getter in snake case.
      */
+    const TABLE_NAME = 'adyen_payment_response';
+    const TABLE_NAME_ALIAS = 'payment_response';
     const ENTITY_ID = 'entity_id';
     const MERCHANT_REFERENCE = 'merchant_reference';
     const RESULT_CODE = 'result_code';
     const RESPONSE = 'response';
+    const CREATED_AT = 'created_at';
 
     public function getEntityId();
 

--- a/Cron/PaymentResponseCleanUp.php
+++ b/Cron/PaymentResponseCleanUp.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2026 Adyen N.V. (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\Payment\Cron;
+
+use Adyen\Payment\Helper\Config;
+use Adyen\Payment\Logger\AdyenLogger;
+use Adyen\Payment\Model\ResourceModel\PaymentResponse as PaymentResponseResourceModel;
+use Adyen\Payment\Model\ResourceModel\PaymentResponse\CollectionFactory as PaymentResponseCollectionFactory;
+use Exception;
+
+/**
+ * Cleans up stale rows from the `adyen_payment_response` table.
+ *
+ * The table stores the raw /payments API response and is only consumed by the
+ * multishipping success page to resume pending action components. Once an order
+ * is finalized (complete, closed or canceled) or is orphaned (older than the
+ * grace period with no associated Magento order), the row is safe to delete.
+ *
+ * Feature is OFF by default and gated by `payment/adyen_abstract/clean_adyen_payment_response`.
+ */
+class PaymentResponseCleanUp
+{
+    /**
+     * Maximum number of rows processed per step per cron run.
+     */
+    const BATCH_SIZE = 1000;
+
+    /**
+     * Grace period (in days) before an orphan row becomes eligible for deletion.
+     */
+    const ORPHAN_GRACE_DAYS = 1;
+
+    /**
+     * @param PaymentResponseCollectionFactory $paymentResponseCollectionFactory
+     * @param PaymentResponseResourceModel $paymentResponseResourceModel
+     * @param Config $configHelper
+     * @param AdyenLogger $adyenLogger
+     */
+    public function __construct(
+        private readonly PaymentResponseCollectionFactory $paymentResponseCollectionFactory,
+        private readonly PaymentResponseResourceModel $paymentResponseResourceModel,
+        private readonly Config $configHelper,
+        private readonly AdyenLogger $adyenLogger
+    ) { }
+
+    /**
+     * @return void
+     */
+    public function execute(): void
+    {
+        if (!$this->configHelper->getIsPaymentResponseCleanupEnabled()) {
+            $this->adyenLogger->addAdyenDebug(
+                'Adyen payment response cleanup feature is disabled. The cronjob has been skipped!'
+            );
+            return;
+        }
+
+        $finalizedRemoved = $this->deleteBatch(
+            'finalized',
+            fn (): array => $this->paymentResponseCollectionFactory->create()
+                ->getFinalizedPaymentResponseIds(self::BATCH_SIZE)
+        );
+
+        $orphanRemoved = $this->deleteBatch(
+            'orphan',
+            fn (): array => $this->paymentResponseCollectionFactory->create()
+                ->getOrphanPaymentResponseIds(self::ORPHAN_GRACE_DAYS, self::BATCH_SIZE)
+        );
+
+        $totalRemoved = $finalizedRemoved + $orphanRemoved;
+
+        if ($totalRemoved > 0) {
+            $this->adyenLogger->addAdyenNotification(
+                (string) __(
+                    '%1 Adyen payment response row(s) have been removed by the PaymentResponseCleanUp cronjob (%2 finalized, %3 orphan).',
+                    $totalRemoved,
+                    $finalizedRemoved,
+                    $orphanRemoved
+                )
+            );
+        } else {
+            $this->adyenLogger->addAdyenDebug(
+                'There are no Adyen payment response rows to be removed by PaymentResponseCleanUp cronjob.'
+            );
+        }
+    }
+
+    /**
+     * Fetches a batch of IDs via the supplied provider and deletes them in a single query.
+     *
+     * @param string $stepName Used only for error logging.
+     * @param callable $idProvider Returns the array of `entity_id`s to delete.
+     * @return int Number of rows removed in this step (0 on failure).
+     */
+    private function deleteBatch(string $stepName, callable $idProvider): int
+    {
+        try {
+            $ids = $idProvider();
+        } catch (Exception $e) {
+            $this->adyenLogger->error(
+                (string) __(
+                    'PaymentResponseCleanUp (%1): failed to fetch ids for deletion. %2',
+                    $stepName,
+                    $e->getMessage()
+                )
+            );
+            return 0;
+        }
+
+        if (empty($ids)) {
+            return 0;
+        }
+
+        try {
+            $this->paymentResponseResourceModel->deleteByIds($ids);
+            return count($ids);
+        } catch (Exception $e) {
+            $this->adyenLogger->error(
+                (string) __(
+                    'PaymentResponseCleanUp (%1): an error occurred while deleting payment responses. %2',
+                    $stepName,
+                    $e->getMessage()
+                )
+            );
+            return 0;
+        }
+    }
+}

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -63,6 +63,7 @@ class Config
     const XML_THREEDS_FLOW = 'threeds_flow';
     const XML_REMOVE_PROCESSED_WEBHOOKS = 'remove_processed_webhooks';
     const XML_PROCESSED_WEBHOOK_REMOVAL_TIME = 'processed_webhook_removal_time';
+    const XML_CLEAN_ADYEN_PAYMENT_RESPONSE = 'clean_adyen_payment_response';
     const XML_PLATFORM_INTEGRATOR = 'platform_integrator';
     const XML_HAS_PLATFORM_INTEGRATOR = 'has_platform_integrator';
     const XML_OUTSIDE_CHECKOUT_DATA_COLLECTION = 'outside_checkout_data_collection';
@@ -612,6 +613,24 @@ class Config
             self::XML_PROCESSED_WEBHOOK_REMOVAL_TIME,
             self::XML_ADYEN_ABSTRACT_PREFIX,
             null
+        );
+    }
+
+    /**
+     * Indicates whether the adyen_payment_response cleanup cronjob is enabled.
+     *
+     * This field can only be configured on default scope level as the
+     * adyen_payment_response table has no relation with the stores.
+     *
+     * @return bool
+     */
+    public function getIsPaymentResponseCleanupEnabled(): bool
+    {
+        return (bool) $this->getConfigData(
+            self::XML_CLEAN_ADYEN_PAYMENT_RESPONSE,
+            self::XML_ADYEN_ABSTRACT_PREFIX,
+            null,
+            true
         );
     }
 

--- a/Model/ResourceModel/PaymentResponse.php
+++ b/Model/ResourceModel/PaymentResponse.php
@@ -12,6 +12,8 @@
 
 namespace Adyen\Payment\Model\ResourceModel;
 
+use Adyen\Payment\Api\Data\PaymentResponseInterface;
+use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Model\ResourceModel\Db\AbstractDb;
 
 class PaymentResponse extends AbstractDb
@@ -23,6 +25,34 @@ class PaymentResponse extends AbstractDb
      */
     protected function _construct()
     {
-        $this->_init('adyen_payment_response', 'entity_id');
+        $this->_init(PaymentResponseInterface::TABLE_NAME, PaymentResponseInterface::ENTITY_ID);
+    }
+
+    /**
+     * Deletes the rows corresponding to the given `entity_id`s.
+     *
+     * @param array $entityIds
+     * @return void
+     * @throws LocalizedException
+     */
+    public function deleteByIds(array $entityIds): void
+    {
+        if (empty($entityIds)) {
+            return;
+        }
+
+        $connection = $this->getConnection();
+        $select = $connection->select()
+            ->from([PaymentResponseInterface::TABLE_NAME_ALIAS => $this->getMainTable()])
+            ->where(
+                sprintf(
+                    '%s.%s IN (?)',
+                    PaymentResponseInterface::TABLE_NAME_ALIAS,
+                    PaymentResponseInterface::ENTITY_ID
+                ),
+                $entityIds
+            );
+
+        $connection->query($select->deleteFromSelect(PaymentResponseInterface::TABLE_NAME_ALIAS));
     }
 }

--- a/Model/ResourceModel/PaymentResponse/Collection.php
+++ b/Model/ResourceModel/PaymentResponse/Collection.php
@@ -12,12 +12,23 @@
 
 namespace Adyen\Payment\Model\ResourceModel\PaymentResponse;
 
+use Adyen\Payment\Api\Data\PaymentResponseInterface;
 use Adyen\Payment\Model\ResourceModel\PaymentResponse as ResourceModel;
 use Adyen\Payment\Model\PaymentResponse;
 use Magento\Framework\Model\ResourceModel\Db\Collection\AbstractCollection;
+use Magento\Sales\Model\Order;
 
 class Collection extends AbstractCollection
 {
+    /**
+     * Order states considered terminal for `adyen_payment_response` cleanup.
+     */
+    const FINALIZED_ORDER_STATES = [
+        Order::STATE_COMPLETE,
+        Order::STATE_CLOSED,
+        Order::STATE_CANCELED
+    ];
+
     public function _construct()
     {
         $this->_init(
@@ -35,5 +46,97 @@ class Collection extends AbstractCollection
     public function getPaymentResponsesWithMerchantReferences($merchantReferences = [])
     {
         return $this->addFieldToFilter('merchant_reference', ["in" => [$merchantReferences]])->getData();
+    }
+
+    /**
+     * Returns the `entity_id`s of payment responses whose associated Magento order has
+     * reached a finalized state (complete, closed or canceled).
+     *
+     * The match is performed via `merchant_reference = sales_order.increment_id`, which
+     * is how `TransactionPayment` stores the Magento order reference on the Adyen
+     * /payments request.
+     *
+     * @param int $batchSize
+     * @return array
+     */
+    public function getFinalizedPaymentResponseIds(int $batchSize): array
+    {
+        $connection = $this->getConnection();
+        $select = $connection->select()
+            ->from(
+                [PaymentResponseInterface::TABLE_NAME_ALIAS => $this->getMainTable()],
+                [PaymentResponseInterface::ENTITY_ID]
+            )
+            ->join(
+                ['so' => $this->getTable('sales_order')],
+                sprintf(
+                    '%s.%s = so.increment_id',
+                    PaymentResponseInterface::TABLE_NAME_ALIAS,
+                    PaymentResponseInterface::MERCHANT_REFERENCE
+                ),
+                []
+            )
+            ->where('so.state IN (?)', self::FINALIZED_ORDER_STATES)
+            ->order(
+                sprintf(
+                    '%s.%s ASC',
+                    PaymentResponseInterface::TABLE_NAME_ALIAS,
+                    PaymentResponseInterface::ENTITY_ID
+                )
+            )
+            ->limit($batchSize);
+
+        return $connection->fetchCol($select);
+    }
+
+    /**
+     * Returns the `entity_id`s of payment responses that have no associated Magento
+     * order and are older than the given grace period in days.
+     *
+     * The grace period guards against deleting rows whose order is still mid-checkout
+     * (e.g. action component not yet resolved).
+     *
+     * @param int $graceDays
+     * @param int $batchSize
+     * @return array
+     */
+    public function getOrphanPaymentResponseIds(int $graceDays, int $batchSize): array
+    {
+        $dateFrom = date('Y-m-d H:i:s', time() - $graceDays * 24 * 60 * 60);
+
+        $connection = $this->getConnection();
+        $select = $connection->select()
+            ->from(
+                [PaymentResponseInterface::TABLE_NAME_ALIAS => $this->getMainTable()],
+                [PaymentResponseInterface::ENTITY_ID]
+            )
+            ->joinLeft(
+                ['so' => $this->getTable('sales_order')],
+                sprintf(
+                    '%s.%s = so.increment_id',
+                    PaymentResponseInterface::TABLE_NAME_ALIAS,
+                    PaymentResponseInterface::MERCHANT_REFERENCE
+                ),
+                []
+            )
+            ->where('so.entity_id IS NULL')
+            ->where(
+                sprintf(
+                    '%s.%s <= ?',
+                    PaymentResponseInterface::TABLE_NAME_ALIAS,
+                    PaymentResponseInterface::CREATED_AT
+                ),
+                $dateFrom
+            )
+            ->order(
+                sprintf(
+                    '%s.%s ASC',
+                    PaymentResponseInterface::TABLE_NAME_ALIAS,
+                    PaymentResponseInterface::ENTITY_ID
+                )
+            )
+            ->limit($batchSize);
+
+        return $connection->fetchCol($select);
     }
 }

--- a/Test/Unit/Cron/PaymentResponseCleanUpTest.php
+++ b/Test/Unit/Cron/PaymentResponseCleanUpTest.php
@@ -1,0 +1,229 @@
+<?php
+/**
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2026 Adyen N.V. (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\Payment\Test\Unit\Cron;
+
+use Adyen\Payment\Cron\PaymentResponseCleanUp;
+use Adyen\Payment\Helper\Config;
+use Adyen\Payment\Logger\AdyenLogger;
+use Adyen\Payment\Model\ResourceModel\PaymentResponse as PaymentResponseResourceModel;
+use Adyen\Payment\Model\ResourceModel\PaymentResponse\Collection as PaymentResponseCollection;
+use Adyen\Payment\Model\ResourceModel\PaymentResponse\CollectionFactory as PaymentResponseCollectionFactory;
+use Adyen\Payment\Test\Unit\AbstractAdyenTestCase;
+use Magento\Framework\DB\Adapter\DeadlockException;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class PaymentResponseCleanUpTest extends AbstractAdyenTestCase
+{
+    protected ?PaymentResponseCleanUp $cron;
+    protected PaymentResponseCollectionFactory|MockObject $collectionFactoryMock;
+    protected PaymentResponseCollection|MockObject $collectionMock;
+    protected PaymentResponseResourceModel|MockObject $resourceModelMock;
+    protected Config|MockObject $configHelperMock;
+    protected AdyenLogger|MockObject $adyenLoggerMock;
+
+    protected function setUp(): void
+    {
+        $this->collectionMock = $this->createMock(PaymentResponseCollection::class);
+        $this->collectionFactoryMock = $this->createGeneratedMock(
+            PaymentResponseCollectionFactory::class,
+            ['create']
+        );
+        $this->collectionFactoryMock->method('create')->willReturn($this->collectionMock);
+
+        $this->resourceModelMock = $this->createMock(PaymentResponseResourceModel::class);
+        $this->configHelperMock = $this->createMock(Config::class);
+        $this->adyenLoggerMock = $this->createMock(AdyenLogger::class);
+
+        $this->cron = new PaymentResponseCleanUp(
+            $this->collectionFactoryMock,
+            $this->resourceModelMock,
+            $this->configHelperMock,
+            $this->adyenLoggerMock
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        $this->cron = null;
+    }
+
+    public function testExecuteConfigDisabled()
+    {
+        $this->configHelperMock->expects($this->once())
+            ->method('getIsPaymentResponseCleanupEnabled')
+            ->willReturn(false);
+
+        $this->collectionMock->expects($this->never())->method('getFinalizedPaymentResponseIds');
+        $this->collectionMock->expects($this->never())->method('getOrphanPaymentResponseIds');
+        $this->resourceModelMock->expects($this->never())->method('deleteByIds');
+
+        $this->adyenLoggerMock->expects($this->once())->method('addAdyenDebug');
+
+        $this->cron->execute();
+    }
+
+    public function testExecuteEnabledWithNoRows()
+    {
+        $this->configHelperMock->expects($this->once())
+            ->method('getIsPaymentResponseCleanupEnabled')
+            ->willReturn(true);
+
+        $this->collectionMock->expects($this->once())
+            ->method('getFinalizedPaymentResponseIds')
+            ->with(PaymentResponseCleanUp::BATCH_SIZE)
+            ->willReturn([]);
+
+        $this->collectionMock->expects($this->once())
+            ->method('getOrphanPaymentResponseIds')
+            ->with(PaymentResponseCleanUp::ORPHAN_GRACE_DAYS, PaymentResponseCleanUp::BATCH_SIZE)
+            ->willReturn([]);
+
+        $this->resourceModelMock->expects($this->never())->method('deleteByIds');
+        $this->adyenLoggerMock->expects($this->once())->method('addAdyenDebug');
+        $this->adyenLoggerMock->expects($this->never())->method('addAdyenNotification');
+
+        $this->cron->execute();
+    }
+
+    public function testExecuteFinalizedOnly()
+    {
+        $finalizedIds = [1, 2, 3];
+
+        $this->configHelperMock->expects($this->once())
+            ->method('getIsPaymentResponseCleanupEnabled')
+            ->willReturn(true);
+
+        $this->collectionMock->expects($this->once())
+            ->method('getFinalizedPaymentResponseIds')
+            ->with(PaymentResponseCleanUp::BATCH_SIZE)
+            ->willReturn($finalizedIds);
+
+        $this->collectionMock->expects($this->once())
+            ->method('getOrphanPaymentResponseIds')
+            ->willReturn([]);
+
+        $this->resourceModelMock->expects($this->once())
+            ->method('deleteByIds')
+            ->with($finalizedIds);
+
+        $this->adyenLoggerMock->expects($this->once())->method('addAdyenNotification');
+
+        $this->cron->execute();
+    }
+
+    public function testExecuteOrphanOnly()
+    {
+        $orphanIds = [10, 20];
+
+        $this->configHelperMock->expects($this->once())
+            ->method('getIsPaymentResponseCleanupEnabled')
+            ->willReturn(true);
+
+        $this->collectionMock->expects($this->once())
+            ->method('getFinalizedPaymentResponseIds')
+            ->willReturn([]);
+
+        $this->collectionMock->expects($this->once())
+            ->method('getOrphanPaymentResponseIds')
+            ->with(PaymentResponseCleanUp::ORPHAN_GRACE_DAYS, PaymentResponseCleanUp::BATCH_SIZE)
+            ->willReturn($orphanIds);
+
+        $this->resourceModelMock->expects($this->once())
+            ->method('deleteByIds')
+            ->with($orphanIds);
+
+        $this->adyenLoggerMock->expects($this->once())->method('addAdyenNotification');
+
+        $this->cron->execute();
+    }
+
+    public function testExecuteFinalizedAndOrphan()
+    {
+        $finalizedIds = [1, 2, 3];
+        $orphanIds = [10, 20];
+
+        $this->configHelperMock->expects($this->once())
+            ->method('getIsPaymentResponseCleanupEnabled')
+            ->willReturn(true);
+
+        $this->collectionMock->expects($this->once())
+            ->method('getFinalizedPaymentResponseIds')
+            ->willReturn($finalizedIds);
+
+        $this->collectionMock->expects($this->once())
+            ->method('getOrphanPaymentResponseIds')
+            ->willReturn($orphanIds);
+
+        $this->resourceModelMock->expects($this->exactly(2))
+            ->method('deleteByIds')
+            ->willReturnCallback(function (array $ids) use ($finalizedIds, $orphanIds) {
+                $this->assertTrue($ids === $finalizedIds || $ids === $orphanIds);
+            });
+
+        $this->adyenLoggerMock->expects($this->once())->method('addAdyenNotification');
+
+        $this->cron->execute();
+    }
+
+    public function testExecuteFinalizedDeletionExceptionDoesNotBlockOrphan()
+    {
+        $finalizedIds = [1, 2, 3];
+        $orphanIds = [10, 20];
+
+        $this->configHelperMock->expects($this->once())
+            ->method('getIsPaymentResponseCleanupEnabled')
+            ->willReturn(true);
+
+        $this->collectionMock->expects($this->once())
+            ->method('getFinalizedPaymentResponseIds')
+            ->willReturn($finalizedIds);
+
+        $this->collectionMock->expects($this->once())
+            ->method('getOrphanPaymentResponseIds')
+            ->willReturn($orphanIds);
+
+        $this->resourceModelMock->expects($this->exactly(2))
+            ->method('deleteByIds')
+            ->willReturnCallback(function (array $ids) use ($finalizedIds) {
+                if ($ids === $finalizedIds) {
+                    throw new DeadlockException();
+                }
+            });
+
+        $this->adyenLoggerMock->expects($this->once())->method('error');
+        // Orphan step still succeeds (2 rows), so we get a success notification.
+        $this->adyenLoggerMock->expects($this->once())->method('addAdyenNotification');
+
+        $this->cron->execute();
+    }
+
+    public function testExecuteProviderExceptionIsLoggedAndSwallowed()
+    {
+        $this->configHelperMock->expects($this->once())
+            ->method('getIsPaymentResponseCleanupEnabled')
+            ->willReturn(true);
+
+        $this->collectionMock->expects($this->once())
+            ->method('getFinalizedPaymentResponseIds')
+            ->willThrowException(new \RuntimeException('boom'));
+
+        $this->collectionMock->expects($this->once())
+            ->method('getOrphanPaymentResponseIds')
+            ->willReturn([]);
+
+        $this->resourceModelMock->expects($this->never())->method('deleteByIds');
+        $this->adyenLoggerMock->expects($this->once())->method('error');
+        $this->adyenLoggerMock->expects($this->once())->method('addAdyenDebug');
+
+        $this->cron->execute();
+    }
+}

--- a/Test/Unit/Helper/ConfigTest.php
+++ b/Test/Unit/Helper/ConfigTest.php
@@ -208,6 +208,23 @@ class ConfigTest extends AbstractAdyenTestCase
         $this->assertEquals(90, $result);
     }
 
+    public function testGetIsPaymentResponseCleanupEnabled()
+    {
+        $path = sprintf(
+            "%s/%s/%s",
+            Config::XML_PAYMENT_PREFIX,
+            Config::XML_ADYEN_ABSTRACT_PREFIX,
+            Config::XML_CLEAN_ADYEN_PAYMENT_RESPONSE
+        );
+
+        $this->scopeConfigMock->expects($this->once())
+            ->method('isSetFlag')
+            ->with($this->equalTo($path), $this->equalTo(ScopeInterface::SCOPE_STORE), $this->equalTo(null))
+            ->willReturn(true);
+
+        $this->assertTrue($this->configHelper->getIsPaymentResponseCleanupEnabled());
+    }
+
     public function testGetHAsPlatformIntegrator()
     {
         $hasPlatformIntegrator = true;

--- a/Test/Unit/Model/ResourceModel/PaymentResponse/CollectionTest.php
+++ b/Test/Unit/Model/ResourceModel/PaymentResponse/CollectionTest.php
@@ -1,0 +1,154 @@
+<?php
+/**
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2026 Adyen N.V. (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\Payment\Test\Unit\Model\ResourceModel\PaymentResponse;
+
+use Adyen\Payment\Model\ResourceModel\PaymentResponse\Collection;
+use Adyen\Payment\Test\Unit\AbstractAdyenTestCase;
+use Magento\Framework\App\ObjectManager;
+use Magento\Framework\Data\Collection\Db\FetchStrategyInterface;
+use Magento\Framework\Data\Collection\EntityFactoryInterface;
+use Magento\Framework\DB\Adapter\AdapterInterface;
+use Magento\Framework\DB\Select;
+use Magento\Framework\Event\ManagerInterface;
+use Magento\Framework\Model\ResourceModel\Db\AbstractDb;
+use Magento\Framework\ObjectManagerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
+
+class CollectionTest extends AbstractAdyenTestCase
+{
+    protected ?Collection $collection;
+    protected EntityFactoryInterface|MockObject $entityFactoryMock;
+    protected LoggerInterface|MockObject $loggerMock;
+    protected FetchStrategyInterface|MockObject $fetchStrategyMock;
+    protected ManagerInterface|MockObject $eventManagerMock;
+    protected AdapterInterface|MockObject $connectionMock;
+    protected AbstractDb|MockObject $resourceMock;
+    protected Select|MockObject $selectMock;
+
+    protected function setUp(): void
+    {
+        $objectManagerMock = $this->createMock(ObjectManagerInterface::class);
+        ObjectManager::setInstance($objectManagerMock);
+
+        $this->entityFactoryMock = $this->createMock(EntityFactoryInterface::class);
+        $this->loggerMock = $this->createMock(LoggerInterface::class);
+        $this->fetchStrategyMock = $this->createMock(FetchStrategyInterface::class);
+        $this->eventManagerMock = $this->createMock(ManagerInterface::class);
+        $this->connectionMock = $this->createMock(AdapterInterface::class);
+        $this->resourceMock = $this->createMock(AbstractDb::class);
+
+        $this->selectMock = $this->createMock(Select::class);
+        $this->selectMock->method('from')->willReturnSelf();
+        $this->selectMock->method('join')->willReturnSelf();
+        $this->selectMock->method('joinLeft')->willReturnSelf();
+        $this->selectMock->method('where')->willReturnSelf();
+        $this->selectMock->method('order')->willReturnSelf();
+        $this->selectMock->method('limit')->willReturnSelf();
+
+        $this->connectionMock->method('select')->willReturn($this->selectMock);
+
+        $this->resourceMock->method('getConnection')->willReturn($this->connectionMock);
+        $this->resourceMock->method('getMainTable')->willReturn('adyen_payment_response');
+        $this->resourceMock->method('getTable')->willReturnCallback(
+            fn (string $table) => $table
+        );
+
+        $this->collection = new Collection(
+            $this->entityFactoryMock,
+            $this->loggerMock,
+            $this->fetchStrategyMock,
+            $this->eventManagerMock,
+            $this->connectionMock,
+            $this->resourceMock
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        $this->collection = null;
+    }
+
+    public function testGetFinalizedPaymentResponseIdsReturnsEntityIds()
+    {
+        $expectedIds = ['1', '2', '3'];
+
+        $this->selectMock->expects($this->once())
+            ->method('join')
+            ->with(
+                $this->equalTo(['so' => 'sales_order']),
+                $this->stringContains('payment_response.merchant_reference = so.increment_id'),
+                $this->equalTo([])
+            )
+            ->willReturnSelf();
+
+        $this->selectMock->expects($this->atLeastOnce())
+            ->method('where')
+            ->willReturnSelf();
+
+        $this->selectMock->expects($this->once())
+            ->method('limit')
+            ->with(500)
+            ->willReturnSelf();
+
+        $this->connectionMock->expects($this->once())
+            ->method('fetchCol')
+            ->with($this->selectMock)
+            ->willReturn($expectedIds);
+
+        $this->assertSame($expectedIds, $this->collection->getFinalizedPaymentResponseIds(500));
+    }
+
+    public function testGetFinalizedPaymentResponseIdsReturnsEmptyArray()
+    {
+        $this->connectionMock->expects($this->once())
+            ->method('fetchCol')
+            ->willReturn([]);
+
+        $this->assertSame([], $this->collection->getFinalizedPaymentResponseIds(1000));
+    }
+
+    public function testGetOrphanPaymentResponseIdsReturnsEntityIds()
+    {
+        $expectedIds = ['10', '20'];
+
+        $this->selectMock->expects($this->once())
+            ->method('joinLeft')
+            ->with(
+                $this->equalTo(['so' => 'sales_order']),
+                $this->stringContains('payment_response.merchant_reference = so.increment_id'),
+                $this->equalTo([])
+            )
+            ->willReturnSelf();
+
+        $this->selectMock->expects($this->once())
+            ->method('limit')
+            ->with(1000)
+            ->willReturnSelf();
+
+        $this->connectionMock->expects($this->once())
+            ->method('fetchCol')
+            ->with($this->selectMock)
+            ->willReturn($expectedIds);
+
+        $this->assertSame($expectedIds, $this->collection->getOrphanPaymentResponseIds(1, 1000));
+    }
+
+    public function testGetOrphanPaymentResponseIdsReturnsEmptyArray()
+    {
+        $this->connectionMock->expects($this->once())
+            ->method('fetchCol')
+            ->willReturn([]);
+
+        $this->assertSame([], $this->collection->getOrphanPaymentResponseIds(1, 1000));
+    }
+}

--- a/Test/Unit/Model/ResourceModel/PaymentResponseTest.php
+++ b/Test/Unit/Model/ResourceModel/PaymentResponseTest.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2026 Adyen N.V. (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\Payment\Test\Unit\Model\ResourceModel;
+
+use Adyen\Payment\Model\ResourceModel\PaymentResponse;
+use Adyen\Payment\Test\Unit\AbstractAdyenTestCase;
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\DB\Adapter\AdapterInterface;
+use Magento\Framework\DB\Select;
+use Magento\Framework\Model\ResourceModel\Db\Context;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class PaymentResponseTest extends AbstractAdyenTestCase
+{
+    protected ?PaymentResponse $paymentResponseResourceModel;
+    protected Context|MockObject $contextMock;
+    protected AdapterInterface|MockObject $connectionMock;
+
+    protected function setUp(): void
+    {
+        $this->connectionMock = $this->createMock(AdapterInterface::class);
+
+        $resourceMock = $this->createMock(ResourceConnection::class);
+        $resourceMock->method('getConnection')->willReturn($this->connectionMock);
+
+        $this->contextMock = $this->createMock(Context::class);
+        $this->contextMock->method('getResources')->willReturn($resourceMock);
+
+        $this->paymentResponseResourceModel = new PaymentResponse($this->contextMock);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->paymentResponseResourceModel = null;
+    }
+
+    public function testDeleteByIds()
+    {
+        $entityIds = [1, 2, 3];
+        $mockQuery = 'DELETE FROM adyen_payment_response WHERE entity_id IN (1, 2, 3)';
+
+        $select = $this->createMock(Select::class);
+        $select->method('from')->willReturnSelf();
+        $select->expects($this->once())
+            ->method('where')
+            ->with('payment_response.entity_id IN (?)', $entityIds)
+            ->willReturnSelf();
+
+        $select->expects($this->once())
+            ->method('deleteFromSelect')
+            ->with('payment_response')
+            ->willReturn($mockQuery);
+
+        $this->connectionMock->expects($this->once())->method('select')->willReturn($select);
+        $this->connectionMock->expects($this->once())->method('query')->with($mockQuery);
+
+        $this->paymentResponseResourceModel->deleteByIds($entityIds);
+    }
+
+    public function testDeleteByIdsWithEmptyInput()
+    {
+        $this->connectionMock->expects($this->never())->method('select');
+        $this->connectionMock->expects($this->never())->method('query');
+
+        $this->paymentResponseResourceModel->deleteByIds([]);
+    }
+}

--- a/etc/adminhtml/system/adyen_testing_performance.xml
+++ b/etc/adminhtml/system/adyen_testing_performance.xml
@@ -92,5 +92,13 @@
                 Enables application reliability metrics data collection and submission to Adyen for performance analysis purpose.
             </tooltip>
         </field>
+        <field id="clean_adyen_payment_response" translate="label" type="select" sortOrder="90" showInDefault="1" showInWebsite="0" showInStore="0">
+            <label>Clean-up Adyen payment response data</label>
+            <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+            <config_path>payment/adyen_abstract/clean_adyen_payment_response</config_path>
+            <tooltip>
+                When enabled, a nightly cronjob removes stale rows from the `adyen_payment_response` table once the order is finalized (complete, closed or canceled) or is orphaned (older than 1 day with no associated order).
+            </tooltip>
+        </field>
     </group>
 </include>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -37,6 +37,7 @@
                 <allow_multistore_tokens>1</allow_multistore_tokens>
                 <remove_processed_webhooks>0</remove_processed_webhooks>
                 <processed_webhook_removal_time>90</processed_webhook_removal_time>
+                <clean_adyen_payment_response>0</clean_adyen_payment_response>
                 <reliability_data_collection>0</reliability_data_collection>
                 <outside_checkout_data_collection>0</outside_checkout_data_collection>
                 <ignore_expire_webhook>1</ignore_expire_webhook>

--- a/etc/crontab.xml
+++ b/etc/crontab.xml
@@ -33,5 +33,8 @@
         <job name="adyen_payment_clean_up_analytics_events" instance="Adyen\Payment\Cron\AnalyticsEventsCleanUp" method="execute">
             <schedule>*/5 * * * *</schedule>
         </job>
+        <job name="adyen_payment_response_clean_up" instance="Adyen\Payment\Cron\PaymentResponseCleanUp" method="execute">
+            <schedule>*/5 0 * * *</schedule>
+        </job>
     </group>
 </config>

--- a/etc/db_schema.xml
+++ b/etc/db_schema.xml
@@ -105,11 +105,15 @@
     <column xsi:type="varchar" name="merchant_reference" nullable="true" length="255" comment="Merchant reference ID"/>
     <column xsi:type="text" name="result_code" nullable="true" comment="Payment Response Result Code"/>
     <column xsi:type="text" name="response" nullable="true" comment="Payment Response"/>
+    <column xsi:type="timestamp" name="created_at" on_update="false" nullable="false" default="CURRENT_TIMESTAMP" comment="Created at"/>
     <constraint xsi:type="primary" referenceId="PRIMARY">
       <column name="entity_id"/>
     </constraint>
     <index referenceId="ADYEN_PAYMENT_RESPONSE_MERCHANT_REFERENCE" indexType="btree">
       <column name="merchant_reference"/>
+    </index>
+    <index referenceId="ADYEN_PAYMENT_RESPONSE_CREATED_AT" indexType="btree">
+      <column name="created_at"/>
     </index>
   </table>
   <table name="adyen_creditmemo" resource="default" engine="innodb" comment="Adyen Creditmemo">

--- a/etc/db_schema_whitelist.json
+++ b/etc/db_schema_whitelist.json
@@ -105,13 +105,15 @@
             "entity_id": true,
             "merchant_reference": true,
             "result_code": true,
-            "response": true
+            "response": true,
+            "created_at": true
         },
         "constraint": {
             "PRIMARY": true
         },
         "index": {
-            "ADYEN_PAYMENT_RESPONSE_MERCHANT_REFERENCE": true
+            "ADYEN_PAYMENT_RESPONSE_MERCHANT_REFERENCE": true,
+            "ADYEN_PAYMENT_RESPONSE_CREATED_AT": true
         }
     },
     "adyen_analytics_event": {


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
This PR introduces an opt-in nightly cron job that removes stale rows from adyen_payment_response. Once the order is finalized or orphaned, it is safe to drop these records.


Fixes  https://github.com/Adyen/adyen-magento2/issues/2578
