### PR TITLE
fix: [Bug]: Trustly orders stuck in payment_review after shipment

### DIFF
--- a/Observer/BeforeShipmentObserver.php
+++ b/Observer/BeforeShipmentObserver.php
@@ -103,6 +103,18 @@ class BeforeShipmentObserver extends AbstractDataAssignObserver
             return;
         }
 
+        $txVariant = $this->paymentMethodsHelper->isAlternativePaymentMethod($paymentMethodInstance)
+            ? $this->paymentMethodsHelper->getAlternativePaymentMethodTxVariant($paymentMethodInstance)
+            : (string) $payment->getCcType();
+
+        if ($this->paymentMethodsHelper->isAutoCapture($order, $txVariant)) {
+            $this->logger->addAdyenInfoLog(
+                "Capture on shipment skipped, payment method is auto-capture for order id {$order->getId()}",
+                ['observer' => 'BeforeShipmentObserver']
+            );
+            return;
+        }
+
         if (!$this->paymentMethodsHelper->isOpenInvoice($paymentMethodInstance)) {
             $this->logger->addAdyenInfoLog(
                 "Payment method is from Adyen but isn't OpenInvoice for order id {$order->getId()}",

--- a/Test/Unit/Observer/BeforeShipmentObserverTest.php
+++ b/Test/Unit/Observer/BeforeShipmentObserverTest.php
@@ -109,6 +109,35 @@ class BeforeShipmentObserverTest extends AbstractAdyenTestCase
         $this->beforeShipmentObserver->execute($this->observerMock);
     }
 
+    public function testAutoCapturePaymentMethodIsNotCapturedOnShipment()
+    {
+        $paymentMethodInstanceMock = $this->createMock(MethodInterface::class);
+
+        $this->paymentMock->method('getMethod')->willReturn('adyen_trustly');
+        $this->paymentMock->method('getMethodInstance')->willReturn($paymentMethodInstanceMock);
+
+        $this->paymentMethodsHelperMock->method('isAdyenPayment')->willReturn(true);
+        $this->paymentMethodsHelperMock->method('isAlternativePaymentMethod')
+            ->with($paymentMethodInstanceMock)
+            ->willReturn(true);
+        $this->paymentMethodsHelperMock->method('getAlternativePaymentMethodTxVariant')
+            ->with($paymentMethodInstanceMock)
+            ->willReturn('trustly');
+        $this->paymentMethodsHelperMock->method('isAutoCapture')
+            ->with($this->orderMock, 'trustly')
+            ->willReturn(true);
+
+        $this->configHelperMock->method('getConfigData')
+            ->with('capture_for_openinvoice', BeforeShipmentObserver::XML_ADYEN_ABSTRACT_PREFIX, 1)
+            ->willReturn(BeforeShipmentObserver::ONSHIPMENT_CAPTURE_OPENINVOICE);
+
+        $this->adyenLoggerMock->expects($this->once())->method('addAdyenInfoLog');
+        $this->paymentMethodsHelperMock->expects($this->never())->method('isOpenInvoice');
+        $this->invoiceRepositoryMock->expects($this->never())->method('save');
+
+        $this->beforeShipmentObserver->execute($this->observerMock);
+    }
+
     public function testNonOpenInvoicePaymentMethod()
     {
         $randomPaymentMethod = 'adyen_klarna';


### PR DESCRIPTION
Fixes #3319

## Root cause

BeforeShipmentObserver requests a manual /captures for auto-capture payment methods

## Changes

- BeforeShipmentObserver now resolves the order's Adyen tx variant and skips the on-shipment online (manual) capture when PaymentMethods::isAutoCapture() reports auto capture for that order, so the observer uses the same source of truth as CaptureWebhookHandler and can no longer create a pending capture that no webhook will ever confirm. Added a unit test covering an auto-capture alternative payment method with capture_for_openinvoice=onshipment.