### PR TITLE
[ECP-9950] Fix CHARGEBACK webhooks failing to create credit memo

### DIFF
--- a/Model/AdyenCreditmemoRepository.php
+++ b/Model/AdyenCreditmemoRepository.php
@@ -103,7 +103,16 @@ class AdyenCreditmemoRepository implements AdyenCreditmemoRepositoryInterface
      */
     public function getByRefundWebhook(NotificationInterface $notification): ?CreditmemoInterface
     {
-        if (!in_array($notification->getEventCode(), [EventCodes::REFUND, EventCodes::CANCEL_OR_REFUND])) {
+        $allowedEventCodes = [
+            EventCodes::REFUND,
+            EventCodes::CANCEL_OR_REFUND,
+            EventCodes::CHARGEBACK,
+            EventCodes::SECOND_CHARGEBACK,
+            EventCodes::NOTIFICATION_OF_CHARGEBACK,
+            EventCodes::CHARGEBACK_REVERSED
+        ];
+
+        if (!in_array($notification->getEventCode(), $allowedEventCodes)) {
             throw new AdyenException(sprintf(
                 'REFUND or CANCEL_OR_REFUND webhook is expected to get the adyen_creditmemo, %s notification given.',
                 $notification->getEventCode()

--- a/Test/Unit/Model/AdyenCreditmemoRepositoryTest.php
+++ b/Test/Unit/Model/AdyenCreditmemoRepositoryTest.php
@@ -205,6 +205,30 @@ class AdyenCreditmemoRepositoryTest extends AbstractAdyenTestCase
                 'isResultValid' => true
             ],
             [
+                'eventCode' => 'CHARGEBACK',
+                'isExpectedType' => true,
+                'creditmemoId' => "",
+                'isResultValid' => false
+            ],
+            [
+                'eventCode' => 'SECOND_CHARGEBACK',
+                'isExpectedType' => true,
+                'creditmemoId' => "",
+                'isResultValid' => false
+            ],
+            [
+                'eventCode' => 'NOTIFICATION_OF_CHARGEBACK',
+                'isExpectedType' => true,
+                'creditmemoId' => "",
+                'isResultValid' => false
+            ],
+            [
+                'eventCode' => 'CHARGEBACK_REVERSED',
+                'isExpectedType' => true,
+                'creditmemoId' => "",
+                'isResultValid' => false
+            ],
+            [
                 'eventCode' => 'CAPTURE',
                 'isExpectedType' => false,
                 'creditmemoId' => "1",


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
This PR updates the AdyenCreditmemoRepository to support chargeback-related webhook event codes, ensuring credit memos are successfully created for chargebacks.

Fixes  https://github.com/Adyen/adyen-magento2/issues/3296
