### PR TITLE
[ECP-9988] Fix payment method specific capture settings being overridden by global capture mode

### DIFF
--- a/Helper/PaymentMethods.php
+++ b/Helper/PaymentMethods.php
@@ -789,10 +789,9 @@ class PaymentMethods extends AbstractHelper
             );
 
             // Use order payment method to evaluate the capture mode instead of notification payment method for POS
-            if ($order->getPayment()->getMethod() === AdyenPosCloudConfigProvider::CODE &&
-                $captureModePos === CaptureMode::CAPTURE_MODE_MANUAL) {
+            if ($order->getPayment()->getMethod() === AdyenPosCloudConfigProvider::CODE && !empty($captureModePos)) {
                 // Evaluate capture mode of POS payments based on the order's `paymentMethod` field and configuration
-                $isAutoCapture = false;
+                $isAutoCapture = $captureModePos !== CaptureMode::CAPTURE_MODE_MANUAL;
             } else {
                 // Evaluate capture mode of ECOM payments based on the webhook's `paymentMethod` field
 
@@ -811,11 +810,17 @@ class PaymentMethods extends AbstractHelper
                     $webhookMethodInstance = $adyenTxVariant->getMethodInstance();
                     $webhookMethodCode = $webhookMethodInstance->getCode();
 
-                    if (($webhookMethodCode === self::ADYEN_SEPADIRECTDEBIT && $sepaFlow === SepaFlow::SEPA_FLOW_AUTHCAP) ||
-                        ($webhookMethodCode === self::ADYEN_PAYPAL && $isPaypalManualCapture) ||
-                        ($this->isOpenInvoice($webhookMethodInstance) && !$autoCaptureOpenInvoice) ||
-                        ($captureMode === CaptureMode::CAPTURE_MODE_MANUAL)
-                    ) {
+                    /*
+                     * Payment method specific settings take precedence over the global capture mode setting.
+                     * The global capture mode is only applied if no method specific setting is available.
+                     */
+                    if ($webhookMethodCode === self::ADYEN_SEPADIRECTDEBIT) {
+                        $isAutoCapture = $sepaFlow !== SepaFlow::SEPA_FLOW_AUTHCAP;
+                    } elseif ($webhookMethodCode === self::ADYEN_PAYPAL) {
+                        $isAutoCapture = !$isPaypalManualCapture;
+                    } elseif ($this->isOpenInvoice($webhookMethodInstance)) {
+                        $isAutoCapture = $autoCaptureOpenInvoice;
+                    } elseif ($captureMode === CaptureMode::CAPTURE_MODE_MANUAL) {
                         $isAutoCapture = false;
                     }
                 } else {
@@ -825,6 +830,18 @@ class PaymentMethods extends AbstractHelper
                 }
             }
         }
+
+        $this->adyenLogger->addAdyenNotification(
+            sprintf(
+                'Capture mode of the webhook payment method %s is resolved as %s.',
+                $notificationPaymentMethod,
+                $isAutoCapture ? 'auto capture' : 'manual capture'
+            ),
+            [
+                'merchantReference' => $order->getIncrementId(),
+                'orderPaymentMethod' => $order->getPayment()->getMethod()
+            ]
+        );
 
         return $isAutoCapture;
     }

--- a/Test/Unit/Helper/PaymentMethodsTest.php
+++ b/Test/Unit/Helper/PaymentMethodsTest.php
@@ -8,10 +8,14 @@ use Adyen\Client;
 use Adyen\Payment\Logger\AdyenLogger;
 use Adyen\Payment\Helper\{ChargedCurrency, Config, Data, Locale, PaymentMethods, PlatformInfo};
 use Adyen\Payment\Model\{AdyenAmountCurrency,
+    Config\Source\CaptureMode,
+    Config\Source\SepaFlow,
+    Method\TxVariant,
     Method\TxVariantFactory,
     Notification,
     Ui\Adminhtml\AdyenMotoConfigProvider,
-    Ui\AdyenPayByLinkConfigProvider};
+    Ui\AdyenPayByLinkConfigProvider,
+    Ui\AdyenPosCloudConfigProvider};
 use Adyen\Payment\Test\Unit\AbstractAdyenTestCase;
 use Magento\Framework\Api\SearchCriteriaBuilder;
 use Magento\Framework\App\Helper\Context;
