### PR TITLE
[ECP-9987-v10] Add deviceFingerprint field into /payments request for Visa DCAP support

### DIFF
--- a/Gateway/Request/DeviceFingerprintDataBuilder.php
+++ b/Gateway/Request/DeviceFingerprintDataBuilder.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2026 Adyen N.V. (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\Payment\Gateway\Request;
+
+use Adyen\Payment\Observer\AdyenCcDataAssignObserver;
+use Magento\Payment\Gateway\Data\PaymentDataObject;
+use Magento\Payment\Gateway\Helper\SubjectReader;
+use Magento\Payment\Gateway\Request\BuilderInterface;
+
+class DeviceFingerprintDataBuilder  implements BuilderInterface
+{
+    /**
+     * @param array $buildSubject
+     * @return array[]
+     */
+    public function build(array $buildSubject): array
+    {
+        /** @var PaymentDataObject $paymentDataObject */
+        $paymentDataObject = SubjectReader::readPayment($buildSubject);
+        $payment = $paymentDataObject->getPayment();
+
+        $deviceFingerprint = $payment->getAdditionalInformation(AdyenCcDataAssignObserver::DEVICE_FINGERPRINT);
+        if (!empty($deviceFingerprint)) {
+            $requestBody['deviceFingerprint'] = $deviceFingerprint;
+        }
+
+        return [
+            'body' => $requestBody ?? []
+        ];
+    }
+}

--- a/Observer/AdyenCcDataAssignObserver.php
+++ b/Observer/AdyenCcDataAssignObserver.php
@@ -33,6 +33,7 @@ class AdyenCcDataAssignObserver extends AbstractDataAssignObserver
     const STORE_PAYMENT_METHOD = 'storePaymentMethod';
     const RETURN_URL = 'returnUrl';
     const RECURRING_PROCESSING_MODEL = 'recurringProcessingModel';
+    const DEVICE_FINGERPRINT = 'deviceFingerprint';
 
     /**
      * Approved root level keys from additional data array
@@ -114,7 +115,12 @@ class AdyenCcDataAssignObserver extends AbstractDataAssignObserver
         // Remove each CC-specific field from the previous payment only if the incoming
         // data contains a replacement for that specific field. This prevents the placeOrder
         // mutation from clearing data that was set by setPaymentMethodOnCart.
-        $ccSpecificKeys = [self::CC_TYPE, self::NUMBER_OF_INSTALLMENTS, self::COMBO_CARD_TYPE];
+        $ccSpecificKeys = [
+            self::CC_TYPE,
+            self::NUMBER_OF_INSTALLMENTS,
+            self::COMBO_CARD_TYPE,
+            self::DEVICE_FINGERPRINT
+        ];
         foreach ($ccSpecificKeys as $ccKey) {
             if (array_key_exists($ccKey, $additionalData)) {
                 $paymentInfo->unsAdditionalInformation($ccKey);
@@ -126,6 +132,20 @@ class AdyenCcDataAssignObserver extends AbstractDataAssignObserver
             $stateData = json_decode((string)$additionalData[self::STATE_DATA], true);
         } else {
             $stateData = $this->stateDataCollection->getStateDataArrayWithQuoteId($paymentInfo->getData('quote_id'));
+        }
+
+        // Store deviceFingerprint to be used later for Visa DCAP if the value exists
+        if (isset($stateData['riskData']['clientData'])) {
+            $decodedClientData = base64_decode($stateData['riskData']['clientData']);
+            if ($decodedClientData !== false) {
+                $clientData = json_decode($decodedClientData, true);
+                if (json_last_error() === JSON_ERROR_NONE) {
+                    $paymentInfo->setAdditionalInformation(
+                        self::DEVICE_FINGERPRINT,
+                        $clientData['deviceFingerprint']
+                    );
+                }
+            }
         }
 
         // Get validated state data array

--- a/Test/Unit/Gateway/Request/DeviceFingerprintDataBuilderTest.php
+++ b/Test/Unit/Gateway/Request/DeviceFingerprintDataBuilderTest.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2026 Adyen N.V. (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+declare(strict_types=1);
+
+namespace Adyen\Payment\Test\Unit\Gateway\Request;
+
+use Adyen\Payment\Gateway\Request\DeviceFingerprintDataBuilder;
+use Adyen\Payment\Observer\AdyenCcDataAssignObserver;
+use Adyen\Payment\Test\Unit\AbstractAdyenTestCase;
+use Magento\Payment\Gateway\Data\PaymentDataObject;
+use Magento\Sales\Model\Order\Payment;
+
+class DeviceFingerprintDataBuilderTest extends AbstractAdyenTestCase
+{
+    private ?DeviceFingerprintDataBuilder $deviceFingerprintDataBuilder;
+
+    protected function setUp(): void
+    {
+        $this->deviceFingerprintDataBuilder = new DeviceFingerprintDataBuilder();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->deviceFingerprintDataBuilder = null;
+    }
+
+    public function testBuildAddsDeviceFingerprintWhenAvailable()
+    {
+        $buildSubject = $this->getBuildSubject('fingerprint-123');
+
+        $request = $this->deviceFingerprintDataBuilder->build($buildSubject);
+
+        $this->assertSame(
+            ['body' => ['deviceFingerprint' => 'fingerprint-123']],
+            $request
+        );
+    }
+
+    /**
+     * @dataProvider emptyDeviceFingerprintProvider
+     */
+    public function testBuildReturnsEmptyBodyWhenDeviceFingerprintIsEmpty($deviceFingerprint)
+    {
+        $buildSubject = $this->getBuildSubject($deviceFingerprint);
+
+        $request = $this->deviceFingerprintDataBuilder->build($buildSubject);
+
+        $this->assertSame(['body' => []], $request);
+    }
+
+    public static function emptyDeviceFingerprintProvider(): array
+    {
+        return [
+            'null' => [null],
+            'empty string' => [''],
+            'zero string' => ['0'],
+        ];
+    }
+
+    public function testBuildThrowsExceptionWhenPaymentDataObjectIsMissing()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->deviceFingerprintDataBuilder->build([]);
+    }
+
+    private function getBuildSubject($deviceFingerprint): array
+    {
+        $paymentMock = $this->createMock(Payment::class);
+        $paymentMock->method('getAdditionalInformation')
+            ->with(AdyenCcDataAssignObserver::DEVICE_FINGERPRINT)
+            ->willReturn($deviceFingerprint);
+
+        return [
+            'payment' => $this->createConfiguredMock(PaymentDataObject::class, [
+                'getPayment' => $paymentMock
+            ])
+        ];
+    }
+}

