### PR TITLE
[ECP-10007-v10] Fix Return controller using incorrect storeId on multi-store setups

### DIFF
--- a/Controller/Return/Index.php
+++ b/Controller/Return/Index.php
@@ -89,10 +89,12 @@ class Index extends Action
     {
         // Receive all params as this could be a GET or POST request
         $redirectResponse = $this->getRequest()->getParams();
-        $storeId = $this->storeManager->getStore()->getId();
 
         if ($redirectResponse) {
-            $result = $this->validateRedirectResponse($redirectResponse);
+            $order = $this->getOrder($redirectResponse['merchantReference'] ?? null);
+            $storeId = (int) $order->getStoreId();
+
+            $result = $this->validateRedirectResponse($redirectResponse, $order);
 
             // Adjust the success path, fail path, and restore quote based on if it is a multishipping quote
             if (
@@ -134,6 +136,7 @@ class Index extends Action
                 $this->_redirect($failPath);
             }
         } else {
+            $storeId = $this->storeManager->getStore()->getId();
             $this->_redirect($this->configHelper->getAdyenAbstractConfigData('return_path', $storeId));
         }
     }
@@ -142,10 +145,9 @@ class Index extends Action
      * @throws LocalizedException
      * @throws Exception
      */
-    protected function validateRedirectResponse(array $redirectResponse): bool
+    protected function validateRedirectResponse(array $redirectResponse, OrderInterface $order): bool
     {
         $this->adyenLogger->addAdyenResult('Processing redirect response');
-        $order = $this->getOrder($redirectResponse['merchantReference'] ?? null);
 
         try {
             // Make paymentsDetails call to validate the payment

--- a/Test/Unit/Controller/Return/IndexTest.php
+++ b/Test/Unit/Controller/Return/IndexTest.php
@@ -112,6 +112,7 @@ class IndexTest extends AbstractAdyenTestCase
         $order->method('getIncrementId')->willReturn('1001');
         $order->method('getPayment')->willReturn($this->createMock(OrderModel\Payment::class));
         $order->method('getEntityId')->willReturn(1);
+        $order->method('getStoreId')->willReturn(1);
 
         $orderModel = $this->createMock(OrderModel::class);
         $orderModel->method('getEntityId')->willReturn(1);
@@ -143,6 +144,7 @@ class IndexTest extends AbstractAdyenTestCase
             ]);
 
         $order = $this->createMock(OrderInterface::class);
+        $order->method('getStoreId')->willReturn(1);
 
         $orderModel = $this->createMock(OrderModel::class);
         $orderModel->method('getEntityId')->willReturn(1);
@@ -160,6 +162,48 @@ class IndexTest extends AbstractAdyenTestCase
         $this->indexController->expects($this->once())
             ->method('_redirect')
             ->with('checkout/cart');
+
+        $this->indexController->execute();
+    }
+
+    public function testExecuteUsesOrderStoreIdForRedirectConfig(): void
+    {
+        // Current store context differs from the store where the order was placed.
+        $orderStoreId = 2;
+
+        $params = ['merchantReference' => '1001', 'redirectResult' => 'test'];
+        $this->request->method('getParams')->willReturn($params);
+        $this->quoteHelper->method('getIsQuoteMultiShippingWithMerchantReference')->willReturn(false);
+
+        // Config is only mapped for the order's store id (2), not the current context store id (1).
+        $this->configHelper->method('getAdyenAbstractConfigData')
+            ->willReturnMap([
+                ['custom_success_redirect_path', $orderStoreId, 'custom/success/path'],
+                ['return_path', $orderStoreId, 'checkout/cart']
+            ]);
+
+        $quote = $this->createMock(QuoteModel::class);
+        $this->session->method('getQuote')->willReturn($quote);
+
+        $order = $this->createMock(OrderInterface::class);
+        $order->method('getIncrementId')->willReturn('1001');
+        $order->method('getPayment')->willReturn($this->createMock(OrderModel\Payment::class));
+        $order->method('getEntityId')->willReturn(1);
+        $order->method('getStoreId')->willReturn($orderStoreId);
+
+        $orderModel = $this->createMock(OrderModel::class);
+        $orderModel->method('getEntityId')->willReturn(1);
+        $orderModel->method('loadByIncrementId')->willReturn($orderModel);
+
+        $this->orderFactory->method('create')->willReturn($orderModel);
+        $this->orderRepository->method('get')->willReturn($order);
+
+        $this->paymentsDetailsHelper->method('initiatePaymentDetails')->willReturn(['resultCode' => 'Authorised']);
+        $this->paymentResponseHandler->method('handlePaymentsDetailsResponse')->willReturn(true);
+
+        $this->indexController->expects($this->once())
+            ->method('_redirect')
+            ->with('custom/success/path', ['_query' => ['order_increment_id' => '1001']]);
 
         $this->indexController->execute();
     }


### PR DESCRIPTION
<!-- Thank you for considering contributing to this repository! We encourage you to use PSR-2. -->

**Description**
<!-- Please provide a description of the changes proposed in the Pull Request -->
This PR fixes the issue related `Return` controller using incorrect `storeId` value to fetch the relevant configuration values on headless integration.

As a part of the patch, the `storeId` is now obtained from the `Order` object associated with the given `merchantReference` in the redirect response.

**Tested scenarios**
<!-- Description of tested scenarios -->
<!-- Please verify that the unit tests are passing by running "vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist vendor/adyen/module-payment/Test/" -->
- Multi-store setup having custom success pages per stores