@@ -386,43 +390,53 @@ class PaymentMethodsTest extends AbstractAdyenTestCase
      * @dataProvider autoCaptureDataProvider
      */
     public function testIsAutoCapture(
-        $manualCaptureSupported,
-        $captureMode,
-        $sepaFlow,
-        $paymentCode,
-        $autoCaptureOpenInvoice,
-        $manualCapturePayPal,
-        $expectedResult
+        string $webhookPaymentMethod,
+        ?string $webhookMethodCode,
+        bool $isOpenInvoice,
+        ?string $captureMode,
+        ?string $sepaFlow,
+        bool $isPaypalManualCapture,
+        bool $autoCaptureOpenInvoice,
+        string $orderMethodCode,
+        ?string $captureModePos,
+        bool $expectedResult
     ) {
-        $paymentMethodInstanceMock = $this->createMock(MethodInterface::class);
-
-        $this->orderPaymentMock->method('getMethodInstance')->willReturn($paymentMethodInstanceMock);
-
         $this->orderMock->method('getStoreId')->willReturn(1);
         $this->orderMock->method('getPayment')->willReturn($this->orderPaymentMock);
+        $this->orderPaymentMock->method('getMethod')->willReturn($orderMethodCode);
 
-        $this->configHelper->method('getConfigData')->willReturnMap([
-            ['capture_mode', 'adyen_abstract', '1', false, $captureMode],
-            ['sepa_flow', 'adyen_abstract', '1', false, $sepaFlow],
-            ['paypal_capture_mode', 'adyen_abstract', '1', false, $manualCapturePayPal],
-            [PaymentMethods::CONFIG_FIELD_IS_OPEN_INVOICE, null, null, null]
-        ]);
+        $this->dataHelper->method('getCcTypesAltData')->willReturn(['visa' => ['manual_capture' => 1]]);
 
-        $this->configHelper->expects($this->any())
-            ->method('getAutoCaptureOpenInvoice')
-            ->with( '1')
-            ->willReturn($autoCaptureOpenInvoice);
+        if (isset($webhookMethodCode)) {
+            $webhookMethodInstance = $this->createMock(MethodInterface::class);
+            $webhookMethodInstance->method('getCode')->willReturn($webhookMethodCode);
+            $webhookMethodInstance->method('getConfigData')->willReturnMap([
+                ['supports_manual_capture', null, true],
+                [PaymentMethods::CONFIG_FIELD_IS_OPEN_INVOICE, null, $isOpenInvoice],
+                ['is_wallet', null, false]
+            ]);
 
-        // Configure the mock to return the method name
-        $this->orderPaymentMock->method('getMethod')
-            ->willReturn($paymentCode);
+            $txVariantMock = $this->createMock(TxVariant::class);
+            $txVariantMock->method('getMethodInstance')->willReturn($webhookMethodInstance);
+            $txVariantMock->method('getCard')->willReturn(null);
+        } else {
+            // The tx variant cannot be resolved into a payment method instance.
+            $txVariantMock = null;
+        }
 
-        // Configure the order mock to return the payment mock
-        $this->orderMock->expects($this->any())
-            ->method('getPayment')
-            ->willReturn($this->orderPaymentMock);
+        $this->txVariantFactory->method('create')
+            ->with(['txVariant' => $webhookPaymentMethod])
+            ->willReturn($txVariantMock);
 
-        $result = $this->helper->isAutoCapture($this->orderMock, $paymentCode);
+        $this->configHelper->method('getCaptureMode')->with(1)->willReturn($captureMode);
+        $this->configHelper->method('getSepaFlow')->with(1)->willReturn($sepaFlow);
+        $this->configHelper->method('isPaypalManualCapture')->with(1)->willReturn($isPaypalManualCapture);
+        $this->configHelper->method('getAutoCaptureOpenInvoice')->with(1)->willReturn($autoCaptureOpenInvoice);
+        $this->configHelper->method('getAdyenPosCloudConfigData')
+            ->with('capture_mode_pos', 1)
+            ->willReturn($captureModePos);
+
+        $result = $this->helper->isAutoCapture($this->orderMock, $webhookPaymentMethod);
 
         $this->assertEquals($expectedResult, $result);
     }