--- a/Test/Unit/Observer/AdyenCcDataAssignObserverTest.php
+++ b/Test/Unit/Observer/AdyenCcDataAssignObserverTest.php
@@ -1,0 +1,434 @@
+<?php
+declare(strict_types=1);
+
+namespace Adyen\Payment\Test\Unit\Observer;
+
+use Adyen\Payment\Gateway\Request\Header\HeaderDataBuilderInterface;
+use Adyen\Payment\Helper\StateData;
+use Adyen\Payment\Helper\Util\CheckoutStateDataValidator;
+use Adyen\Payment\Helper\Vault;
+use Adyen\Payment\Model\ResourceModel\StateData\Collection;
+use Adyen\Payment\Observer\AdyenCcDataAssignObserver;
+use Adyen\Payment\Test\Unit\AbstractAdyenTestCase;
+use Magento\Framework\DataObject;
+use Magento\Framework\Event;
+use Magento\Framework\Event\Observer;
+use Magento\Payment\Observer\AbstractDataAssignObserver;
+use Magento\Quote\Api\Data\PaymentInterface;
+use Magento\Quote\Model\Quote\Payment;
+use Magento\Vault\Api\Data\PaymentTokenInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class AdyenCcDataAssignObserverTest extends AbstractAdyenTestCase
+{
+    const QUOTE_ID = 1;
+
+    private MockObject|CheckoutStateDataValidator $checkoutStateDataValidator;
+    private MockObject|Collection $stateDataCollection;
+    private MockObject|StateData $stateData;
+    private MockObject|Vault $vaultHelper;
+    private MockObject|Payment $paymentInfo;
+    private AdyenCcDataAssignObserver $observer;
+
+    private array $setAdditionalInformationCalls = [];
+    private array $unsAdditionalInformationCalls = [];
+
+    protected function setUp(): void
+    {
+        $this->checkoutStateDataValidator = $this->createMock(CheckoutStateDataValidator::class);
+        $this->stateDataCollection = $this->createMock(Collection::class);
+        $this->stateData = $this->createMock(StateData::class);
+        $this->vaultHelper = $this->createMock(Vault::class);
+
+        $this->paymentInfo = $this->createMockWithMethods(
+            Payment::class,
+            ['setAdditionalInformation', 'unsAdditionalInformation', 'getData'],
+            ['setCcType']
+        );
+        $this->paymentInfo->method('getData')->with('quote_id')->willReturn(self::QUOTE_ID);
+
+        $this->setAdditionalInformationCalls = [];
+        $this->unsAdditionalInformationCalls = [];
+
+        $this->paymentInfo->method('setAdditionalInformation')
+            ->willReturnCallback(function ($key, $value = null) {
+                $this->setAdditionalInformationCalls[$key] = $value;
+                return $this->paymentInfo;
+            });
+
+        $this->paymentInfo->method('unsAdditionalInformation')
+            ->willReturnCallback(function ($key = null) {
+                $this->unsAdditionalInformationCalls[] = $key;
+                return $this->paymentInfo;
+            });
+
+        $this->observer = new AdyenCcDataAssignObserver(
+            $this->checkoutStateDataValidator,
+            $this->stateDataCollection,
+            $this->stateData,
+            $this->vaultHelper
+        );
+    }
+
+    public function testExecuteDoesNothingWhenAdditionalDataIsNotAnArray()
+    {
+        $paymentInfo = $this->createMock(Payment::class);
+        $paymentInfo->expects($this->never())->method('setAdditionalInformation');
+        $paymentInfo->expects($this->never())->method('unsAdditionalInformation');
+        $this->stateDataCollection->expects($this->never())->method('getStateDataArrayWithQuoteId');
+
+        $observer = $this->getPreparedObserver(
+            new DataObject([PaymentInterface::KEY_ADDITIONAL_DATA => 'not-an-array']),
+            $paymentInfo
+        );
+
+        $this->observer->execute($observer);
+    }
+
+    public function testExecuteUnsetsCcSpecificKeysWhenTheyArePresentInTheRequest()
+    {
+        $this->stateDataCollection->method('getStateDataArrayWithQuoteId')->willReturn([]);
+
+        $observer = $this->getPreparedObserver(
+            new DataObject([
+                PaymentInterface::KEY_ADDITIONAL_DATA => [
+                    AdyenCcDataAssignObserver::CC_TYPE => 'VI',
+                    AdyenCcDataAssignObserver::NUMBER_OF_INSTALLMENTS => 3,
+                    AdyenCcDataAssignObserver::COMBO_CARD_TYPE => 'debit'
+                ]
+            ]),
+            $this->paymentInfo
+        );
+
+        $this->observer->execute($observer);
+
+        $this->assertEquals(
+            [
+                AdyenCcDataAssignObserver::CC_TYPE,
+                AdyenCcDataAssignObserver::NUMBER_OF_INSTALLMENTS,
+                AdyenCcDataAssignObserver::COMBO_CARD_TYPE
+            ],
+            $this->unsAdditionalInformationCalls
+        );
+    }
+
+    public function testExecuteKeepsPreviousCcDataWhenNoReplacementIsProvided()
+    {
+        $this->stateDataCollection->method('getStateDataArrayWithQuoteId')->willReturn([]);
+
+        $observer = $this->getPreparedObserver(
+            new DataObject([
+                PaymentInterface::KEY_ADDITIONAL_DATA => [
+                    AdyenCcDataAssignObserver::GUEST_EMAIL => 'shopper@adyen.com'
+                ]
+            ]),
+            $this->paymentInfo
+        );
+
+        $this->observer->execute($observer);
+
+        $this->assertSame([], $this->unsAdditionalInformationCalls);
+        $this->assertSame(
+            [AdyenCcDataAssignObserver::GUEST_EMAIL => 'shopper@adyen.com'],
+            $this->setAdditionalInformationCalls
+        );
+    }
+
+    public function testExecuteAssignsOnlyApprovedAdditionalDataKeys()
+    {
+        $this->stateDataCollection->method('getStateDataArrayWithQuoteId')->willReturn([]);
+
+        $observer = $this->getPreparedObserver(
+            new DataObject([
+                PaymentInterface::KEY_ADDITIONAL_DATA => [
+                    AdyenCcDataAssignObserver::CC_TYPE => 'VI',
+                    AdyenCcDataAssignObserver::GUEST_EMAIL => 'shopper@adyen.com',
+                    AdyenCcDataAssignObserver::RETURN_URL => 'https://adyen.com/return',
+                    PaymentTokenInterface::PUBLIC_HASH => 'publicHash',
+                    HeaderDataBuilderInterface::ADDITIONAL_DATA_FRONTEND_TYPE_KEY => 'headless',
+                    AdyenCcDataAssignObserver::DEVICE_FINGERPRINT => 'spoofedFingerprint',
+                    'notApprovedKey' => 'notApprovedValue'
+                ]
+            ]),
+            $this->paymentInfo
+        );
+
+        $this->paymentInfo->expects($this->once())->method('setCcType')->with('VI');
+
+        $this->observer->execute($observer);
+
+        $this->assertSame(
+            [
+                AdyenCcDataAssignObserver::GUEST_EMAIL,
+                AdyenCcDataAssignObserver::CC_TYPE,
+                AdyenCcDataAssignObserver::RETURN_URL,
+                PaymentTokenInterface::PUBLIC_HASH,
+                HeaderDataBuilderInterface::ADDITIONAL_DATA_FRONTEND_TYPE_KEY
+            ],
+            array_keys($this->setAdditionalInformationCalls)
+        );
+    }
+
+    public function testExecuteStoresStateDataFromTheRequestAndRemovesItFromAdditionalData()
+    {
+        $stateData = ['paymentMethod' => ['type' => 'scheme']];
+
+        $observer = $this->getPreparedObserver(
+            new DataObject([
+                PaymentInterface::KEY_ADDITIONAL_DATA => [
+                    AdyenCcDataAssignObserver::STATE_DATA => json_encode($stateData)
+                ]
+            ]),
+            $this->paymentInfo
+        );
+
+        $this->stateDataCollection->expects($this->never())->method('getStateDataArrayWithQuoteId');
+        $this->checkoutStateDataValidator->expects($this->once())
+            ->method('getValidatedAdditionalData')
+            ->with($stateData)
+            ->willReturn($stateData);
+        $this->stateData->expects($this->once())
+            ->method('setStateData')
+            ->with($stateData, self::QUOTE_ID);
+
+        $this->observer->execute($observer);
+
+        $this->assertArrayNotHasKey(
+            AdyenCcDataAssignObserver::STATE_DATA,
+            $this->setAdditionalInformationCalls
+        );
+    }
+
+    public function testExecuteFetchesStateDataFromDatabaseWhenNotProvidedInTheRequest()
+    {
+        $stateData = ['paymentMethod' => ['type' => 'scheme']];
+
+        $observer = $this->getPreparedObserver(
+            new DataObject([
+                PaymentInterface::KEY_ADDITIONAL_DATA => [
+                    AdyenCcDataAssignObserver::CC_TYPE => 'VI'
+                ]
+            ]),
+            $this->paymentInfo
+        );
+
+        $this->stateDataCollection->expects($this->once())
+            ->method('getStateDataArrayWithQuoteId')
+            ->with(self::QUOTE_ID)
+            ->willReturn($stateData);
+        $this->checkoutStateDataValidator->expects($this->once())
+            ->method('getValidatedAdditionalData')
+            ->with($stateData)
+            ->willReturn($stateData);
+        $this->stateData->expects($this->once())
+            ->method('setStateData')
+            ->with($stateData, self::QUOTE_ID);
+
+        $this->observer->execute($observer);
+    }
+
+    public function testExecuteSetsStoreCcWhenStorePaymentMethodIsEnabled()
+    {
+        $stateData = [
+            'paymentMethod' => ['type' => 'scheme'],
+            AdyenCcDataAssignObserver::STORE_PAYMENT_METHOD => true
+        ];
+
+        $observer = $this->getPreparedObserver(
+            new DataObject([
+                PaymentInterface::KEY_ADDITIONAL_DATA => [
+                    AdyenCcDataAssignObserver::STATE_DATA => json_encode($stateData)
+                ]
+            ]),
+            $this->paymentInfo
+        );
+
+        $this->checkoutStateDataValidator->method('getValidatedAdditionalData')->willReturn($stateData);
+
+        $this->observer->execute($observer);
+
+        $this->assertSame(
+            [AdyenCcDataAssignObserver::STORE_CC => true],
+            $this->setAdditionalInformationCalls
+        );
+    }
+
+    public function testExecuteDoesNotProcessGiftcardStateData()
+    {
+        $stateData = ['paymentMethod' => ['type' => 'giftcard']];
+
+        $observer = $this->getPreparedObserver(
+            new DataObject([
+                PaymentInterface::KEY_ADDITIONAL_DATA => [
+                    AdyenCcDataAssignObserver::STATE_DATA => json_encode($stateData)
+                ]
+            ]),
+            $this->paymentInfo
+        );
+
+        $this->checkoutStateDataValidator->expects($this->never())->method('getValidatedAdditionalData');
+        $this->stateData->expects($this->never())->method('setStateData');
+
+        $this->observer->execute($observer);
+    }
+
+    public function testExecuteStoresDeviceFingerprintFromRiskDataClientData()
+    {
+        $stateData = [
+            'paymentMethod' => ['type' => 'scheme'],
+            'riskData' => [
+                'clientData' => base64_encode(json_encode(['deviceFingerprint' => 'testDeviceFingerprint']))
+            ]
+        ];
+
+        $observer = $this->getPreparedObserver(
+            new DataObject([
+                PaymentInterface::KEY_ADDITIONAL_DATA => [
+                    AdyenCcDataAssignObserver::STATE_DATA => json_encode($stateData)
+                ]
+            ]),
+            $this->paymentInfo
+        );
+
+        $this->checkoutStateDataValidator->method('getValidatedAdditionalData')->willReturn($stateData);
+
+        $this->observer->execute($observer);
+
+        $this->assertSame(
+            'testDeviceFingerprint',
+            $this->setAdditionalInformationCalls[AdyenCcDataAssignObserver::DEVICE_FINGERPRINT]
+        );
+    }
+
+    public function testExecuteDoesNotStoreDeviceFingerprintWhenClientDataIsNotValidJson()
+    {
+        $stateData = [
+            'paymentMethod' => ['type' => 'scheme'],
+            'riskData' => ['clientData' => base64_encode('not-a-json-string')]
+        ];
+
+        $observer = $this->getPreparedObserver(
+            new DataObject([
+                PaymentInterface::KEY_ADDITIONAL_DATA => [
+                    AdyenCcDataAssignObserver::STATE_DATA => json_encode($stateData)
+                ]
+            ]),
+            $this->paymentInfo
+        );
+
+        $this->checkoutStateDataValidator->method('getValidatedAdditionalData')->willReturn($stateData);
+
+        $this->observer->execute($observer);
+
+        $this->assertArrayNotHasKey(
+            AdyenCcDataAssignObserver::DEVICE_FINGERPRINT,
+            $this->setAdditionalInformationCalls
+        );
+    }
+
+    public function testExecuteRemovesInvalidRecurringProcessingModel()
+    {
+        $this->stateDataCollection->method('getStateDataArrayWithQuoteId')->willReturn([]);
+
+        $observer = $this->getPreparedObserver(
+            new DataObject([
+                PaymentInterface::KEY_ADDITIONAL_DATA => [
+                    AdyenCcDataAssignObserver::CC_TYPE => 'VI',
+                    AdyenCcDataAssignObserver::RECURRING_PROCESSING_MODEL => 'InvalidModel'
+                ]
+            ]),
+            $this->paymentInfo
+        );
+
+        $this->vaultHelper->expects($this->once())
+            ->method('validateRecurringProcessingModel')
+            ->with('InvalidModel')
+            ->willReturn(false);
+
+        $this->observer->execute($observer);
+
+        $this->assertContains(
+            AdyenCcDataAssignObserver::RECURRING_PROCESSING_MODEL,
+            $this->unsAdditionalInformationCalls
+        );
+        $this->assertArrayNotHasKey(
+            AdyenCcDataAssignObserver::RECURRING_PROCESSING_MODEL,
+            $this->setAdditionalInformationCalls
+        );
+    }
+
+    public function testExecuteKeepsValidRecurringProcessingModel()
+    {
+        $this->stateDataCollection->method('getStateDataArrayWithQuoteId')->willReturn([]);
+
+        $observer = $this->getPreparedObserver(
+            new DataObject([
+                PaymentInterface::KEY_ADDITIONAL_DATA => [
+                    AdyenCcDataAssignObserver::RECURRING_PROCESSING_MODEL => 'Subscription'
+                ]
+            ]),
+            $this->paymentInfo
+        );
+
+        $this->vaultHelper->expects($this->once())
+            ->method('validateRecurringProcessingModel')
+            ->with('Subscription')
+            ->willReturn(true);
+
+        $this->observer->execute($observer);
+
+        $this->assertSame(
+            [AdyenCcDataAssignObserver::RECURRING_PROCESSING_MODEL => 'Subscription'],
+            $this->setAdditionalInformationCalls
+        );
+    }
+
+    public function testExecuteDoesNotSetCcTypeWhenItIsNotProvided()
+    {
+        $this->stateDataCollection->method('getStateDataArrayWithQuoteId')->willReturn([]);
+
+        $observer = $this->getPreparedObserver(
+            new DataObject([
+                PaymentInterface::KEY_ADDITIONAL_DATA => [
+                    AdyenCcDataAssignObserver::GUEST_EMAIL => 'shopper@adyen.com'
+                ]
+            ]),
+            $this->paymentInfo
+        );
+
+        $this->paymentInfo->expects($this->never())->method('setCcType');
+
+        $this->observer->execute($observer);
+    }
+
+    private function getPreparedObserver(DataObject $dataObject, Payment|MockObject $paymentInfo): Observer|MockObject
+    {
+        return $this->getPreparedObserverWithMap([
+            [AbstractDataAssignObserver::DATA_CODE, $dataObject],
+            [AbstractDataAssignObserver::MODEL_CODE, $paymentInfo],
+        ]);
+    }
+
+    /**
+     * @param array $returnMap
+     * @return MockObject|Observer
+     */
+    private function getPreparedObserverWithMap(array $returnMap): Observer|MockObject
+    {
+        $observer = $this->getMockBuilder(Observer::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $event = $this->getMockBuilder(Event::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $observer->expects(static::atLeastOnce())
+            ->method('getEvent')
+            ->willReturn($event);
+        $event->expects(static::atLeastOnce())
+            ->method('getDataByKey')
+            ->willReturnMap($returnMap);
+
+        return $observer;
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1114,6 +1114,7 @@
                 <item name="giftcard" xsi:type="string">Adyen\Payment\Gateway\Request\GiftcardDataBuilder</item>
                 <item name="company" xsi:type="string">Adyen\Payment\Gateway\Request\CompanyDataBuilder</item>
                 <item name="merchantRiskIndicator" xsi:type="string">Adyen\Payment\Gateway\Request\MerchantRiskIndicatorDataBuilder</item>
+                <item name="deviceFingerprint" xsi:type="string">Adyen\Payment\Gateway\Request\DeviceFingerprintDataBuilder</item>
             </argument>
         </arguments>
     </virtualType>
@@ -1175,6 +1176,7 @@
                 <item name="giftcard" xsi:type="string">Adyen\Payment\Gateway\Request\GiftcardDataBuilder</item>
                 <item name="company" xsi:type="string">Adyen\Payment\Gateway\Request\CompanyDataBuilder</item>
                 <item name="merchantRiskIndicator" xsi:type="string">Adyen\Payment\Gateway\Request\MerchantRiskIndicatorDataBuilder</item>
+                <item name="deviceFingerprint" xsi:type="string">Adyen\Payment\Gateway\Request\DeviceFingerprintDataBuilder</item>
             </argument>
         </arguments>
     </virtualType>


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
Visa DCAP requires [these](https://docs.adyen.com/online-payments/3d-secure/data-only#dcap) values to be sent as a part of `/payments` API request. This PR add the missing `deviceFingerprint` field by obtaining it from checkout component's `clientData` which is part of the state data. This PR assumes risk tools are enabled on the frontend checkout component.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- Passing `deviceFingerprint` in the `/payments` request
- Finalizing a data only payment using test cards