### PR TITLE
Fix fetching proper configuration

### DIFF
--- a/Controller/Return/Index.php
+++ b/Controller/Return/Index.php
@@ -102,7 +102,7 @@ class Index extends Action
                 $successPath = $failPath = 'multishipping/checkout/success';
                 $setQuoteAsActive = true;
             } else {
-                $storeId = $this->getOrder()->getStoreId() !== $storeId ? $this->getOrder()->getStoreId() : $storeId;
+                $storeId = $this->getOrder()->getStoreId();
                 $successPath = $this->configHelper->getAdyenAbstractConfigData('custom_success_redirect_path', $storeId) ??
                     'checkout/onepage/success';
                 $failPath = $this->configHelper->getAdyenAbstractConfigData('return_path', $storeId);
@@ -114,7 +114,7 @@ class Index extends Action
                 $quote->setIsActive($setQuoteAsActive);
                 $this->cartRepository->save($quote);
 
-                $storeId = $quote->getStoreId() !== $storeId ? $quote->getStoreId() : $storeId;
+                $storeId = $quote->getStoreId();
                 // Add OrderIncrementId to redirect parameters for headless support.
                 $redirectParams = $this->configHelper->getAdyenAbstractConfigData('custom_success_redirect_path', $storeId)
                     ? ['_query' => ['order_increment_id' => $this->order->getIncrementId()]]

--- a/Controller/Return/Index.php
+++ b/Controller/Return/Index.php
@@ -102,6 +102,7 @@ class Index extends Action
                 $successPath = $failPath = 'multishipping/checkout/success';
                 $setQuoteAsActive = true;
             } else {
+                $storeId = $this->getOrder()->getStoreId() !== $storeId ? $this->getOrder()->getStoreId() : $storeId;
                 $successPath = $this->configHelper->getAdyenAbstractConfigData('custom_success_redirect_path', $storeId) ??
                     'checkout/onepage/success';
                 $failPath = $this->configHelper->getAdyenAbstractConfigData('return_path', $storeId);
@@ -113,6 +114,7 @@ class Index extends Action
                 $quote->setIsActive($setQuoteAsActive);
                 $this->cartRepository->save($quote);
 
+                $storeId = $quote->getStoreId() !== $storeId ? $quote->getStoreId() : $storeId;
                 // Add OrderIncrementId to redirect parameters for headless support.
                 $redirectParams = $this->configHelper->getAdyenAbstractConfigData('custom_success_redirect_path', $storeId)
                     ? ['_query' => ['order_increment_id' => $this->order->getIncrementId()]]


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
Fix redirect configuration being fetched from the wrong store when the current store context differs from the order's store.                                                                                                           
                                                                                                                                                                                                                                         
  The $storeId was initialized from $this->storeManager->getStore()->getId(), which reflects the current store context at the time of the return request — not necessarily the store the order was placed on. In multi-store setups (e.g.
   different store views per language/region), this caused custom_success_redirect_path and return_path to be read from the wrong store's configuration.                                                                                 
                                                                                                                                                                                                                                         
  Two corrections applied in Controller/Return/Index.php:                                                                                                                                                                              
  1. Before reading success/fail paths — override $storeId with the order's store if they differ.
  2. Before checking custom_success_redirect_path for redirect params — override $storeId with the quote's store if they differ. 

**Tested scenarios**
  - Single-store setup: redirect paths resolve correctly as before                                                                                                                                                                       
  - Multi-store setup: return from Adyen redirect payment uses correct store's custom_success_redirect_path and return_path configuration
  - Verified no regression on standard checkout success redirect                                                                                                                                                                         
  - Unit tests passing: vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/     

Fixes  <!-- #-prefixed github issue number -->
https://github.com/Adyen/adyen-magento2/issues/3299
