### PR TITLE
[ECP-9984-v10] Use repository while reprocessing webhooks to prevent memory issues

### DIFF
--- a/Api/Repository/AdyenNotificationRepositoryInterface.php
+++ b/Api/Repository/AdyenNotificationRepositoryInterface.php
@@ -29,4 +29,12 @@ interface AdyenNotificationRepositoryInterface
      * @return void
      */
     public function deleteByIds(array $entityIds): void;
+
+    /**
+     * Returns the adyen_notification entity with the given `entity_id`.
+     *
+     * @param int $entityId adyen_notification entity_id
+     * @return NotificationInterface
+     */
+    public function getById(int $entityId): NotificationInterface;
 }

--- a/Controller/Adminhtml/Notifications/WebhookReprocess.php
+++ b/Controller/Adminhtml/Notifications/WebhookReprocess.php
@@ -11,19 +11,17 @@
 
 namespace Adyen\Payment\Controller\Adminhtml\Notifications;
 
+use Adyen\Payment\Api\Repository\AdyenNotificationRepositoryInterface as AdyenNotificationRepositoryInterfaceAlias;
 use Adyen\Payment\Helper\Webhook;
-use Adyen\Payment\Model\Notification;
-use Adyen\Payment\Model\ResourceModel\Notification\CollectionFactory;
+use Magento\Backend\App\Action;
 use Magento\Backend\App\Action\Context;
+use Magento\Framework\Controller\Result\Redirect;
+use Magento\Framework\Controller\ResultFactory;
+use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\Message\ManagerInterface;
 
