### PR TITLE
[ECP-9942-V9] Handle dispute webhooks with missing originalReference

### DIFF
--- a/Helper/Order.php
+++ b/Helper/Order.php
@@ -581,6 +581,23 @@ class Order extends AbstractHelper
             ->addFieldToFilter(Notification::PSPREFRENCE, $notification->getOriginalReference())
             ->getFirstItem();
 
+        if (empty($notification->getOriginalReference()) || !$orderPayment->getEntityId()) {
+            $this->adyenLogger->addAdyenWarning(
+                sprintf(
+                    'Skipping refund for notification %s (%s): originalReference is missing or no matching '
+                    . 'adyen_order_payment was found. Configure the webhook to include originalReference.',
+                    $notification->getId(),
+                    $notification->getEventCode()
+                ),
+                array_merge(
+                    $this->adyenLogger->getOrderContext($order),
+                    ['pspReference' => $notification->getPspreference()]
+                )
+            );
+
+            return $order;
+        }
+
         $this->adyenOrderPaymentHelper->refundAdyenOrderPayment($orderPayment, $notification);
         $this->adyenLogger->addAdyenNotification(
             sprintf(

--- a/Test/Unit/Helper/OrderTest.php
+++ b/Test/Unit/Helper/OrderTest.php
@@ -252,6 +252,36 @@ class OrderTest extends AbstractAdyenTestCase
         $orderHelper->refundOrder($order, $notification);
     }
 
+    public function testRefundOrderSkipsWhenOriginalReferenceIsMissing()
+    {
+        $adyenOrderPaymentHelper = $this->createMock(AdyenOrderPayment::class);
+        $adyenOrderPaymentHelper->expects($this->never())->method('refundAdyenOrderPayment');
+
+        $adyenLoggerMock = $this->createMock(AdyenLogger::class);
+        $adyenLoggerMock->method('getOrderContext')->willReturn([]);
+        $adyenLoggerMock->expects($this->once())
+            ->method('addAdyenWarning')
+            ->with($this->stringContains('originalReference is missing'));
+
+        $orderHelper = $this->createOrderHelper(
+            null,
+            null,
+            $adyenOrderPaymentHelper,
+            null,
+            null,
+            $this->createAdyenOrderPaymentCollection(null),
+            null,
+            $adyenLoggerMock
+        );
+
+        $order = $this->createMock(MagentoOrder::class);
+        $notification = $this->createWebhook(null, '123-pspref');
+
+        $result = $orderHelper->refundOrder($order, $notification);
+
+        $this->assertSame($order, $result);
+    }
+
     public function testRefundFailedNotice()
     {
         $notification = $this->createMock(Notification::class);


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
This PR fixes a crash in webhook processing when a `CHARGEBACK_REVERSED` / `SECOND_CHARGEBACK` notification has no `original_reference`. In that case the `adyen_order_payment` lookup returns an empty model and `Payment::getTotalRefunded()` returns `null` against its `: float` return type, throwing a `TypeError`. This guards `Order::refundOrder()` to skip the refund and log a warning when `originalReference` is missing or no matching payment is found, instead of crashing.