@@ -430,14 +444,66 @@ class PaymentMethodsTest extends AbstractAdyenTestCase
     public static function autoCaptureDataProvider(): array
     {
         return [
-            // Manual capture supported, capture mode manual, sepa flow not authcap
-            [true, 'manual', 'notauthcap', 'paypal', true, null, true],
-            // Manual capture supported, capture mode auto
-            [true, 'auto', '', 'sepadirectdebit', true, null, true],
-            // Manual capture supported open invoice
-            [true, 'manual', '', 'klarna', false, null, true],
-            // Manual capture not supported
-            [false, '', '', 'sepadirectdebit', true, null, true]
+            'SEPA sale overrides global manual capture' => [
+                'sepadirectdebit', PaymentMethods::ADYEN_SEPADIRECTDEBIT, false,
+                CaptureMode::CAPTURE_MODE_MANUAL, SepaFlow::SEPA_FLOW_SALE,
+                false, true, PaymentMethods::ADYEN_SEPADIRECTDEBIT, null, true
+            ],
+            'SEPA authcap overrides global auto capture' => [
+                'sepadirectdebit', PaymentMethods::ADYEN_SEPADIRECTDEBIT, false,
+                CaptureMode::CAPTURE_MODE_AUTO, SepaFlow::SEPA_FLOW_AUTHCAP,
+                false, true, PaymentMethods::ADYEN_SEPADIRECTDEBIT, null, false
+            ],
+            'PayPal auto capture overrides global manual capture' => [
+                'paypal', PaymentMethods::ADYEN_PAYPAL, false,
+                CaptureMode::CAPTURE_MODE_MANUAL, SepaFlow::SEPA_FLOW_AUTHCAP,
+                false, true, PaymentMethods::ADYEN_PAYPAL, null, true
+            ],
+            'PayPal manual capture overrides global auto capture' => [
+                'paypal', PaymentMethods::ADYEN_PAYPAL, false,
+                CaptureMode::CAPTURE_MODE_AUTO, SepaFlow::SEPA_FLOW_AUTHCAP,
+                true, true, PaymentMethods::ADYEN_PAYPAL, null, false
+            ],
+            'Open invoice auto capture overrides global manual capture' => [
+                'klarna', 'adyen_klarna', true,
+                CaptureMode::CAPTURE_MODE_MANUAL, SepaFlow::SEPA_FLOW_AUTHCAP,
+                false, true, 'adyen_klarna', null, true
+            ],
+            'Open invoice manual capture overrides global auto capture' => [
+                'klarna', 'adyen_klarna', true,
+                CaptureMode::CAPTURE_MODE_AUTO, SepaFlow::SEPA_FLOW_AUTHCAP,
+                false, false, 'adyen_klarna', null, false
+            ],
+            'Other payment methods follow global manual capture' => [
+                'twint', 'adyen_twint', false,
+                CaptureMode::CAPTURE_MODE_MANUAL, SepaFlow::SEPA_FLOW_AUTHCAP,
+                false, true, 'adyen_twint', null, false
+            ],
+            'Other payment methods follow global auto capture' => [
+                'twint', 'adyen_twint', false,
+                CaptureMode::CAPTURE_MODE_AUTO, SepaFlow::SEPA_FLOW_AUTHCAP,
+                false, true, 'adyen_twint', null, true
+            ],
+            'POS auto capture overrides global manual capture' => [
+                'twint', 'adyen_twint', false,
+                CaptureMode::CAPTURE_MODE_MANUAL, SepaFlow::SEPA_FLOW_AUTHCAP,
+                false, true, AdyenPosCloudConfigProvider::CODE, CaptureMode::CAPTURE_MODE_AUTO, true
+            ],
+            'POS manual capture overrides global auto capture' => [
+                'twint', 'adyen_twint', false,
+                CaptureMode::CAPTURE_MODE_AUTO, SepaFlow::SEPA_FLOW_AUTHCAP,
+                false, true, AdyenPosCloudConfigProvider::CODE, CaptureMode::CAPTURE_MODE_MANUAL, false
+            ],
+            'Unresolved tx variant follows global manual capture' => [
+                'visa', null, false,
+                CaptureMode::CAPTURE_MODE_MANUAL, SepaFlow::SEPA_FLOW_AUTHCAP,
+                false, true, PaymentMethods::ADYEN_CC, null, false
+            ],
+            'Unresolved tx variant follows global auto capture' => [
+                'visa', null, false,
+                CaptureMode::CAPTURE_MODE_AUTO, SepaFlow::SEPA_FLOW_AUTHCAP,
+                false, true, PaymentMethods::ADYEN_CC, null, true
+            ]
         ];
     }
 

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -149,7 +149,7 @@
                 <can_void>1</can_void>
                 <can_cancel>1</can_cancel>
                 <supports_recurring>1</supports_recurring>
-                <supports_manual_capture>1</supports_manual_capture>
+                <supports_manual_capture>0</supports_manual_capture>
                 <is_wallet>0</is_wallet>
                 <group>adyen-alternative-payment-method</group>
             </adyen_ideal>