-class WebhookReprocess extends \Magento\Backend\App\Action
+class WebhookReprocess extends Action
 {
-    /**
-     * @var CollectionFactory
-     */
-    private $notificationCollectionFactory;
-
     /**
      * @var ManagerInterface
      */
@@ -32,47 +30,54 @@ class WebhookReprocess extends \Magento\Backend\App\Action
     /**
      * @var Webhook
      */
-    private $webhookHelper;
+    private Webhook $webhookHelper;
+
+    /**
+     * @var AdyenNotificationRepositoryInterfaceAlias
+     */
+    private AdyenNotificationRepositoryInterfaceAlias $notificationRepository;
 
     /**
      * Update constructor.
      *
      * @param Context $context
-     * @param CollectionFactory $notificationCollectionFactory
      * @param ManagerInterface $messageManager
      * @param Webhook $webhookHelper
+     * @param AdyenNotificationRepositoryInterfaceAlias $notificationRepository
      */
     public function __construct(
         Context $context,
-        CollectionFactory $notificationCollectionFactory,
         ManagerInterface $messageManager,
-        Webhook $webhookHelper
-    )
-    {
-        $this->notificationCollectionFactory = $notificationCollectionFactory;
+        Webhook $webhookHelper,
+        AdyenNotificationRepositoryInterfaceAlias $notificationRepository
+    ) {
         $this->messageManager = $messageManager;
         $this->webhookHelper = $webhookHelper;
-
+        $this->notificationRepository = $notificationRepository;
 
         parent::__construct($context);
     }
 
-    /**
-     * @return \Magento\Framework\View\Result\Forward
-     */
-    public function execute()
+    public function execute(): Redirect
     {
-        $redirect = $this->resultFactory->create(\Magento\Framework\Controller\ResultFactory::TYPE_REDIRECT);
+        $redirect = $this->resultFactory->create(ResultFactory::TYPE_REDIRECT);
         $redirect->setUrl($this->_redirect->getRefererUrl());
 
-        $notification = $this->notificationCollectionFactory->create();
-        $notification = $notification->getItemById($this->getRequest()->getParam('entity_id'));
+        try {
+            $notification = $this->notificationRepository->getById(
+                (int) $this->getRequest()->getParam('entity_id')
+            );
+        } catch (NoSuchEntityException $exception) {
+            $this->messageManager->addErrorMessage(__("The webhook notification could not be found!"));
+
+            return $redirect;
+        }
 
         if($this->webhookHelper->processNotification($notification)) {
             $this->messageManager->addSuccessMessage(__("Webhook notification reprocessed successfully!"));
         }
         else {
-            $this->messageManager->addErrorMessage(__("Issue occured while reprocessing the webhook notification!"));
+            $this->messageManager->addErrorMessage(__("Issue occurred while reprocessing the webhook notification!"));
         }
 
         return $redirect;

--- a/Controller/Adminhtml/Notifications/WebhookReprocess.php
+++ b/Controller/Adminhtml/Notifications/WebhookReprocess.php
@@ -11,7 +11,7 @@
 
 namespace Adyen\Payment\Controller\Adminhtml\Notifications;
 
-use Adyen\Payment\Api\Repository\AdyenNotificationRepositoryInterface as AdyenNotificationRepositoryInterfaceAlias;
+use Adyen\Payment\Api\Repository\AdyenNotificationRepositoryInterface;
 use Adyen\Payment\Helper\Webhook;
 use Magento\Backend\App\Action;
 use Magento\Backend\App\Action\Context;
@@ -33,9 +33,9 @@ class WebhookReprocess extends Action
     private Webhook $webhookHelper;
 
     /**
-     * @var AdyenNotificationRepositoryInterfaceAlias
+     * @var AdyenNotificationRepositoryInterface
      */
-    private AdyenNotificationRepositoryInterfaceAlias $notificationRepository;
+    private AdyenNotificationRepositoryInterface $notificationRepository;
 
     /**
      * Update constructor.
@@ -43,13 +43,13 @@ class WebhookReprocess extends Action
      * @param Context $context
      * @param ManagerInterface $messageManager
      * @param Webhook $webhookHelper
-     * @param AdyenNotificationRepositoryInterfaceAlias $notificationRepository
+     * @param AdyenNotificationRepositoryInterface $notificationRepository
      */
     public function __construct(
         Context $context,
         ManagerInterface $messageManager,
         Webhook $webhookHelper,
-        AdyenNotificationRepositoryInterfaceAlias $notificationRepository
+        AdyenNotificationRepositoryInterface $notificationRepository
     ) {
         $this->messageManager = $messageManager;
         $this->webhookHelper = $webhookHelper;

--- a/Model/AdyenNotificationRepository.php
+++ b/Model/AdyenNotificationRepository.php
@@ -14,16 +14,19 @@ namespace Adyen\Payment\Model;
 use Adyen\Payment\Api\Data\NotificationInterface;
 use Adyen\Payment\Api\Repository\AdyenNotificationRepositoryInterface;
 use Magento\Framework\Exception\AlreadyExistsException;
+use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\ObjectManagerInterface;
 
 class AdyenNotificationRepository implements AdyenNotificationRepositoryInterface
 {
     /**
      * @param ObjectManagerInterface $objectManager
+     * @param NotificationFactory $notificationFactory
      * @param string $resourceModel
      */
     public function __construct(
         private readonly ObjectManagerInterface $objectManager,
+        private readonly NotificationFactory $notificationFactory,
         private readonly string $resourceModel
     ) { }
 
@@ -50,6 +53,29 @@ class AdyenNotificationRepository implements AdyenNotificationRepositoryInterfac
     {
         $resource = $this->objectManager->get($this->resourceModel);
         $resource->save($entity);
+
+        return $entity;
+    }
+
+    /**
+     * Returns the entity with the given `entity_id`
+     *
+     * @param int $entityId
+     * @return NotificationInterface
+     * @throws NoSuchEntityException
+     */
+    public function getById(int $entityId): NotificationInterface
+    {
+        $resource = $this->objectManager->get($this->resourceModel);
+
+        $entity = $this->notificationFactory->create();
+        $resource->load($entity, $entityId, NotificationInterface::ENTITY_ID);
+
+        if (!$entity->getEntityId()) {
+            throw new NoSuchEntityException(
+                __('Adyen notification with entity_id %1 does not exist.', $entityId)
+            );
+        }
 
         return $entity;
     }

--- a/Test/Unit/Controller/Adminhtml/Notification/WebhookReprocessTest.php
+++ b/Test/Unit/Controller/Adminhtml/Notification/WebhookReprocessTest.php
@@ -1,0 +1,160 @@
+<?php
+/**
+ *
+ * Adyen Payment module (https://www.adyen.com/)
+ *
+ * Copyright (c) 2025 Adyen N.V. (https://www.adyen.com/)
+ * See LICENSE.txt for license details.
+ *
+ * Author: Adyen <magento@adyen.com>
+ */
+
+namespace Adyen\Payment\Test\Unit\Controller\Adminhtml\Notification;
+
+use Adyen\Payment\Api\Repository\AdyenNotificationRepositoryInterface;
+use Adyen\Payment\Controller\Adminhtml\Notifications\WebhookReprocess;
+use Adyen\Payment\Helper\Webhook;
+use Adyen\Payment\Model\Notification;
+use Adyen\Payment\Test\Unit\AbstractAdyenTestCase;
+use Magento\Backend\App\Action\Context;
+use Magento\Framework\App\RequestInterface;
+use Magento\Framework\App\Response\RedirectInterface;
+use Magento\Framework\Controller\Result\Redirect;
+use Magento\Framework\Controller\ResultFactory;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\Message\ManagerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class WebhookReprocessTest extends AbstractAdyenTestCase
+{
+    const ENTITY_ID = 1;
+    const REFERER_URL = 'https://localhost/admin/adyen/notifications/overview';
+
+    protected ?WebhookReprocess $webhookReprocessController;
+    protected Context|MockObject $contextMock;
+    protected ManagerInterface|MockObject $messageManagerMock;
+    protected Webhook|MockObject $webhookHelperMock;
+    protected AdyenNotificationRepositoryInterface|MockObject $notificationRepositoryMock;
+    protected Redirect|MockObject $redirectResultMock;
+    protected RequestInterface|MockObject $requestMock;
+
+    protected function setUp(): void
+    {
+        $this->messageManagerMock = $this->createMock(ManagerInterface::class);
+        $this->webhookHelperMock = $this->createMock(Webhook::class);
+        $this->notificationRepositoryMock = $this->createMock(AdyenNotificationRepositoryInterface::class);
+
+        $this->redirectResultMock = $this->createMock(Redirect::class);
+
+        $resultFactoryMock = $this->createMock(ResultFactory::class);
+        $resultFactoryMock->method('create')
+            ->with(ResultFactory::TYPE_REDIRECT)
+            ->willReturn($this->redirectResultMock);
+
+        $redirectMock = $this->createMock(RedirectInterface::class);
+        $redirectMock->method('getRefererUrl')->willReturn(self::REFERER_URL);
+
+        $this->requestMock = $this->createMock(RequestInterface::class);
+
+        $this->contextMock = $this->createMock(Context::class);
+        $this->contextMock->method('getResultFactory')->willReturn($resultFactoryMock);
+        $this->contextMock->method('getRedirect')->willReturn($redirectMock);
+        $this->contextMock->method('getRequest')->willReturn($this->requestMock);
+        // `messageManager` is overwritten by the parent constructor with the instance from the context.
+        $this->contextMock->method('getMessageManager')->willReturn($this->messageManagerMock);
+
+        $this->webhookReprocessController = new WebhookReprocess(
+            $this->contextMock,
+            $this->messageManagerMock,
+            $this->webhookHelperMock,
+            $this->notificationRepositoryMock
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        $this->webhookReprocessController = null;
+    }
+
+    public function testExecuteSuccessfulReprocess()
+    {
+        $notificationMock = $this->createMock(Notification::class);
+
+        $this->requestMock->expects($this->once())
+            ->method('getParam')
+            ->with('entity_id')
+            ->willReturn((string) self::ENTITY_ID);
+
+        $this->notificationRepositoryMock->expects($this->once())
+            ->method('getById')
+            ->with(self::ENTITY_ID)
+            ->willReturn($notificationMock);
+
+        $this->webhookHelperMock->expects($this->once())
+            ->method('processNotification')
+            ->with($notificationMock)
+            ->willReturn(true);
+
+        $this->redirectResultMock->expects($this->once())
+            ->method('setUrl')
+            ->with(self::REFERER_URL);
+
+        $this->messageManagerMock->expects($this->once())
+            ->method('addSuccessMessage')
+            ->with(__("Webhook notification reprocessed successfully!"));
+        $this->messageManagerMock->expects($this->never())->method('addErrorMessage');
+
+        $result = $this->webhookReprocessController->execute();
+        $this->assertInstanceOf(Redirect::class, $result);
+    }
+
+    public function testExecuteFailedReprocess()
+    {
+        $notificationMock = $this->createMock(Notification::class);
+
+        $this->requestMock->method('getParam')->with('entity_id')->willReturn(self::ENTITY_ID);
+
+        $this->notificationRepositoryMock->expects($this->once())
+            ->method('getById')
+            ->with(self::ENTITY_ID)
+            ->willReturn($notificationMock);
+
+        $this->webhookHelperMock->expects($this->once())
+            ->method('processNotification')
+            ->with($notificationMock)
+            ->willReturn(false);
+
+        $this->messageManagerMock->expects($this->never())->method('addSuccessMessage');
+        $this->messageManagerMock->expects($this->once())
+            ->method('addErrorMessage')
+            ->with(__("Issue occurred while reprocessing the webhook notification!"));
+
+        $result = $this->webhookReprocessController->execute();
+        $this->assertInstanceOf(Redirect::class, $result);
+    }
+
+    public function testExecuteNonExistingNotification()
+    {
+        $this->requestMock->method('getParam')->with('entity_id')->willReturn(self::ENTITY_ID);
+
+        $this->notificationRepositoryMock->expects($this->once())
+            ->method('getById')
+            ->with(self::ENTITY_ID)
+            ->willThrowException(new NoSuchEntityException());
+
+        // Assert that reprocessing is not attempted for a non-existing entity.
+        $this->webhookHelperMock->expects($this->never())->method('processNotification');
+
+        $this->messageManagerMock->expects($this->never())->method('addSuccessMessage');
+        $this->messageManagerMock->expects($this->once())
+            ->method('addErrorMessage')
+            ->with(__("The webhook notification could not be found!"));
+
+        $this->redirectResultMock->expects($this->once())
+            ->method('setUrl')
+            ->with(self::REFERER_URL);
+
+        $result = $this->webhookReprocessController->execute();
+        $this->assertInstanceOf(Redirect::class, $result);
+    }
+}

--- a/Test/Unit/Model/AdyenNotificationRepositoryTest.php
+++ b/Test/Unit/Model/AdyenNotificationRepositoryTest.php
@@ -14,11 +14,13 @@ namespace Adyen\Payment\Test\Helper\Unit\Model;
 use Adyen\Payment\Api\Data\NotificationInterface;
 use Adyen\Payment\Model\AdyenNotificationRepository;
 use Adyen\Payment\Model\Notification as NotificationModel;
+use Adyen\Payment\Model\NotificationFactory;
 use Adyen\Payment\Model\ResourceModel\Notification;
 use Adyen\Payment\Model\ResourceModel\Notification\CollectionFactory;
 use Adyen\Payment\Test\Unit\AbstractAdyenTestCase;
 use Magento\Framework\Api\Search\SearchResultFactory;
 use Magento\Framework\Api\SearchCriteria\CollectionProcessor;
+use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\ObjectManagerInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 
@@ -29,6 +31,7 @@ class AdyenNotificationRepositoryTest extends AbstractAdyenTestCase
     protected CollectionFactory|MockObject $collectionFactoryMock;
     protected CollectionProcessor|MockObject $collectionProcessorMock;
     protected ObjectManagerInterface|MockObject $objectManagerMock;
+    protected NotificationFactory|MockObject $notificationFactoryMock;
 
     const RESOURCE_MODEL = 'Adyen\Payment\Model\ResourceModel\Notification';
 
@@ -41,9 +44,14 @@ class AdyenNotificationRepositoryTest extends AbstractAdyenTestCase
         );
         $this->collectionProcessorMock = $this->createMock(CollectionProcessor::class);
         $this->objectManagerMock = $this->createMock(ObjectManagerInterface::class);
+        $this->notificationFactoryMock = $this->createGeneratedMock(
+            NotificationFactory::class,
+            ['create']
+        );
 
         $this->adyenNotificationRepository = new AdyenNotificationRepository(
             $this->objectManagerMock,
+            $this->notificationFactoryMock,
             self::RESOURCE_MODEL
         );
     }
@@ -100,5 +108,53 @@ class AdyenNotificationRepositoryTest extends AbstractAdyenTestCase
 
         $result = $this->adyenNotificationRepository->save($notification);
         $this->assertInstanceOf(NotificationInterface::class, $result);
+    }
+
+    public function testGetById()
+    {
+        $entityId = 1;
+
+        $notification = $this->createMock(NotificationModel::class);
+        $notification->method('getEntityId')->willReturn($entityId);
+
+        $resourceModel = $this->createMock(Notification::class);
+        $resourceModel->expects($this->once())
+            ->method('load')
+            ->with($notification, $entityId, NotificationInterface::ENTITY_ID);
+
+        $this->objectManagerMock->expects($this->once())
+            ->method('get')
+            ->with(self::RESOURCE_MODEL)
+            ->willReturn($resourceModel);
+
+        $this->notificationFactoryMock->expects($this->once())
+            ->method('create')
+            ->willReturn($notification);
+
+        $result = $this->adyenNotificationRepository->getById($entityId);
+        $this->assertInstanceOf(NotificationInterface::class, $result);
+    }
+
+    public function testGetByIdNonExistingEntity()
+    {
+        $entityId = 1;
+
+        $notification = $this->createMock(NotificationModel::class);
+        $notification->method('getEntityId')->willReturn(null);
+
+        $resourceModel = $this->createMock(Notification::class);
+        $resourceModel->expects($this->once())
+            ->method('load')
+            ->with($notification, $entityId, NotificationInterface::ENTITY_ID);
+
+        $this->objectManagerMock->method('get')
+            ->with(self::RESOURCE_MODEL)
+            ->willReturn($resourceModel);
+
+        $this->notificationFactoryMock->method('create')->willReturn($notification);
+
+        $this->expectException(NoSuchEntityException::class);
+
+        $this->adyenNotificationRepository->getById($entityId);
     }
 }


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
The plugin allows system admins the reprocess Adyen webhooks if they are stuck in `Processing` state by using `Reprocess` functionality under `Webhooks Overview` page.

While fetching the relevant webhook, the controller uses collection, which causes of an overload if there many records in the database.

This PR implements and uses the repository to fetch the relevant item only to prevent memory exhaustion. 

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- Performing action against database with 600K dummy `adyen_notification` entity