### PR TITLE
[ECP-9949-V9] Fix TWINT tokenization

### DIFF
--- a/etc/config.xml
+++ b/etc/config.xml
@@ -1721,7 +1721,7 @@
                 <supports_recurring>1</supports_recurring>
                 <supports_manual_capture>1</supports_manual_capture>
                 <supports_auto_capture>1</supports_auto_capture>
-                <is_wallet>1</is_wallet>
+                <is_wallet>0</is_wallet>
                 <group>adyen-alternative-payment-method</group>
             </adyen_twint>
             <adyen_twint_vault>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -1728,8 +1728,8 @@
                 <title>Stored TWINT</title>
                 <model>AdyenPaymentTwintVaultFacade</model>
                 <instant_purchase>
-                    <available>Adyen\Payment\Model\InstantPurchase\Card\AvailabilityChecker</available>
-                    <tokenFormat>Adyen\Payment\Model\InstantPurchase\Card\TokenFormatter</tokenFormat>
+                    <available>Adyen\Payment\Model\InstantPurchase\PaymentMethods\AvailabilityChecker</available>
+                    <tokenFormat>Adyen\Payment\Model\InstantPurchase\PaymentMethods\TokenFormatter</tokenFormat>
                 </instant_purchase>
             </adyen_twint_vault>
             <adyen_walley>

--- a/etc/frontend/di.xml
+++ b/etc/frontend/di.xml
@@ -168,7 +168,7 @@
                 <item name="adyen_klarna_paynow" xsi:type="object">Adyen\Payment\Model\Ui\PaymentMethodTokenUiComponentProvider</item>
                 <item name="adyen_paybybank" xsi:type="object">Adyen\Payment\Model\Ui\PaymentMethodTokenUiComponentProvider</item>
                 <item name="adyen_trustly" xsi:type="object">Adyen\Payment\Model\Ui\PaymentMethodTokenUiComponentProvider</item>
-                <item name="adyen_twint" xsi:type="object">Adyen\Payment\Model\Ui\CardTokenUiComponentProvider</item>
+                <item name="adyen_twint" xsi:type="object">Adyen\Payment\Model\Ui\PaymentMethodTokenUiComponentProvider</item>
                 <item name="adyen_zip" xsi:type="object">Adyen\Payment\Model\Ui\CardTokenUiComponentProvider</item>
                 <item name="adyen_gcash" xsi:type="object">Adyen\Payment\Model\Ui\CardTokenUiComponentProvider</item>
                 <item name="adyen_carnet" xsi:type="object">Adyen\Payment\Model\Ui\PaymentMethodTokenUiComponentProvider</item>


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
This PR reclassifies TWINT as a non-wallet payment method to prevent vault token errors caused by missing card-related fields in the Adyen response.