@@ -719,7 +719,7 @@
                 <can_void>1</can_void>
                 <can_cancel>1</can_cancel>
                 <supports_recurring>0</supports_recurring>
-                <supports_manual_capture>1</supports_manual_capture>
+                <supports_manual_capture>0</supports_manual_capture>
                 <is_wallet>0</is_wallet>
                 <group>adyen-alternative-payment-method</group>
             </adyen_bankTransfer_BE>
@@ -740,7 +740,7 @@
                 <can_void>1</can_void>
                 <can_cancel>1</can_cancel>
                 <supports_recurring>0</supports_recurring>
-                <supports_manual_capture>1</supports_manual_capture>
+                <supports_manual_capture>0</supports_manual_capture>
                 <is_wallet>0</is_wallet>
                 <group>adyen-alternative-payment-method</group>
             </adyen_bankTransfer_CH>
@@ -761,7 +761,7 @@
                 <can_void>1</can_void>
                 <can_cancel>1</can_cancel>
                 <supports_recurring>0</supports_recurring>
-                <supports_manual_capture>1</supports_manual_capture>
+                <supports_manual_capture>0</supports_manual_capture>
                 <is_wallet>0</is_wallet>
                 <group>adyen-alternative-payment-method</group>
             </adyen_bankTransfer_DE>
@@ -782,7 +782,7 @@
                 <can_void>1</can_void>
                 <can_cancel>1</can_cancel>
                 <supports_recurring>0</supports_recurring>
-                <supports_manual_capture>1</supports_manual_capture>
+                <supports_manual_capture>0</supports_manual_capture>
                 <is_wallet>0</is_wallet>
                 <group>adyen-alternative-payment-method</group>
             </adyen_bankTransfer_GB>
@@ -803,7 +803,7 @@
                 <can_void>1</can_void>
                 <can_cancel>1</can_cancel>
                 <supports_recurring>0</supports_recurring>
-                <supports_manual_capture>1</supports_manual_capture>
+                <supports_manual_capture>0</supports_manual_capture>
                 <is_wallet>0</is_wallet>
                 <group>adyen-alternative-payment-method</group>
             </adyen_bankTransfer_IBAN>
@@ -824,7 +824,7 @@
                 <can_void>1</can_void>
                 <can_cancel>1</can_cancel>
                 <supports_recurring>0</supports_recurring>
-                <supports_manual_capture>1</supports_manual_capture>
+                <supports_manual_capture>0</supports_manual_capture>
                 <is_wallet>0</is_wallet>
                 <group>adyen-alternative-payment-method</group>
             </adyen_bankTransfer_NL>
@@ -2147,7 +2147,7 @@
                 <can_void>1</can_void>
                 <can_cancel>1</can_cancel>
                 <supports_recurring>0</supports_recurring>
-                <supports_manual_capture>1</supports_manual_capture>
+                <supports_manual_capture>0</supports_manual_capture>
                 <is_wallet>0</is_wallet>
                 <group>adyen-alternative-payment-method</group>
             </adyen_onlinebanking_IN>
@@ -2189,7 +2189,7 @@
                 <can_void>1</can_void>
                 <can_cancel>1</can_cancel>
                 <supports_recurring>0</supports_recurring>
-                <supports_manual_capture>1</supports_manual_capture>
+                <supports_manual_capture>0</supports_manual_capture>
                 <is_wallet>1</is_wallet>
                 <group>adyen-alternative-payment-method</group>
             </adyen_wallet_IN>
@@ -2210,7 +2210,7 @@
                 <can_void>1</can_void>
                 <can_cancel>1</can_cancel>
                 <supports_recurring>0</supports_recurring>
-                <supports_manual_capture>1</supports_manual_capture>
+                <supports_manual_capture>0</supports_manual_capture>
                 <is_wallet>0</is_wallet>
                 <group>adyen-alternative-payment-method</group>
             </adyen_upi>


### PR DESCRIPTION

<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
This PR fixes two capture-mode issues.

1. global capture mode setting incorrectly overrode payment method specific configurations. Also fixes POS: `capture_mode_pos` is now evaluated whenever it is configured, so POS orders set to Immediate are auto captured even if the global capture mode is manual.
2. Wrong `supports_manual_capture` flags (`etc/config.xml`). Restoring v10 behaviour, where these methods were absent from `MANUAL_CAPTURE_SUPPORTED_PAYMENT_METHODS`.

