### PR TITLE
[ECP-9955-V9] Add jcb_applepay to manual capture supported payment methods

### DIFF
--- a/Helper/Util/PaymentMethodUtil.php
+++ b/Helper/Util/PaymentMethodUtil.php
@@ -40,6 +40,7 @@ class PaymentMethodUtil
         'discover_applepay',
         'maestro_applepay',
         'cartebancaire_applepay',
+        'jcb_applepay',
         'paywithgoogle',
         'mc_googlepay',
         'visa_googlepay',


### PR DESCRIPTION


<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
Add jcb_applepay to the manual capture allowlist so JCB Apple Pay can be captured.

